### PR TITLE
Add cvxpy to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 channels:
 - defaults
 - menpo
+- omnia
 dependencies:
 - future
 - numpy
@@ -20,6 +21,7 @@ dependencies:
 - keras
 - tqdm
 - opencv3
+- cvxpy
 - pip:
   - tifffile==0.12.1
   - peakutils


### PR DESCRIPTION
Installing cvxpy after creating the caiman environment was causing issues with the tifffile package.  This two line change installs the cvxpy package through the conda channel omnia when the environment gets created and solves the problem.