### PR TITLE
Remove some dead code, also a spurious print that messes up pydoc

### DIFF
--- a/SLURM/demo_pipeline.py
+++ b/SLURM/demo_pipeline.py
@@ -1,12 +1,6 @@
 from __future__ import print_function
 #%%
 from builtins import range
-try:
-#    get_ipython().magic(u'load_ext autoreload')
-#    get_ipython().magic(u'autoreload 2')
-    print((1))
-except:
-    print('NOT IPYTHON')
 
 import matplotlib as mpl
 mpl.use('TKAgg')

--- a/caiman/utils/stats.py
+++ b/caiman/utils/stats.py
@@ -11,7 +11,7 @@ from past.utils import old_div
 try:
     import numba
 except:
-    print("numba not found")
+    pass
 
 import numpy as np    
 


### PR DESCRIPTION
Executing code during a library import is usually a bad idea (pydoc imports libraries while parsing code, as an example). Here I removed an instance of that, making a failure to find the numba library quiet. Also removed a bit of dead code from the slurm demo pipeline.