### PR TITLE
Fix python2-python3 string/base64 encoding issues

### DIFF
--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from builtins import str
 from builtins import range
 from past.utils import old_div
+import base64
 import cv2
 import numpy as np
 import pylab as pl
@@ -748,7 +749,7 @@ def anim_to_html(anim, fps=20):
         with NamedTemporaryFile(suffix='.mp4') as f:
             anim.save(f.name, fps=fps, extra_args=['-vcodec', 'libx264'])
             video = open(f.name, "rb").read()
-        anim._encoded_video = video.encode("base64")
+        anim._encoded_video = base64.b64encode(video)
 
     return VIDEO_TAG.format(anim._encoded_video)
 


### PR DESCRIPTION
On python3, for better unicode compatibility, the core language thinks in terms of strings, but files on disk usually are represented as "bytes" (in python2 these are the same thing). Things are not transparently converted between the two. Additionally, python3's STRING.encode() method doesn't handle base64; that was pushed out into another library (that's included in the core language).

This diff adjusts our master branch for python3 compatibility.