### PR TITLE
add epsilon in HALS routine to prevent NaNs

### DIFF
--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -894,7 +894,7 @@ def hals(Y, A, C, b, f, bSiz=3, maxIter=5):
 
     def HALS4activity(Yr, A, C, iters=2):
         U = A.T.dot(Yr)
-        V = A.T.dot(A)
+        V = A.T.dot(A) + np.finfo(A.dtype).eps
         for _ in range(iters):
             for m in range(len(U)):  # neurons and background
                 C[m] = np.clip(C[m] + (U[m] - V[m].dot(C)) /
@@ -903,7 +903,7 @@ def hals(Y, A, C, b, f, bSiz=3, maxIter=5):
 
     def HALS4shape(Yr, A, C, iters=2):
         U = C.dot(Yr.T)
-        V = C.dot(C.T)
+        V = C.dot(C.T) + np.finfo(C.dtype).eps
         for _ in range(iters):
             for m in range(K):  # neurons
                 ind_pixels = np.squeeze(ind_A[:, m].toarray())


### PR DESCRIPTION
the hals init routine was yielding NaN corrupted data in some CNMF runs I was doing, this stabilized it