### PR TITLE
caimanmanager tests demos, CI tells it to (Linux + OSX)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get install bzip2
 RUN apt-get install -y gcc
 RUN apt-get install -y g++
 RUN apt-get install -y libgtk2.0-0
+RUN apt-get install -y xvfb
 RUN export MINICONDA=$HOME/miniconda
 RUN export PATH="$MINICONDA/bin:$PATH"
 RUN hash -r

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
           steps {
             bat '%ANACONDA%\\scripts\\conda env create -q -f environment.yml -p %CONDA_ENV%'
             bat 'set SRCPATH=%CD%'
-            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
+            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && set CAIMAN_DATA=%TEMP%\\caiman_data && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
+              caimanmanager.py demotest
             '''
           }
         }
@@ -50,6 +51,7 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
+              caimanmanager.py demotest
             '''
           }
         }
@@ -71,6 +73,7 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
+              caimanmanager.py demotest
             '''
           }
         }
@@ -92,6 +95,7 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
+              caimanmanager.py demotest
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,6 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
-              caimanmanager.py demotest
             '''
           }
         }
@@ -95,7 +94,6 @@ pipeline {
               cd $TEMPDIR
               caimanmanager.py install
               nosetests --traverse-namespace caiman
-              caimanmanager.py demotest
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ pipeline {
           steps {
             sh 'conda env create -q -f environment_python2.yml -p $CONDA_ENV'
             sh '''#!/bin/bash -ex
-              yum install xorg-x11-server-Xvfb
               source $CONDA_ENV/bin/activate $CONDA_ENV
               pip install .
               TEMPDIR=$(mktemp -d)
@@ -45,7 +44,6 @@ pipeline {
           steps {
             sh 'conda env create -q -f environment.yml -p $CONDA_ENV'
             sh '''#!/bin/bash -ex
-              yum install xorg-x11-server-Xvfb
               source $CONDA_ENV/bin/activate $CONDA_ENV
               pip install .
               TEMPDIR=$(mktemp -d)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
           steps {
             sh 'conda env create -q -f environment_python2.yml -p $CONDA_ENV'
             sh '''#!/bin/bash -ex
+              yum install xorg-x11-server-Xvfb
               source $CONDA_ENV/bin/activate $CONDA_ENV
               pip install .
               TEMPDIR=$(mktemp -d)
@@ -44,6 +45,7 @@ pipeline {
           steps {
             sh 'conda env create -q -f environment.yml -p $CONDA_ENV'
             sh '''#!/bin/bash -ex
+              yum install xorg-x11-server-Xvfb
               source $CONDA_ENV/bin/activate $CONDA_ENV
               pip install .
               TEMPDIR=$(mktemp -d)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,8 +121,7 @@ pipeline {
           }
           steps {
             bat '%ANACONDA%\\scripts\\conda env create -q -f environment.yml -p %CONDA_ENV%'
-            bat 'set SRCPATH=%CD%'
-            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && set CAIMAN_DATA=%TEMP%\\caiman_data && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
+            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && set "CAIMAN_DATA=%TEMP%\\caiman_data" && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
           steps {
             bat '%ANACONDA%\\scripts\\conda env create -q -f environment.yml -p %CONDA_ENV%'
             bat 'set SRCPATH=%CD%'
-            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && python caimanmanager.py install && python caimanmanager.py test'
+            bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
           }
         }
       }

--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -239,8 +239,10 @@ def evaluate_components_CNN(A, dims, gSig, model_name='use_cases/CaImAnpaper/cnn
     """ evaluate component quality using a CNN network
 
     """
+
+    import os
     if not isGPU:
-        import os
+
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
 
 #    try:
@@ -249,7 +251,7 @@ def evaluate_components_CNN(A, dims, gSig, model_name='use_cases/CaImAnpaper/cnn
 #    except:
 #        print('PROBLEM LOADING KERAS: cannot use classifier')
 
-        
+
     if loaded_model is None:
         if os.path.isfile(os.path.join(caiman_datadir(), model_name + ".json")):
             model_file    = os.path.join(caiman_datadir(), model_name + ".json")
@@ -540,9 +542,8 @@ def estimate_components_quality_auto(Y, A, C, b, f, YrA, frate, decay_time, gSig
 #%%
 def select_components_from_metrics(A, dims, gSig, r_values,  comp_SNR, r_values_min,
                                    r_values_lowest, min_SNR, min_std_reject,
-                                   thresh_cnn_min, thresh_cnn_lowest, use_cnn, gSig_range):
+                                   thresh_cnn_min, thresh_cnn_lowest, use_cnn, gSig_range, neuron_class = 1):
     '''
-
     '''
 
     idx_components_r = np.where((r_values >= r_values_min))[0]
@@ -550,7 +551,7 @@ def select_components_from_metrics(A, dims, gSig, r_values,  comp_SNR, r_values_
 
     idx_components = []
     if use_cnn:
-        neuron_class = 1  # normally 1
+          # normally 1
         if gSig_range is None:
             predictions, _ = evaluate_components_CNN(A, dims, gSig)
             predictions = predictions[:, neuron_class]

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -430,9 +430,8 @@ def save_memmap(filenames, base_name='Yr', resize_fact=(1, 1, 1), remove_init=0,
                     big_mov[:, Ttot:Ttot + T] = Yr
                     del big_mov
                 else:
-                    print('SAVING WITH f.write()')
-                    with open(fname_tot, 'wb') as f:
-                        f.write(Yr)
+                    print('SAVING WITH numpy.tofile()')
+                    Yr.tofile(fname_tot)
             else:
                 big_mov = np.memmap(fname_tot, dtype=np.float32, mode='r+',
                                     shape=(np.prod(dims), Ttot + T), order=order)

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -817,19 +817,15 @@ class CNMF(object):
             path = path_to_model.split(".")[:-1]
             json_path = ".".join(path + ["json"])
             model_path = ".".join(path + ["h5"])
-            try:
-                json_file = open(json_path, 'r')
-                loaded_model_json = json_file.read()
-                json_file.close()
-                loaded_model = model_from_json(loaded_model_json)
-                loaded_model.load_weights(model_path)
-                opt = keras.optimizers.rmsprop(lr=0.0001, decay=1e-6)
-                loaded_model.compile(loss=keras.losses.categorical_crossentropy,
-                              optimizer=opt, metrics=['accuracy'])
-            except:
-                print('No model found')
-                loaded_model = None
-                sniper_mode = False
+
+            json_file = open(json_path, 'r')
+            loaded_model_json = json_file.read()
+            json_file.close()
+            loaded_model = model_from_json(loaded_model_json)
+            loaded_model.load_weights(model_path)
+            opt = keras.optimizers.rmsprop(lr=0.0001, decay=1e-6)
+            loaded_model.compile(loss=keras.losses.categorical_crossentropy,
+                          optimizer=opt, metrics=['accuracy'])
 
         self.loaded_model = loaded_model
         self.sniper_mode = sniper_mode
@@ -903,9 +899,9 @@ class CNMF(object):
         self.mn = (t-1)/t*self.mn + res_frame/t
         self.vr = (t-1)/t*self.vr + (res_frame - mn_)*(res_frame - self.mn)/t
         self.sn = np.sqrt(self.vr)
-        
+
         if self.update_num_comps:
-            
+
             self.mean_buff += (res_frame-self.Yres_buf[self.Yres_buf.cur])/self.minibatch_shape
 #            cv2.imshow('untitled', 0.1*cv2.resize(res_frame.reshape(self.dims,order = 'F'),(512,512)))
 #            cv2.waitKey(1)
@@ -914,8 +910,9 @@ class CNMF(object):
 
             res_frame = np.reshape(res_frame, self.dims2, order='F')
 
-            rho = imblur(res_frame, sig=self.gSig,
+            rho = imblur(np.maximum(res_frame,0), sig=self.gSig,
                          siz=self.gSiz, nDimBlur=len(self.dims2))**2
+
             rho = np.reshape(rho, np.prod(self.dims2))
             self.rho_buf.append(rho)
 

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -786,10 +786,10 @@ class CNMF(object):
         self.sn = np.array(np.std(self.Yres_buf,axis=0))
         self.vr = np.array(np.var(self.Yres_buf,axis=0))
         self.mn = self.Yres_buf.mean(0)
-        self.Yres_buf = np.maximum(self.Yres_buf,0)
+        self.Yres_buf = self.Yres_buf
         self.mean_buff = self.Yres_buf.mean(0)
         self.ind_new = []
-        self.rho_buf = imblur(self.Yres_buf.T.reshape(
+        self.rho_buf = imblur(np.maximum(self.Yres_buf.T,0).reshape(
             self.dims2 + (-1,), order='F'), sig=self.gSig, siz=self.gSiz, nDimBlur=len(self.dims2))**2
         self.rho_buf = np.reshape(
             self.rho_buf, (np.prod(self.dims2), -1)).T

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -823,18 +823,18 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv=True):
                 for frame in range(X.shape[-1]):
                     if sys.version_info >= (3, 0):
                         X[:, :, frame] = cv2.GaussianBlur(X[:, :, frame], tuple(
-                            siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_REPLICATE)
+                            siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
                     else:
                         X[:, :, frame] = cv2.GaussianBlur(X[:, :, frame], tuple(siz.astype(np.int)), sig[
-                                                          0], sig[1], cv2.BORDER_REPLICATE, 0)
+                                                          0], sig[1], cv2.BORDER_CONSTANT, 0)
 
             else:
                 if sys.version_info >= (3, 0):
                     X = cv2.GaussianBlur(
-                        X, tuple(siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_REPLICATE)
+                        X, tuple(siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
                 else:
                     X = cv2.GaussianBlur(
-                        X, tuple(siz.astype(np.int)), sig[0], sig[1], cv2.BORDER_REPLICATE, 0)
+                        X, tuple(siz.astype(np.int)), sig[0], sig[1], cv2.BORDER_CONSTANT, 0)
         else:
             for i in range(nDimBlur):
                 h = np.exp(

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -302,7 +302,7 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
 
     d, T = np.shape(Y)[:-1], np.shape(Y)[-1]
     # rescale according to downsampling factor
-    gSig = np.asarray(gSig, dtype=float) / ssub
+    gSig = np.round(np.asarray(gSig) / ssub).astype(np.int)
     gSiz = np.round(np.asarray(gSiz) / ssub).astype(np.int)
 
     if normalize_init is True:
@@ -823,18 +823,18 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv=True):
                 for frame in range(X.shape[-1]):
                     if sys.version_info >= (3, 0):
                         X[:, :, frame] = cv2.GaussianBlur(X[:, :, frame], tuple(
-                            siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
+                            siz), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
                     else:
-                        X[:, :, frame] = cv2.GaussianBlur(X[:, :, frame], tuple(siz.astype(np.int)), sig[
+                        X[:, :, frame] = cv2.GaussianBlur(X[:, :, frame], tuple(siz), sig[
                                                           0], sig[1], cv2.BORDER_CONSTANT, 0)
 
             else:
                 if sys.version_info >= (3, 0):
                     X = cv2.GaussianBlur(
-                        X, tuple(siz.astype(np.int)), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
+                        X, tuple(siz), sig[0], None, sig[1], cv2.BORDER_CONSTANT)
                 else:
                     X = cv2.GaussianBlur(
-                        X, tuple(siz.astype(np.int)), sig[0], sig[1], cv2.BORDER_CONSTANT, 0)
+                        X, tuple(siz), sig[0], sig[1], cv2.BORDER_CONSTANT, 0)
         else:
             for i in range(nDimBlur):
                 h = np.exp(

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -813,7 +813,6 @@ def update_num_components(t, sv, Ab, Cf, Yres_buf, Y_buf, rho_buf,
             M = M + 1
 
             Yres_buf[:, indeces] -= np.outer(cin, ain)
-            Yres_buf[:, indeces] = np.maximum(Yres_buf[:, indeces],0)
             # vb = imblur(np.reshape(Ain, dims, order='F'), sig=gSig,
             #             siz=gSiz, nDimBlur=2).ravel()
             # restrict blurring to region where component is located

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -113,8 +113,8 @@ def runcmd(cmdlist, ignore_error=False, verbose=True):
         ret = pipeline.returncode
         if ret != 0 and not ignore_error:
                 print("Error in runcmd")
-		print("STDOUT: " + str(stdout))
-		print("STDERR: " + str(stderr))
+                print("STDOUT: " + str(stdout))
+                print("STDERR: " + str(stderr))
                 sys.exit(1)
         return stdout, stderr, ret
 

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -52,8 +52,37 @@ def do_run_nosetests(targdir):
 	out, err, ret = runcmd(["nosetests", "--traverse-namespace", "caiman"])
 	if ret != 0:
 		print("Nosetests failed with return code " + str(ret))
+		sys.exit(ret)
 	else:
 		print("Nosetests success!")
+
+def do_run_demotests(targdir):
+	out, err, ret = runcmd(["test_demos.sh"])
+	if ret != 0:
+		print("Demos failed with return code " + str(ret))
+		sys.exit(ret)
+	else:
+		print("Demos success!")
+
+def do_nt_run_demotests(targdir):
+	# Windows platform can't run shell scripts, and doing it in batch files
+	# is a terrible idea. So we'll do a minimal implementation of run_demos for
+	# windows inline here.
+	os.environ['MPLCONFIG'] = 'ps' # Not sure this does anything on windows
+	demos = glob.glob('demos/general/*.py') # Should still work on windows I think
+	for demo in demos:
+		print("========================================")
+		print("Testing " + str(demo))
+		if "demo_behavior.py" in demo:
+			print("  Skipping tests on " + demo + ": This is interactive")
+		else:
+			out, err, ret = runcmd(["python", demo], ignore_error=False)
+			if ret != 0:
+				print("  Tests failed with returncode " + str(ret))
+				print("  Failed test is " + str(demo))
+				sys.exit(2)
+			print("===================================")
+	print("Demos succeeded!")
 
 ###############
 #
@@ -96,6 +125,11 @@ def main():
 		do_check_install(cfg.userdir)
 	elif cfg.command == 'test':
 		do_run_nosetests(cfg.userdir)
+	elif cfg.command == 'demotest':
+		if os.name == 'nt':
+			do_nt_run_demotests(cfg.userdir)
+		else:
+			do_run_demotests(cfg.userdir)
 	else:
 		raise Exception("Unknown command")
 

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -57,7 +57,7 @@ def do_run_nosetests(targdir):
 		print("Nosetests success!")
 
 def do_run_demotests(targdir):
-	out, err, ret = runcmd(["test_demos.sh"])
+	out, err, ret = runcmd([os.path.join(caiman_datadir(), "test_demos.sh")])
 	if ret != 0:
 		print("Demos failed with return code " + str(ret))
 		sys.exit(ret)

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -112,7 +112,9 @@ def runcmd(cmdlist, ignore_error=False, verbose=True):
         (stdout, stderr) = pipeline.communicate()
         ret = pipeline.returncode
         if ret != 0 and not ignore_error:
-                print("Error in runcmd: " + str(stderr))
+                print("Error in runcmd")
+		print("STDOUT: " + str(stdout))
+		print("STDERR: " + str(stderr))
                 sys.exit(1)
         return stdout, stderr, ret
 

--- a/demos/general/demo_caiman_basic.py
+++ b/demos/general/demo_caiman_basic.py
@@ -80,7 +80,7 @@ is_patches = True      # flag for processing in patches or not
 if is_patches:          # PROCESS IN PATCHES AND THEN COMBINE
     rf = 10             # half size of each patch
     stride = 4          # overlap between patches
-    K = 3               # number of components in each patch
+    K = 4               # number of components in each patch
 else:                   # PROCESS THE WHOLE FOV AT ONCE
     rf = None           # setting these parameters to None
     stride = None       # will run CNMF on the whole FOV
@@ -104,14 +104,6 @@ plt.figure()
 crd = cm.utils.visualization.plot_contours(cnm.A, Cn, thr=0.9)
 plt.title('Contour plots of components')
 
-#%% visualize selected and rejected components
-plt.figure()
-plt.subplot(1, 2, 1)
-cm.utils.visualization.plot_contours(cnm.A[:, :], Cn, thr=0.9)
-plt.title('Selected components')
-plt.subplot(1, 2, 2)
-plt.title('Discaded components')
-cm.utils.visualization.plot_contours(cnm.A[:, :], Cn, thr=0.9)
 
 
 
@@ -142,6 +134,15 @@ idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
                                      dview=dview, min_SNR=min_SNR,
                                      r_values_min=rval_thr, use_cnn=use_cnn,
                                      thresh_cnn_min=min_cnn_thr)
+#%% visualize selected and rejected components
+plt.figure()
+plt.subplot(1, 2, 1)
+cm.utils.visualization.plot_contours(cnm2.A[:, idx_components], Cn, thr=0.9)
+plt.title('Selected components')
+plt.subplot(1, 2, 2)
+plt.title('Discaded components')
+cm.utils.visualization.plot_contours(cnm2.A[:, idx_components_bad], Cn, thr=0.9)
+
 #%%
 plt.figure()
 crd = cm.utils.visualization.plot_contours(cnm2.A.tocsc()[:,idx_components], Cn, thr=0.9)

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - defaults
 dependencies:
 - python=3.6
-- tensorflow # Must list before keras to preempt default keras backend
+- tensorflow=1.4.0 # Must list before keras to preempt default keras backend
 - bokeh
 - cython
 - future

--- a/environment_python2.yml
+++ b/environment_python2.yml
@@ -3,7 +3,7 @@ channels:
 - defaults
 dependencies:
 - python=2.7
-- tensorflow # Must list before keras to preempt default keras backend
+- tensorflow=1.4.0 # Must list before keras to preempt default keras backend
 - bokeh
 - cython
 - future

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ binaries = ['caimanmanager.py']
 extra_dirs = ['demos', 'docs', 'use_cases', 'example_movies']
 data_files = [('', ['LICENSE.txt']),
               ('', ['README.md']),
+              ('share/caiman', ['test_demos.sh']),
               ('share/caiman/testdata', ['caiman/tests/comparison/groundtruth.npz', 'caiman/tests/comparison/tests/example/example.npz'])
              ]
 for part in extra_dirs:

--- a/test/linux-python2/Dockerfile
+++ b/test/linux-python2/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     qtbase5-dev \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
-# RUN conda install -c cvxgrp cvxpy
+# RUN conda install -c cvxgrp cvxpy tensorflow
 # RUN conda install -c https://conda.anaconda.org/conda-forge tifffile
 # RUN git clone --recursive -b agiovann-master https://github.com/valentina-s/Constrained_NMF.git
 # RUN git clone --recursive https://github.com/agiovann/Constrained_NMF.git

--- a/test/linux-python2/Dockerfile
+++ b/test/linux-python2/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     libc6-i386 \
     libgl1-mesa-swx11 \
     xvfb \
+    qtbase5-dev \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
 # RUN conda install -c cvxgrp cvxpy

--- a/test/linux-python2/Dockerfile
+++ b/test/linux-python2/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     libgtk2.0-0 \
     libc6-i386 \
     libgl1-mesa-swx11 \
+    xvfb \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
 # RUN conda install -c cvxgrp cvxpy

--- a/test/linux-python3/Dockerfile
+++ b/test/linux-python3/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     qtbase5-dev \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
-# RUN conda install -c cvxgrp cvxpy
+# RUN conda install -c cvxgrp cvxpy tensorflow
 # RUN conda install -c https://conda.anaconda.org/conda-forge tifffile
 # RUN git clone --recursive -b agiovann-master https://github.com/valentina-s/Constrained_NMF.git
 # RUN git clone --recursive https://github.com/agiovann/Constrained_NMF.git

--- a/test/linux-python3/Dockerfile
+++ b/test/linux-python3/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     libc6-i386 \
     libgl1-mesa-swx11 \
     xvfb \
+    qtbase5-dev \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
 # RUN conda install -c cvxgrp cvxpy

--- a/test/linux-python3/Dockerfile
+++ b/test/linux-python3/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     libgtk2.0-0 \
     libc6-i386 \
     libgl1-mesa-swx11 \
+    xvfb \
   && rm -rf /var/lib/apt/lists/*
 # RUN conda install -c menpo opencv3=3.1.0
 # RUN conda install -c cvxgrp cvxpy

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -26,7 +26,7 @@ if [ $OS == "Linux" ]; then
 		echo "xvfb-run command not found"
 		exit 1
 	fi
-	XVFB="xvfb-run -s \"-screen 0 800x600x16\" -d -e /dev/stdout "
+	XVFB="xvfb-run -s -a -e - "
 fi
 
 # Tell matplotlib to try to plot less to begin with by specifying a postscript backend

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -14,10 +14,19 @@
 
 # Make sure the xvfb-run command exists before starting demos, so we can give a better
 # error message
-command -v xvfb-run
-if [ $? != 0 ]; then
-	echo "xvfb-run command not found"
-	exit 1
+XVFB=""
+OS=$(uname -s)
+
+# On Linux we wrap our command with xvfb-run to allow X things to happen
+# and make them effectively no-ops. Not necessary on other platforms.
+
+if [ $OS == "Linux" ]; then
+	command -v xvfb-run
+	if [ $? != 0 ]; then
+		echo "xvfb-run command not found"
+		exit 1
+	fi
+	XVFB="xvfb-run -s \"-screen 0 800x600x16\" "
 fi
 
 # Tell matplotlib to try to plot less to begin with by specifying a postscript backend
@@ -32,7 +41,7 @@ for demo in demos/general/*; do
 		true
 	else
 		echo Testing demo [$demo]
-		xvfb-run -s "-screen 0 800x600x16" python $demo
+		$XVFB python $demo
 		err=$?
 		if [ $err != 0 ]; then
 			echo "	Tests failed with returncode $err"

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-# TODO: Set pythonpath to wherever this was unpacked
 ##########################
 # test_demos.sh
 #
-# This is intended to run all the python (.py) demos in the
-# codebase for testing. Jenkins will eventually invoke this.
+# This is intended to test the python (.py) demos
 #
 # dependencies:
 #   xvfb-run - This starts a dummy X server for anything that might
@@ -13,8 +11,6 @@
 #              we test MUST NOT wait for input while showing a movie,
 #              because in the test environment nobody will show up to provide
 #              that input (like clicking things or hitting q)
-
-# TODO: Enter appropriate conda environment, unless my wrapper script does that
 
 # Make sure the xvfb-run command exists before starting demos, so we can give a better
 # error message

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -26,7 +26,7 @@ if [ $OS == "Linux" ]; then
 		echo "xvfb-run command not found"
 		exit 1
 	fi
-	XVFB="xvfb-run -s -a -e - "
+	XVFB="xvfb-run -a "
 fi
 
 # Tell matplotlib to try to plot less to begin with by specifying a postscript backend

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -26,7 +26,7 @@ if [ $OS == "Linux" ]; then
 		echo "xvfb-run command not found"
 		exit 1
 	fi
-	XVFB="xvfb-run -s \"-screen 0 800x600x16\" "
+	XVFB="xvfb-run -s \"-screen 0 800x600x16\" -d -e /dev/stdout "
 fi
 
 # Tell matplotlib to try to plot less to begin with by specifying a postscript backend

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -23,6 +23,8 @@ fi
 # Tell matplotlib to try to plot less to begin with by specifying a postscript backend
 export MPLCONFIG=ps
 
+cd `dirname ${BASH_SOURCE[0]}`
+
 for demo in demos/general/*; do
 	if [ $demo == "demos/general/demo_behavior.py" ]; then
 		echo "	Skipping tests on $demo: This is interactive"

--- a/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
+++ b/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
@@ -287,7 +287,8 @@ params_movies.append(params_movie.copy())
 #%%
 def myfun(x):
     from caiman.source_extraction.cnmf.deconvolution import constrained_foopsi
-    return constrained_foopsi(*x)[5]
+    dc = constrained_foopsi(*x)
+    return (dc[0],dc[5])
 def fun_exc(x):
     from scipy.stats import norm
     from caiman.components_evaluation import compute_event_exceptionality
@@ -315,7 +316,7 @@ n_pixels_per_process=4000
 block_size=4000
 num_blocks_per_run=10
 
-for params_movie in np.array(params_movies)[6:7]:
+for params_movie in np.array(params_movies)[7:8]:
 #    params_movie['gnb'] = 3
     params_display = {
         'downsample_ratio': .2,
@@ -573,8 +574,11 @@ for params_movie in np.array(params_movies)[6:7]:
 #        pl.hist(np.sum(comp_SNR_trace>2.5,0)/len(comp_SNR_trace),15)
 #        np.savez(fname_new.split('/')[-4]+'_act.npz', comp_SNR_trace=comp_SNR_trace, C_gt=C_gt, A_gt=A_gt, dims=(d1,d2))
 
-        S = dview.map(myfun,[[fluor, None, None, None, None, 2, 'oasis'] for fluor in (C_gt+YrA_gt)])
-        np.savez(fname_new.split('/')[-4]+'_spikes.npz', S=S, C_gt=C_gt, A_gt=A_gt, dims=(d1,d2))
+        S_gt = dview.map(myfun,[[fluor, None, None, None, None, 2, 'oasis'] for fluor in (C_gt+YrA_gt)])
+        S = [s[1] for s in S_gt]
+        C = [s[0] for s in S_gt]
+        F = C_gt+YrA_gt
+        np.savez(fname_new.split('/')[-4]+'_spikes.npz', S=S, C=C, A_gt=A_gt, F = F, dims=(d1,d2))
         continue
 #        gt_file = os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'match_masks.npz')
 #        with np.load(gt_file, encoding = 'latin1') as ld:

--- a/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
+++ b/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
@@ -305,7 +305,7 @@ all_comp_SNR_delta = []
 all_predictions = []
 all_labels = []
 all_results = dict()
-reload = True
+reload = False
 plot_on = False
 save_on = False
 skip_refinement = False
@@ -316,7 +316,7 @@ n_pixels_per_process=4000
 block_size=4000
 num_blocks_per_run=10
 
-for params_movie in np.array(params_movies)[7:8]:
+for params_movie in np.array(params_movies)[:]:
 #    params_movie['gnb'] = 3
     params_display = {
         'downsample_ratio': .2,
@@ -501,7 +501,7 @@ for params_movie in np.array(params_movies)[7:8]:
         if save_on:
             np.savez(os.path.join(os.path.split(fname_new)[0],
                               os.path.split(fname_new)[1][:-4] +
-                              'results_analysis_after_merge_loc_ipy_ceph.npz'),
+                              'results_analysis_new_dev.npz'),
                               Cn=Cn, fname_new = fname_new,
                               A=A, C=C, b=b, f=f, YrA=YrA, sn=sn, d1=d1,
                               d2=d2, idx_components=idx_components,
@@ -545,7 +545,7 @@ for params_movie in np.array(params_movies)[7:8]:
 #         print(os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'results_analysis_after_merge_5.npz'))
 # =============================================================================
 
-        with np.load(os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'results_analysis_after_merge_loc_ipy_ceph.npz'), encoding = 'latin1') as ld:
+        with np.load(os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'results_analysis_new_dev.npz'), encoding = 'latin1') as ld:
             ld1 = {k:ld[k] for k in ['d1','d2','A','params_movie','fname_new',
                    'C','idx_components','idx_components_bad','Cn','b','f','YrA',
                    'sn','comp_SNR','r_values','predictionsCNN','A_gt','A_gt_thr',
@@ -574,12 +574,12 @@ for params_movie in np.array(params_movies)[7:8]:
 #        pl.hist(np.sum(comp_SNR_trace>2.5,0)/len(comp_SNR_trace),15)
 #        np.savez(fname_new.split('/')[-4]+'_act.npz', comp_SNR_trace=comp_SNR_trace, C_gt=C_gt, A_gt=A_gt, dims=(d1,d2))
 
-        S_gt = dview.map(myfun,[[fluor, None, None, None, None, 2, 'oasis'] for fluor in (C_gt+YrA_gt)])
-        S = [s[1] for s in S_gt]
-        C = [s[0] for s in S_gt]
-        F = C_gt+YrA_gt
-        np.savez(fname_new.split('/')[-4]+'_spikes.npz', S=S, C=C, A_gt=A_gt, F = F, dims=(d1,d2))
-        continue
+#        S_gt = dview.map(myfun,[[fluor, None, None, None, None, 2, 'oasis'] for fluor in (C_gt+YrA_gt)])
+#        S = [s[1] for s in S_gt]
+#        C = [s[0] for s in S_gt]
+#        F = C_gt+YrA_gt
+#        np.savez(fname_new.split('/')[-4]+'_spikes.npz', S=S, C=C, A_gt=A_gt, F = F, dims=(d1,d2))
+#        continue
 #        gt_file = os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'match_masks.npz')
 #        with np.load(gt_file, encoding = 'latin1') as ld:
 #            print(ld.keys())
@@ -1130,56 +1130,56 @@ for params_movie in np.array(params_movies)[7:8]:
         pl.ylabel('F1-score')
 
 
-#%% activity
-import glob
-import numpy as np
-import pylab as pl
-from scipy.signal import savgol_filter
-ffllss = glob.glob('*_act.npz')
-ffllss.sort()
-print(ffllss)
-for thresh in np.arange(1.5,4.5,1):
-    count = 1
-    pl.pause(0.1)
-    for ffll in ffllss:
+        #%% activity
+        import glob
+        import numpy as np
+        import pylab as pl
+        from scipy.signal import savgol_filter
+        ffllss = glob.glob('*_act.npz')
+        ffllss.sort()
+        print(ffllss)
+        for thresh in np.arange(1.5,4.5,1):
+            count = 1
+            pl.pause(0.1)
+            for ffll in ffllss:
 
-        with np.load(ffll) as ld:
-            print(ld.keys())
-            locals().update(ld)
-            pl.subplot(3,4,count)
-            count += 1
-            a = np.histogram(np.sum(comp_SNR_trace>thresh,0)/len(comp_SNR_trace),100)
-            pl.plot(a[1][1:][a[0]>0],savgol_filter(a[0][a[0]>0]/comp_SNR_trace.shape[-1],5,3))
+                with np.load(ffll) as ld:
+                    print(ld.keys())
+                    locals().update(ld)
+                    pl.subplot(3,4,count)
+                    count += 1
+                    a = np.histogram(np.sum(comp_SNR_trace>thresh,0)/len(comp_SNR_trace),100)
+                    pl.plot(a[1][1:][a[0]>0],savgol_filter(a[0][a[0]>0]/comp_SNR_trace.shape[-1],5,3))
 
-            pl.title(ffll)
+                    pl.title(ffll)
 
-pl.legend(np.arange(1.5,4.5,1))
-pl.xlabel('fraction active')
-pl.ylabel('fraction of frames')
-#%% spikes
-import glob
-import numpy as np
-import pylab as pl
-from scipy.signal import savgol_filter
-ffllss = glob.glob('*_spikes.npz')
-ffllss.sort()
-print(ffllss)
-for thresh in np.arange(0,.3,.1):
-    count = 1
-    pl.pause(0.1)
-    for ffll in ffllss:
+        pl.legend(np.arange(1.5,4.5,1))
+        pl.xlabel('fraction active')
+        pl.ylabel('fraction of frames')
+        #%% spikes
+        import glob
+        import numpy as np
+        import pylab as pl
+        from scipy.signal import savgol_filter
+        ffllss = glob.glob('*_spikes.npz')
+        ffllss.sort()
+        print(ffllss)
+        for thresh in np.arange(0,.3,.1):
+            count = 1
+            pl.pause(0.1)
+            for ffll in ffllss:
 
-        with np.load(ffll) as ld:
-            print(ld.keys())
-            locals().update(ld)
-            S = S/np.max(S,1)[:,None]
-            pl.subplot(3,4,count)
-            count += 1
-            a = np.histogram(np.sum(S>thresh,0)/len(S),100)
-            pl.plot(a[1][1:][a[0]>0],savgol_filter(a[0][a[0]>0]/S.shape[-1],5,3))
+                with np.load(ffll) as ld:
+                    print(ld.keys())
+                    locals().update(ld)
+                    S = S/np.max(S,1)[:,None]
+                    pl.subplot(3,4,count)
+                    count += 1
+                    a = np.histogram(np.sum(S>thresh,0)/len(S),100)
+                    pl.plot(a[1][1:][a[0]>0],savgol_filter(a[0][a[0]>0]/S.shape[-1],5,3))
 
-            pl.title(ffll)
+                    pl.title(ffll)
 
-pl.legend(np.arange(0,.3,.1))
-pl.xlabel('fraction active')
-pl.ylabel('fraction of frames')
+        pl.legend(np.arange(0,.3,.1))
+        pl.xlabel('fraction active')
+        pl.ylabel('fraction of frames')

--- a/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
+++ b/use_cases/CaImAnpaper/compare_gt_cnmf_CNN.py
@@ -172,6 +172,7 @@ params_movies.append(params_movie.copy())
 #%% neurofinder 00.00
 params_movie = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.00.00/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_2936_.mmap',
                   'gtname':'/mnt/ceph/neuro/labeling/neurofinder.00.00/regions/joined_consensus_active_regions.npy',
+                  'merge_thresh': 0.8,  # merging threshold, max correlation allow
                  'rf': 20,  # half-size of the patches in pixels. rf=25, patches are 50x50    20
                  'stride_cnmf': 10,  # amounpl.it of overlap between the patches in pixels
                  'K': 6,  # number of components per patch
@@ -259,7 +260,7 @@ params_movie = {#'fname': '/opt/local/Data/labeling/J123_2015-11-20_L01_0/Yr_d1_
                  'rf': 40,  # half-size of the patches in pixels. rf=25, patches are 50x50    20
                  'stride_cnmf': 20,  # amounpl.it of overlap between the patches in pixels
                  'K': 10,  # number of components per patch
-                 'gSig': [8,12],  # expected half size of neurons
+                 'gSig': [10,10],  # expected half size of neurons
                  'decay_time' : 0.5,
                  'fr' : 30,
                  'n_chunks': 10,
@@ -539,6 +540,7 @@ for params_movie in np.array(params_movies)[:]:
             'downsample_ratio': .2,
             'thr_plot': 0.8
         }
+
         fn_old = fname_new
         #analysis_file = '/mnt/ceph/neuro/jeremie_analysis/neurofinder.03.00.test/Yr_d1_498_d2_467_d3_1_order_C_frames_2250_._results_analysis.npz'
 # =============================================================================
@@ -552,6 +554,7 @@ for params_movie in np.array(params_movies)[:]:
                    'A_thr','C_gt','b_gt','f_gt','YrA_gt','idx_components_gt',
                    'idx_components_bad_gt', 'comp_SNR_gt', 'r_values_gt', 'predictionsCNN_gt',
                    't_eva_comps', 't_patch', 't_refine']}
+
             locals().update(ld1)
             dims_off = d1,d2
             A = scipy.sparse.coo_matrix(A[()])
@@ -762,6 +765,9 @@ for params_movie in np.array(params_movies)[:]:
     plot_results = plot_on
     if plot_results:
         pl.figure(figsize=(30,20))
+        Cn_ = Cn
+    else:
+        Cn_ = None
 
 #    idx_components = range(len(r_values))
 #    tp_gt, tp_comp, fn_gt, fp_comp, performance_cons_off =\
@@ -775,7 +781,7 @@ for params_movie in np.array(params_movies)[:]:
                     A_gt_thr[:,idx_components_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
                     A_thr[:,idx_components_cnmf].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
                     thresh_cost=.8, min_dist = 10,
-                    print_assignment= False, plot_results=plot_results, Cn=Cn, labels=['GT','Offline'])
+                    print_assignment= False, plot_results=plot_results, Cn=Cn_, labels=['GT','Offline'])
     pl.rcParams['pdf.fonttype'] = 42
     font = {'family' : 'Arial',
             'weight' : 'regular',
@@ -1104,7 +1110,7 @@ for params_movie in np.array(params_movies)[:]:
 
         f1s = dict()
         f1s['batch'] = [0.77777,0.67,0.7623,0.72391,0.778739,0.7731,0.76578,0.77386,0.6783]
-        f1s['online'] = [0.765,0.686,0.759,0.719,0.776,0.745,0.8,0.82,0.77]
+        f1s['online'] = [0.76,0.678,0.783,0.721,0.769,0.725,0.818,0.805,0.803]
         f1s['L1'] = [np.nan,np.nan,0.78,np.nan,0.89,0.8,0.89,np.nan,0.85]
         f1s['L2'] = [0.9,0.69,0.9,0.92,0.87,0.89,0.92,0.93,0.83]
         f1s['L3'] = [0.85,0.75,0.82,0.83,0.84,0.78,0.93,0.94,0.9]

--- a/use_cases/CaImAnpaper/online_testing2_bk.py
+++ b/use_cases/CaImAnpaper/online_testing2_bk.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 
 """
-Complete pipeline for online processing using OnACID. 
+Complete pipeline for online processing using OnACID.
 @author: Andrea Giovannucci @agiovann and Eftychios Pnevmatikakis @epnev
-Special thanks to Andreas Tolias and his lab at Baylor College of Medicine 
+Special thanks to Andreas Tolias and his lab at Baylor College of Medicine
 for sharing their data used in this demo.
 """
 from __future__ import division
@@ -57,21 +57,22 @@ except:
 # 7: J115
 # 8: J123
 # 9: sue_ann_k37
-#10: Jan-AMG_exp3_001    
+#10: Jan-AMG_exp3_001
 
-ind_dataset = 1
+ind_dataset = 6
 
 #%% set some global parameters here
 #'use_cases/edge-cutter/binary_cross_bootstrapped.json'
 global_params = {'min_SNR': .75,        # minimum SNR when considering adding a new neuron
-                 'gnb' : 2,             # number of background components   
+                 'gnb' : 2,             # number of background components
                  'epochs' : 2,          # number of passes over the data
                  'rval_thr' : 0.70,     # spatial correlation threshold
                  'batch_length_dt': 10, # length of mini batch for OnACID in decay time units (length would be batch_length_dt*decay_time*fr)
                  'max_thr': 0.25,       # parameter for thresholding components when cleaning up shapes
                  'mot_corr' : False,    # flag for motion correction (set to False to compare directly on the same FOV)
-                 'min_num_trial' : 3,   # minimum number of times to attempt to add a component
-                 'path_to_model' : 'use_cases/edge-cutter/sniper_sensitive.json', #'use_cases/edge-cutter/binary_cross_bootstrapped.json', #'use_cases/edge-cutter/residual_classifier_2classes.json',
+                 'min_num_trial' : 5,   # minimum number of times to attempt to add a component
+                 'path_to_model' : 'use_cases/CaImAnpaper/net_models/sniper_sensitive.json', #'use_cases/edge-cutter/binary_cross_bootstrapped.json', #'use_cases/edge-cutter/residual_classifier_2classes.json',
+                 'use_peak_max' : True,
                  'thresh_CNN_noisy' : .5,
                  'sniper_mode' : True,
                  'rm_flag' : False,
@@ -86,7 +87,7 @@ params_movie[0] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.03.00.test/ima
                  'p': 1,  # order of the autoregressive system
                  'fr': 7,
                  'decay_time': 0.4,
-                 'gSig': [12,12],  # expected half size of neurons              
+                 'gSig': [12,12],  # expected half size of neurons
                  'gnb': 3,
                  'T1': 2250
                  }
@@ -96,7 +97,7 @@ params_movie[1] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.04.00.test/ima
                  'epochs' : 2,
                  'ds_factor' : 1,
                  'p': 1,  # order of the autoregressive system
-                 'fr': 8, 
+                 'fr': 8,
                  'gSig': [7,7],  # expected half size of neurons
                  'decay_time' : 0.5, # rough length of a transient
                  'gnb' : 3,
@@ -108,16 +109,16 @@ params_movie[2] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.02.00/images/f
                  'folder_name' : '/mnt/ceph/neuro/labeling/neurofinder.02.00/',
                  'ds_factor' : 1,
                  'p': 1,  # order of the autoregressive system
-                 'fr' : 30, # imaging rate in Hz                 
+                 'fr' : 30, # imaging rate in Hz
                  'gSig': [8,8],  # expected half size of neuron
-                 'decay_time': 0.3,                 
-                 'gnb': 2,          
-                 'T1':8000,                 
+                 'decay_time': 0.3,
+                 'gnb': 2,
+                 'T1':8000,
                  }
 
 #% yuste
 params_movie[3] = {'fname': '/mnt/ceph/neuro/labeling/yuste.Single_150u/images/final_map/Yr_d1_200_d2_256_d3_1_order_C_frames_3000_.mmap',
-                 'folder_name': '/mnt/ceph/neuro/labeling/yuste.Single_150u/', 
+                 'folder_name': '/mnt/ceph/neuro/labeling/yuste.Single_150u/',
                  'epochs' : 2,
                  'ds_factor' : 1,
                  'p': 1,  # order of the autoregressive system
@@ -134,7 +135,7 @@ params_movie[4] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.00.00/images/f
                  'folder_name':  '/mnt/ceph/neuro/labeling/neurofinder.00.00/',
                  'ds_factor' : 1,
                  'p': 1,  # order of the autoregressive system
-                 'decay_time' : 0.4, 
+                 'decay_time' : 0.4,
                  'fr' : 16,
                  'gSig': [8,8],  # expected half size of neurons
                  'gnb': 2,
@@ -148,7 +149,7 @@ params_movie[5] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.01.01/images/f
                  'fr' : 8,
                  'gnb':1,
                  'T1' : 1825,
-                 'decay_time' : 1.4,     
+                 'decay_time' : 1.4,
                  'gSig': [6,6]
                  }
 #% Sue Ann k53
@@ -159,7 +160,7 @@ params_movie[6] = {'fname': '/mnt/ceph/neuro/labeling/k53_20160530/images/final_
                  'ds_factor' : 2,
                  'p': 1,  # order of the autoregressive system
                  'T1': 3000, # number of frames per file
-                 'fr': 30, 
+                 'fr': 30,
                  'decay_time' : 0.4,
                  'gSig': [8,8],  # expected half size of neurons
                  'gnb' : 2,
@@ -170,7 +171,7 @@ params_movie[7] = {'fname': '/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/im
                 'folder_name':'/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/',
                 'gtname':'/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/regions/joined_consensus_active_regions.npy',
                 'epochs' : 1,
-                'ds_factor' : 2, 
+                'ds_factor' : 2,
                 'p': 1,  # order of the autoregressive system
                 'T1' : 1000,
                 'gnb' : 2,
@@ -183,7 +184,7 @@ params_movie[7] = {'fname': '/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/im
 params_movie[8] = {'fname': '/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/images/final_map/Yr_d1_458_d2_477_d3_1_order_C_frames_41000_.mmap',
                 'folder_name':'/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/',
                 'gtname':'/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/regions/joined_consensus_active_regions.npy',
-                 'ds_factor' : 2, 
+                 'ds_factor' : 2,
                  'epochs' : 1,
                  'thresh_CNN_noisy' : 0.999,
                  'min_num_trial' : 2,
@@ -228,7 +229,7 @@ params_movie[10] = {'fname' : '/mnt/ceph/neuro/labeling/Jan-AMG_exp3_001/images/
 #    for file_count, ffll in enumerate(fls):
 #        file_name = '/'.join(ffll.split('/')[:-2]+['mmap_tifs']+[ffll.split('/')[-1][:-4]+'tif'])
 #        if not os.path.isfile(file_name):
-#            fl_temp = cm.movie(np.array(cm.load(ffll)))        
+#            fl_temp = cm.movie(np.array(cm.load(ffll)))
 #            fl_temp.save(file_name)
 #        print(file_name)
 #    print(ind_dataset)
@@ -247,7 +248,7 @@ else:
         fls = glob.glob('/'.join( params_movie[ind_dataset]['fname'].split('/')[:-3]+['images','tiff_VST','*.tif']))
 
 fls.sort()
-print(fls)  
+print(fls)
 
 #%% Set up some parameters
 ds_factor = params_movie[ind_dataset]['ds_factor']                            # spatial downsampling factor (increases speed but may lose some fine structure)
@@ -262,7 +263,7 @@ min_SNR = 3.0956*np.log(len(fls)*params_movie[ind_dataset]['T1']/(307.85*params_
 N_samples = np.ceil(params_movie[ind_dataset]['fr']*params_movie[ind_dataset]['decay_time'])   # number of timesteps to consider when testing new neuron candidates
 pr_inc = 1 - scipy.stats.norm.cdf(global_params['min_SNR'])           # inclusion probability of noise transient
 thresh_fitness_raw = np.log(pr_inc)*N_samples       # event exceptionality threshold
-thresh_fitness_delta = -80.                         # make this very neutral 
+thresh_fitness_delta = -80.                         # make this very neutral
 p = params_movie[ind_dataset]['p']                  # order of AR indicator dynamics
 #rval_thr = global_params['rval_thr']                # correlation threshold for new component inclusion
 rval_thr = 0.06*np.log(len(fls)*params_movie[ind_dataset]['T1']/(2177.*params_movie[ind_dataset]['fr'])-0.0462) +0.8862
@@ -270,7 +271,7 @@ rval_thr = 0.06*np.log(len(fls)*params_movie[ind_dataset]['T1']/(2177.*params_mo
 try:
     gnb = params_movie[ind_dataset]['gnb']
 except:
-    gnb = global_params['gnb']    
+    gnb = global_params['gnb']
 
 try:
     epochs = params_movie[ind_dataset]['epochs']                     # number of background components
@@ -309,7 +310,7 @@ if ds_factor > 1:                                   # load only the first initba
     Y = cm.load(fls[0], subindices = slice(0,initbatch,None)).astype(np.float32).resize(1. / ds_factor, 1. / ds_factor)
 else:
     Y =  cm.load(fls[0], subindices = slice(0,initbatch,None)).astype(np.float32)
-    
+
 if mot_corr:                                        # perform motion correction on the first initbatch frames
     max_shift = np.ceil(5./ds_factor).astype('int')     # maximum allowed shift during motion correction
     mc = Y.motion_correct(max_shift, max_shift, template = template)
@@ -317,16 +318,16 @@ if mot_corr:                                        # perform motion correction 
     borders = np.max(mc[1])
 else:
     Y = Y.astype(np.float32)
-      
+
 img_min = Y.min()                                   # minimum value of movie. Subtract it to make the data non-negative
 Y -= img_min
-img_norm = np.std(Y, axis=0)                        
+img_norm = np.std(Y, axis=0)
 img_norm += np.median(img_norm)                     # normalizing factor to equalize the FOV
 Y = Y / img_norm[None, :, :]                        # normalize data
 
 _, d1, d2 = Y.shape
 dims = (d1, d2)                                     # dimensions of FOV
-Yr = Y.to_2D().T                                    # convert data into 2D array                                    
+Yr = Y.to_2D().T                                    # convert data into 2D array
 
 t_corr = time()
 Cn_init = Y.local_correlations(swap_dim = False)    # compute correlation image
@@ -339,7 +340,7 @@ cnm_init = bare_initialization(Y[:initbatch].transpose(1, 2, 0), init_batch=init
                                  update_num_comps = True, rval_thr=rval_thr,
                                  thresh_fitness_delta = thresh_fitness_delta,
                                  thresh_fitness_raw = thresh_fitness_raw, use_dense = False,
-                                 batch_update_suff_stat=True, max_comp_update_shape = 200, 
+                                 batch_update_suff_stat=True, max_comp_update_shape = 200,
                                  deconv_flag = True,  thresh_CNN_noisy = thresh_CNN_noisy,
                                  simultaneously = False, n_refit = 0)
 
@@ -350,7 +351,7 @@ cnm_init = bare_initialization(Y[:initbatch].transpose(1, 2, 0), init_batch=init
 #A, C, b, f, YrA, sn = cnm_init.A, cnm_init.C, cnm_init.b, cnm_init.f, cnm_init.YrA, cnm_init.sn
 #view_patches_bar(Yr, scipy.sparse.coo_matrix(A.tocsc()[:, :]), C[:, :], b, f, dims[0], dims[1], YrA=YrA[:, :], img=Cn_init)
 
-#% Prepare object for OnACID
+#%% Prepare object for OnACID
 t_deep = time()
 cnm2 = deepcopy(cnm_init)
 timings['deep'] = time() - t_deep
@@ -359,7 +360,7 @@ cnm2._prepare_object(np.asarray(Yr[:,:initbatch]), T1, expected_comps, idx_compo
                          max_num_added = min_num_trial,
                          min_num_trial = min_num_trial,
                          sniper_mode = global_params['sniper_mode'],
-                         path_to_model = global_params['path_to_model'])
+                         path_to_model = global_params['path_to_model'], use_peak_max = global_params['use_peak_max'])
 
 timings['init'] = time() - t_init
 #%% Run OnACID and optionally plot results in real time
@@ -384,14 +385,14 @@ resize_fact = 1.2                        # image resizing factor
 if online_files == 0:                    # check whether there are any additional files
     process_files = fls[:init_files]     # end processing at this file
     init_batc_iter = [initbatch]         # place where to start
-    end_batch = T1              
+    end_batch = T1
 else:
     process_files = fls[:init_files + online_files]     # additional files
     init_batc_iter = [initbatch] + [0]*online_files     # where to start reading at each file
 
 shifts = []
 if save_movie and play_reconstr:
-    fourcc = cv2.VideoWriter_fourcc('8', 'B', 'P', 'S') 
+    fourcc = cv2.VideoWriter_fourcc('8', 'B', 'P', 'S')
     out = cv2.VideoWriter(movie_name,fourcc, 30.0, tuple([int(2*x*resize_fact) for x in cnm2.dims]))
 
 
@@ -400,25 +401,25 @@ for iter in range(epochs):
     if iter > 0:
         process_files = fls[:init_files + online_files]     # if not on first epoch process all files from scratch
         init_batc_iter = [0]*(online_files+init_files)      #
-        
+
     for file_count, ffll in enumerate(process_files):  # np.array(fls)[np.array([1,2,3,4,5,-5,-4,-3,-2,-1])]:
         print('Now processing file ' + ffll)
         t_load = time()
         Y_ = cm.load(ffll, subindices=slice(init_batc_iter[file_count],T1,None))
         timings['load'] += time() - t_load
-        
+
         if plot_contours_flag:   # update max-correlation (and perform offline motion correction) just for illustration purposes
             if ds_factor > 1:
                 Y_1 = Y_.resize(1. / ds_factor, 1. / ds_factor, 1)
             else:
-                Y_1 = Y_.copy()                    
+                Y_1 = Y_.copy()
                 if mot_corr:
-                    templ = (cnm2.Ab.data[:cnm2.Ab.indptr[1]] * cnm2.C_on[0, t - 1]).reshape(cnm2.dims, order='F') * img_norm        
-                    newcn = (Y_1 - img_min).motion_correct(max_shift, max_shift, template=templ)[0].local_correlations(swap_dim=False)                
+                    templ = (cnm2.Ab.data[:cnm2.Ab.indptr[1]] * cnm2.C_on[0, t - 1]).reshape(cnm2.dims, order='F') * img_norm
+                    newcn = (Y_1 - img_min).motion_correct(max_shift, max_shift, template=templ)[0].local_correlations(swap_dim=False)
                     Cn = np.maximum(Cn, newcn)
                 else:
                     Cn = np.maximum(Cn, Y_1.local_correlations(swap_dim=False))
-    
+
         old_comps = cnm2.N                              # number of existing components
         for frame_count, frame in enumerate(Y_):        # now process each file
             if np.isnan(np.sum(frame)):
@@ -426,14 +427,14 @@ for iter in range(epochs):
             if t % 200 == 0:
                 print('Epoch: ' + str(iter+1) + '. ' + str(t)+' frames have beeen processed in total. '+str(cnm2.N - old_comps)+' new components were added. Total number of components is '+str(cnm2.Ab.shape[-1]-gnb))
                 old_comps = cnm2.N
-    
+
             t1 = time()                                 # count time only for the processing part
-            frame_ = frame.copy().astype(np.float32)    # 
+            frame_ = frame.copy().astype(np.float32)    #
             if ds_factor > 1:
-                frame_ = cv2.resize(frame_, img_norm.shape[::-1])   # downsample if necessary 
-    
+                frame_ = cv2.resize(frame_, img_norm.shape[::-1])   # downsample if necessary
+
             frame_ -= img_min                                       # make data non-negative
-    
+
             if mot_corr:                                            # motion correct
                 templ = cnm2.Ab.dot(cnm2.C_on[:cnm2.M, t - 1]).reshape(cnm2.dims, order='F') * img_norm
                 frame_cor, shift = motion_correct_iteration_fast(frame_, templ, max_shift, max_shift)
@@ -441,15 +442,15 @@ for iter in range(epochs):
             else:
                 templ = None
                 frame_cor = frame_
-    
+
             frame_cor = frame_cor / img_norm                        # normalize data-frame
             cnm2.fit_next(t, frame_cor.reshape(-1, order='F'))      # run OnACID on this frame
             timings['fitn'] += time() - t1
             tottime.append(time() - t1)                             # store time
-            
+
             t += 1
             #    break
-            
+
             t_remv = time()
             if t % T_rm == 0 and remove_flag and (t + 1000 < T1):
                 prd, _ = evaluate_components_CNN(cnm2.Ab[:, gnb:], dims, gSig)
@@ -457,14 +458,14 @@ for iter in range(epochs):
                 cnm2.remove_components(ind_rem)
                 print('Removing '+str(len(ind_rem))+' components')
             timings['remv'] += time() - t_remv
-            
+
             if t % 1000 == 0 and plot_contours_flag:
             #if t>=4500:tours_flag:
                 pl.cla()
                 A = cnm2.Ab[:, cnm2.gnb:]
                 crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)  # update the contour plot every 1000 frames
                 pl.pause(1)
-                
+
             if play_reconstr:                                               # generate movie with the results
                 A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
                 C, f = cnm2.C_on[cnm2.gnb:cnm2.M, :], cnm2.C_on[:cnm2.gnb, :]
@@ -480,17 +481,17 @@ for iter in range(epochs):
                 cv2.putText(vid_frame,'Inferred Activity',(np.int(cnm2.dims[0]*resize_fact) + 5,20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
                 cv2.putText(vid_frame,'Identified Components',(5,np.int(cnm2.dims[1]*resize_fact)  + 20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
                 cv2.putText(vid_frame,'Denoised Data',(np.int(cnm2.dims[0]*resize_fact) + 5 ,np.int(cnm2.dims[1]*resize_fact)  + 20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
-                cv2.putText(vid_frame,'Frame = '+str(t),(vid_frame.shape[1]//2-vid_frame.shape[1]//10,vid_frame.shape[0]-20),fontFace = 5, fontScale = 1.2, color = (0,255,255), thickness = 1)                
+                cv2.putText(vid_frame,'Frame = '+str(t),(vid_frame.shape[1]//2-vid_frame.shape[1]//10,vid_frame.shape[0]-20),fontFace = 5, fontScale = 1.2, color = (0,255,255), thickness = 1)
                 if save_movie:
                     out.write(vid_frame)
-                cv2.imshow('frame',vid_frame)                
+                cv2.imshow('frame',vid_frame)
                 if cv2.waitKey(1) & 0xFF == ord('q'):
-                    break                                
-                
+                    break
+
         print('Cumulative processing speed is ' + str((t - initbatch) / np.sum(tottime))[:5] + ' frames per second.')
     cnm2.A_epoch.append(cnm2.Ab.copy())
-    timings['epoc'].append(time()-t_epoc)    
-        
+    timings['epoc'].append(time()-t_epoc)
+
 if save_movie:
     out.release()
 cv2.destroyAllWindows()
@@ -501,7 +502,7 @@ save_results = False
 if save_results:
     np.savez(params_movie[ind_dataset]['folder_name']+'results_analysis_online_sensitive_EP_05.npz',
              Cn=Cn, Ab=cnm2.Ab, Cf=cnm2.C_on, b=cnm2.b, f=cnm2.f,
-             dims=cnm2.dims, tottime=tottime, noisyC=cnm2.noisyC, shifts=shifts, img=Cn, 
+             dims=cnm2.dims, tottime=tottime, noisyC=cnm2.noisyC, shifts=shifts, img=Cn,
              params_movie = params_movie[ind_dataset], global_params = global_params, timings = timings)
 
 #%% extract results from the objects and do some plotting
@@ -512,7 +513,7 @@ if params_movie[ind_dataset]['p'] > 0:
     b_trace = [osi.b for osi in cnm2.OASISinstances]
 
 pl.figure()
-crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)    
+crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
 
 #%%
 
@@ -535,7 +536,7 @@ with np.load(gt_file, encoding = 'latin1') as ld:
     d2_or = int(ld['d2'])
     dims_or = (d1_or,d2_or)
     A_gt = ld['A_gt'][()].toarray()
-    Cn_orig = ld['Cn']    
+    Cn_orig = ld['Cn']
     #locals().update(ld)
     #A_gt = scipy.sparse.coo_matrix(A_gt[()])
     #dims = (d1,d2)
@@ -547,28 +548,28 @@ if ds_factor > 1:
     Cn_orig = cv2.resize(Cn_orig,None,fx=1./ds_factor,fy=1./ds_factor)
 else:
     A_gt2 = A_gt.copy()
-        
+
 A_gt_thr = cm.source_extraction.cnmf.spatial.threshold_components(A_gt2, dims, medw=None, thr_method='max', maxthr=global_params['max_thr'], extract_cc=True,
-                         se=None, ss=None, dview=None) 
+                         se=None, ss=None, dview=None)
 
 A_gt_thr_bin = A_gt_thr > 0
 size_neurons_gt = A_gt_thr_bin.sum(0)
 idx_size_neurons_gt = np.where((size_neurons_gt>min_size_neuro) & (size_neurons_gt < max_size_neuro) )[0]
-print(A_gt_thr.shape)     
+print(A_gt_thr.shape)
 #%% filter for size found neurons
 
 A_thr = cm.source_extraction.cnmf.spatial.threshold_components(A.tocsc()[:,:].toarray(), dims, medw=None, thr_method='max', maxthr=global_params['max_thr'], extract_cc=True,
-                         se=None, ss=None, dview=dview) 
-A_thr_bin = A_thr > 0  
+                         se=None, ss=None, dview=dview)
+A_thr_bin = A_thr > 0
 size_neurons = A_thr_bin.sum(0)
 idx_size_neurons = np.where((size_neurons>min_size_neuro) & (size_neurons<max_size_neuro))[0]
 #A_thr = A_thr[:,idx_size_neuro]
 print(A_thr.shape)
 
-#%% compute results 
+#%% compute results
 
 use_cnn = True  # Use CNN classifier
-if use_cnn:    
+if use_cnn:
     from caiman.components_evaluation import evaluate_components_CNN
     predictions,final_crops = evaluate_components_CNN(A,dims,gSig,model_name = 'use_cases/CaImAnpaper/cnn_model')
     thresh_cnn = .10
@@ -581,11 +582,11 @@ else:
 #%% detect duplicates
 
 #%%
-   
+
 from caiman.base.rois import detect_duplicates_and_subsets
 
 duplicates, indeces_keep, indeces_remove, D, overlap = detect_duplicates_and_subsets(
-            A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1., 
+            A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
             predictions[idx_neurons,1], r_values = None,
             dist_thr=0.1, min_dist = 10, thresh_subset = 0.6)
 
@@ -613,7 +614,7 @@ print('Duplicates CNMF:'+str(len(duplicates)))
 #%%
 
 duplicates_gt, indeces_keep_gt, indeces_remove_gt, D_gt, overlap_gt = detect_duplicates_and_subsets(
-        A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1., 
+        A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
         predictions = None, r_values = None,
         dist_thr=0.1, min_dist = 10,thresh_subset = 0.6)
 
@@ -633,9 +634,9 @@ if len(duplicates_gt) > 0:
         pl.colorbar()
         pl.pause(1)
     idx_components_gt = np.delete(idx_components_gt,indeces_remove_gt)
-print('Duplicates gt:'+str(len(duplicates_gt)))            
+print('Duplicates gt:'+str(len(duplicates_gt)))
 
-#%%    
+#%%
 plot_results = False
 if plot_results:
     pl.figure(figsize=(30,20))
@@ -653,13 +654,13 @@ pl.rc('font', **font)
 print({a:b.astype(np.float16) for a,b in performance_cons_off.items()})
 ##%%
 ## =============================================================================
-## 
+##
 ## =============================================================================
 #with np.load(params_movie[ind_dataset]['folder_name']+'results_analysis_online_standard.npz') as  ld:
 #    print(ld.keys())
 #    locals().update(ld)
-#Ab = Ab[()]    
-##%%    
+#Ab = Ab[()]
+##%%
 #
 #A, b = Ab[:, b.shape[-1]:], Ab[:, :b.shape[-1]].toarray()
 #C, f = Cf[b.shape[-1]:Ab.shape[-1], :], Cf[:b.shape[-1], :]
@@ -675,17 +676,17 @@ print({a:b.astype(np.float16) for a,b in performance_cons_off.items()})
 #with np.load('/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/images/final_map/Yr_d1_463_d2_472_d3_1_order_C_frames_90000_.results_analysis_after_merge_4.npz') as ld:
 #    print(ld.keys())
 #    Cn = ld['Cn']
-#    C_gt = ld['C_gt']    
-#    
-#    
+#    C_gt = ld['C_gt']
+#
+#
 #with np.load('/mnt/ceph/neuro/DataForPublications/caiman-paper/all_results_Jan_2018.npz') as ld:
-#     all_results = ld['all_results']        
+#     all_results = ld['all_results']
 #     all_results = all_results[()]
-#     
-#ld = all_results['Datak53_20160530']     
+#
+#ld = all_results['Datak53_20160530']
 #ag_idx = ld['idx_components_cnmf'][ld['tp_comp']][np.argsort(ld['predictionsCNN'][ld['idx_components_cnmf'][ld['tp_comp']]])[[-6,-5,-4,-3,-2]]]
-#[np.where(ld['tp_comp']==aaa)[0] for aaa in ag_idx]   
-##pl.imshow(Cn)    
+#[np.where(ld['tp_comp']==aaa)[0] for aaa in ag_idx]
+##pl.imshow(Cn)
 #
 ##%%
 #pl.figure()

--- a/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
+++ b/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
@@ -653,6 +653,7 @@ plot_results = False
 if plot_results:
     pl.figure(figsize=(30,20))
 
+
 tp_gt, tp_comp, fn_gt, fp_comp, performance_cons_off =  cm.base.rois.nf_match_neurons_in_binary_masks(A_gt_thr_bin[:,idx_components_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
                                                                               A_thr_bin[:,idx_components_cnmf].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,thresh_cost=.8, min_dist = 10,
                                                                               print_assignment= False,plot_results=plot_results,Cn=Cn_orig, labels = ['GT','Offline'])

--- a/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
+++ b/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
@@ -76,7 +76,7 @@ except:
     save_results = False
 
 
-ind_dataset = ID
+ind_dataset = ID + 6
 
 #%% set some global parameters here
 #'use_cases/edge-cutter/binary_cross_bootstrapped.json'

--- a/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
+++ b/use_cases/CaImAnpaper/online_testing2_bk_slurm.py
@@ -1,0 +1,845 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Complete pipeline for online processing using OnACID.
+@author: Andrea Giovannucci @agiovann and Eftychios Pnevmatikakis @epnev
+Special thanks to Andreas Tolias and his lab at Baylor College of Medicine
+for sharing their data used in this demo.
+"""
+from __future__ import division
+from __future__ import print_function
+import numpy as np
+try:
+    if __IPYTHON__:
+        print('Debugging!')
+        # this is used for debugging purposes only. allows to reload classes when changed
+        get_ipython().magic('load_ext autoreload')
+        get_ipython().magic('autoreload 2')
+except NameError:
+    print('Not IPYTHON')
+    pass
+
+from time import time
+import caiman as cm
+from caiman.source_extraction import cnmf as cnmf
+from caiman.utils.visualization import view_patches_bar
+from caiman.utils.utils import download_demo
+import pylab as pl
+import scipy
+from caiman.motion_correction import motion_correct_iteration_fast
+import cv2
+from caiman.utils.visualization import plot_contours
+import glob
+from caiman.source_extraction.cnmf.online_cnmf import bare_initialization, initialize_movie_online, RingBuffer
+from caiman.components_evaluation import evaluate_components_CNN
+#from caiman.source_extraction.cnmf.online_cnmf import load_object, save_object
+from copy import deepcopy
+import os
+import sys
+from caiman.base.rois import detect_duplicates_and_subsets
+
+
+from builtins import str
+from builtins import range
+
+try:
+    cv2.setNumThreads(1)
+except:
+    print('Open CV is naturally single threaded')
+
+
+#%% Select a dataset
+# 0: neuforinder.03.00.test
+# 1: neurofinder.04.00.test
+# 2: neurofinder.02.00
+# 3: yuste
+# 4: neurofinder.00.00
+# 5: neurofinder,01.01
+# 6: sue_ann_k53_20160530
+# 7: J115
+# 8: J123
+# 9: sue_ann_k37
+#10: Jan-AMG_exp3_001
+try:
+    ID = sys.argv[1]
+    ID = str(np.int(ID)-1)
+    print('Processing ID:'+ str(ID))
+    ID = np.int(ID)
+    plot_on = False
+    save_results = True
+
+except:
+    ID = 0
+    print('ID NOT PASSED')
+    plot_on = False
+    save_results = False
+
+
+ind_dataset = ID
+
+#%% set some global parameters here
+#'use_cases/edge-cutter/binary_cross_bootstrapped.json'
+global_params = {'min_SNR': .75,        # minimum SNR when considering adding a new neuron
+                 'gnb' : 2,             # number of background components
+                 'epochs' : 2,          # number of passes over the data
+                 'rval_thr' : 0.70,     # spatial correlation threshold
+                 'batch_length_dt': 10, # length of mini batch for OnACID in decay time units (length would be batch_length_dt*decay_time*fr)
+                 'max_thr': 0.25,       # parameter for thresholding components when cleaning up shapes
+                 'mot_corr' : False,    # flag for motion correction (set to False to compare directly on the same FOV)
+                 'min_num_trial' : 5,   # minimum number of times to attempt to add a component
+                 'path_to_model' : '/mnt/home/agiovann/SOFTWARE/CaImAn/use_cases/CaImAnpaper/net_models/sniper_sensitive.json', #'use_cases/edge-cutter/binary_cross_bootstrapped.json', #'use_cases/edge-cutter/residual_classifier_2classes.json',
+                 'use_peak_max' : True,
+                 'thresh_CNN_noisy' : .5,
+                 'sniper_mode' : True,
+                 'rm_flag' : False,
+                 'T_rm' : 1100
+                 }
+
+params_movie = [{}]*11        # set up list of dictionaries
+#% neurofinder.03.00.test
+params_movie[0] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.03.00.test/images/final_map/Yr_d1_498_d2_467_d3_1_order_C_frames_2250_.mmap',
+                 'folder_name' : '/mnt/ceph/neuro/labeling/neurofinder.03.00.test/',
+                 'ds_factor' : 2,
+                 'p': 1,  # order of the autoregressive system
+                 'fr': 7,
+                 'decay_time': 0.4,
+                 'gSig': [12,12],  # expected half size of neurons
+                 'gnb': 3,
+                 'T1': 2250
+                 }
+#% neurofinder.04.00.test
+params_movie[1] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.04.00.test/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_3000_.mmap',
+                 'folder_name' : '/mnt/ceph/neuro/labeling/neurofinder.04.00.test/',
+                 'epochs' : 2,
+                 'ds_factor' : 1,
+                 'p': 1,  # order of the autoregressive system
+                 'fr': 8,
+                 'gSig': [7,7],  # expected half size of neurons
+                 'decay_time' : 0.5, # rough length of a transient
+                 'gnb' : 3,
+                 'T1' : 3000,
+                 }
+
+#% neurofinder 02.00
+params_movie[2] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.02.00/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_8000_.mmap',
+                 'folder_name' : '/mnt/ceph/neuro/labeling/neurofinder.02.00/',
+                 'ds_factor' : 1,
+                 'p': 1,  # order of the autoregressive system
+                 'fr' : 30, # imaging rate in Hz
+                 'gSig': [8,8],  # expected half size of neuron
+                 'decay_time': 0.3,
+                 'gnb': 2,
+                 'T1':8000,
+                 }
+
+#% yuste
+params_movie[3] = {'fname': '/mnt/ceph/neuro/labeling/yuste.Single_150u/images/final_map/Yr_d1_200_d2_256_d3_1_order_C_frames_3000_.mmap',
+                 'folder_name': '/mnt/ceph/neuro/labeling/yuste.Single_150u/',
+                 'epochs' : 2,
+                 'ds_factor' : 1,
+                 'p': 1,  # order of the autoregressive system
+                 'fr' : 10,
+                 'decay_time' : .75,
+                 'T1' : 3000,
+                 'gnb': 3,
+                 'gSig': [5,5],  # expected half size of neurons
+                 }
+
+
+#% neurofinder.00.00
+params_movie[4] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.00.00/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_2936_.mmap',
+                 'folder_name':  '/mnt/ceph/neuro/labeling/neurofinder.00.00/',
+                 'ds_factor' : 1,
+                 'p': 1,  # order of the autoregressive system
+                 'decay_time' : 0.4,
+                 'fr' : 16,
+                 'gSig': [8,8],  # expected half size of neurons
+                 'gnb': 2,
+                 'T1' : 2936,
+                  }
+#% neurofinder.01.01
+params_movie[5] = {'fname': '/mnt/ceph/neuro/labeling/neurofinder.01.01/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_1825_.mmap',
+                 'folder_name': '/mnt/ceph/neuro/labeling/neurofinder.01.01/',
+                 'ds_factor' : 1,
+                 'p': 1,  # order of the autoregressive system
+                 'fr' : 8,
+                 'gnb':1,
+                 'T1' : 1825,
+                 'decay_time' : 1.4,
+                 'gSig': [6,6]
+                 }
+#% Sue Ann k53
+params_movie[6] = {'fname': '/mnt/ceph/neuro/labeling/k53_20160530/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_116043_.mmap',
+                 'folder_name':'/mnt/ceph/neuro/labeling/k53_20160530/',
+                 'gtname':'/mnt/ceph/neuro/labeling/k53_20160530/regions/joined_consensus_active_regions.npy',
+                 'epochs' : 1,
+                 'ds_factor' : 2,
+                 'thresh_CNN_noisy' : .75,
+                 'p': 1,  # order of the autoregressive system
+                 'T1': 3000, # number of frames per file
+                 'fr': 30,
+                 'decay_time' : 0.4,
+                 'gSig': [8,8],  # expected half size of neurons
+                 'gnb' : 2,
+                 }
+
+#% J115
+params_movie[7] = {'fname': '/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/images/final_map/Yr_d1_463_d2_472_d3_1_order_C_frames_90000_.mmap',
+                'folder_name':'/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/',
+                'gtname':'/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/regions/joined_consensus_active_regions.npy',
+                'epochs' : 1,
+                'ds_factor' : 2,
+                'thresh_CNN_noisy' : .75,
+                'p': 1,  # order of the autoregressive system
+                'T1' : 1000,
+                'gnb' : 2,
+                'fr' : 30,
+                'decay_time' : 0.4,
+                'gSig' : [8,8]
+                 }
+
+#% J123
+params_movie[8] = {'fname': '/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/images/final_map/Yr_d1_458_d2_477_d3_1_order_C_frames_41000_.mmap',
+                'folder_name':'/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/',
+                'gtname':'/mnt/ceph/neuro/labeling/J123_2015-11-20_L01_0/regions/joined_consensus_active_regions.npy',
+                 'ds_factor' : 2,
+                 'epochs' : 1,
+                 'min_num_trial' : 2,
+                 'p': 1,  # order of the autoregressive system
+                 'fr' : 30,
+                 'T1' : 1000,
+                 'gnb' : 1,
+                 'decay_time' : 0.5,
+                 'gSig': [10,10]
+                 }
+
+#% Sue Ann k37
+params_movie[9] = {'fname' : '/mnt/ceph/neuro/labeling/k37_20160109_AM_150um_65mW_zoom2p2_00001_1-16/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_48000_.mmap',
+                    'folder_name' : '/mnt/ceph/neuro/labeling/k37_20160109_AM_150um_65mW_zoom2p2_00001_1-16/',
+                    'gtname' : '/mnt/ceph/neuro/labeling/k37_20160109_AM_150um_65mW_zoom2p2_00001_1-16/regions/joined_consensus_active_regions.npy',
+                    'ds_factor' : 2,
+                    'p' : 1,
+                    'fr' : 30,
+                    'T1' : 3000,
+                    'gnb' : 2,
+                    'decay_time' : 0.5,
+                    'gSig' : [8,8]
+                    }
+#% Jan-AMG_exp3_001
+params_movie[10] = {'fname' : '/mnt/ceph/neuro/labeling/Jan-AMG_exp3_001/images/final_map/Yr_d1_512_d2_512_d3_1_order_C_frames_115897_.mmap',
+                    'folder_name' : '/mnt/ceph/neuro/labeling/Jan-AMG_exp3_001/',
+                    'gt_name' : '/mnt/ceph/neuro/labeling/Jan-AMG_exp3_001/regions/joined_consensus_active_regions.npy',
+                    'ds_factor' : 2,
+                    'p' : 1,
+                    'thresh_CNN_noisy' : .75,
+                    'fr' : 30,
+                    'T1' : 1002,
+                    'gnb' : 2,
+                    'decay_time' : 0.5,
+                    'gSig' : [7,7]
+                    }
+
+#%% convert mmaps into tifs
+#import os.path
+#
+#for ind_dataset in [10]:
+#    fls = glob.glob(params_movie[ind_dataset]['folder_name']+'images/mmap/*.mmap')
+#    for file_count, ffll in enumerate(fls):
+#        file_name = '/'.join(ffll.split('/')[:-2]+['mmap_tifs']+[ffll.split('/')[-1][:-4]+'tif'])
+#        if not os.path.isfile(file_name):
+#            fl_temp = cm.movie(np.array(cm.load(ffll)))
+#            fl_temp.save(file_name)
+#        print(file_name)
+#    print(ind_dataset)
+#%%  download and list all files to be processed
+
+mot_corr = global_params['mot_corr']
+use_VST = False
+
+if mot_corr:
+    fls = glob.glob('/'.join( params_movie[ind_dataset]['fname'].split('/')[:-3]+['images','tifs','*.tif']))
+    template = cm.load( '/'.join( params_movie[ind_dataset]['fname'].split('/')[:-3]+['projections','median_projection.tif']))
+else:
+    if not use_VST:
+        fls = glob.glob('/'.join( params_movie[ind_dataset]['fname'].split('/')[:-3]+['images','mmap_tifs','*.tif']))
+    else:
+        fls = glob.glob('/'.join( params_movie[ind_dataset]['fname'].split('/')[:-3]+['images','tiff_VST','*.tif']))
+
+fls.sort()
+print(fls)
+
+#%% Set up some parameters
+ds_factor = params_movie[ind_dataset]['ds_factor']                            # spatial downsampling factor (increases speed but may lose some fine structure)
+gSig = tuple(np.ceil(np.array(params_movie[ind_dataset]['gSig'])/ds_factor).astype(np.int))  # expected half size of neurons
+init_files = 1                                                       # number of files used for initialization
+online_files = len(fls) - 1                                          # number of files used for online
+initbatch = 200                                                      # number of frames for initialization (presumably from the first file)
+expected_comps = 4000                                                # maximum number of expected components used for memory pre-allocation (exaggerate here)
+K = 2                                                                # initial number of components
+min_SNR = global_params['min_SNR']
+min_SNR = 3.0956*np.log(len(fls)*params_movie[ind_dataset]['T1']/(307.85*params_movie[ind_dataset]['fr']) + 0.7421)
+N_samples = np.ceil(params_movie[ind_dataset]['fr']*params_movie[ind_dataset]['decay_time'])   # number of timesteps to consider when testing new neuron candidates
+pr_inc = 1 - scipy.stats.norm.cdf(global_params['min_SNR'])           # inclusion probability of noise transient
+thresh_fitness_raw = np.log(pr_inc)*N_samples       # event exceptionality threshold
+thresh_fitness_delta = -80.                         # make this very neutral
+p = params_movie[ind_dataset]['p']                  # order of AR indicator dynamics
+#rval_thr = global_params['rval_thr']                # correlation threshold for new component inclusion
+rval_thr = 0.06*np.log(len(fls)*params_movie[ind_dataset]['T1']/(2177.*params_movie[ind_dataset]['fr'])-0.0462) +0.8862
+
+try:
+    gnb = params_movie[ind_dataset]['gnb']
+except:
+    gnb = global_params['gnb']
+
+try:
+    epochs = params_movie[ind_dataset]['epochs']                     # number of background components
+except:
+    epochs = global_params['epochs']                    # number of passes over the data
+
+try:
+    thresh_CNN_noisy = params_movie[ind_dataset]['thresh_CNN_noisy']
+except:
+    thresh_CNN_noisy = global_params['thresh_CNN_noisy']
+
+try:
+    min_num_trial = params_movie[ind_dataset]['min_num_trial']
+except:
+    min_num_trial = global_params['min_num_trial']
+
+T1 = params_movie[ind_dataset]['T1']*len(fls)*epochs        # total length of all files (if not known use a large number, then truncate at the end)
+#minibatch_length = int(global_params['batch_length_dt']*params_movie[ind_dataset]['fr']*params_movie[ind_dataset]['decay_time'])
+
+
+#%% Initialize timing structure
+
+timings = {'init' : 0,
+           'corr' : 0,
+           'load' : 0,
+           'deep' : 0,
+           'fitn' : 0,
+           'remv' : 0,
+           'epoc' : []
+            }
+
+
+#%%    Initialize movie
+t_init = time()
+if ds_factor > 1:                                   # load only the first initbatch frames and possibly downsample them
+    Y = cm.load(fls[0], subindices = slice(0,initbatch,None)).astype(np.float32).resize(1. / ds_factor, 1. / ds_factor)
+else:
+    Y =  cm.load(fls[0], subindices = slice(0,initbatch,None)).astype(np.float32)
+
+if mot_corr:                                        # perform motion correction on the first initbatch frames
+    max_shift = np.ceil(5./ds_factor).astype('int')     # maximum allowed shift during motion correction
+    mc = Y.motion_correct(max_shift, max_shift, template = template)
+    Y = mc[0].astype(np.float32)
+    borders = np.max(mc[1])
+else:
+    Y = Y.astype(np.float32)
+
+img_min = Y.min()                                   # minimum value of movie. Subtract it to make the data non-negative
+Y -= img_min
+img_norm = np.std(Y, axis=0)
+img_norm += np.median(img_norm)                     # normalizing factor to equalize the FOV
+Y = Y / img_norm[None, :, :]                        # normalize data
+
+_, d1, d2 = Y.shape
+dims = (d1, d2)                                     # dimensions of FOV
+Yr = Y.to_2D().T                                    # convert data into 2D array
+
+t_corr = time()
+Cn_init = Y.local_correlations(swap_dim = False)    # compute correlation image
+timings['corr'] = time() - t_corr
+
+#%% initialize OnACID with bare initialization
+rval_thr = 1
+cnm_init = bare_initialization(Y[:initbatch].transpose(1, 2, 0), init_batch=initbatch, k=K, gnb=gnb,
+                                 gSig=gSig, p=p, minibatch_shape=100, minibatch_suff_stat=5,
+                                 update_num_comps = True, rval_thr=rval_thr,
+                                 thresh_fitness_delta = thresh_fitness_delta,
+                                 thresh_fitness_raw = thresh_fitness_raw, use_dense = False,
+                                 batch_update_suff_stat=True, max_comp_update_shape = 200,
+                                 deconv_flag = True,  thresh_CNN_noisy = thresh_CNN_noisy,
+                                 simultaneously = False, n_refit = 0)
+
+#crd = plot_contours(cnm_init.A.tocsc(), Cn_init, thr=0.9)
+
+#% Plot initialization results
+
+#A, C, b, f, YrA, sn = cnm_init.A, cnm_init.C, cnm_init.b, cnm_init.f, cnm_init.YrA, cnm_init.sn
+#view_patches_bar(Yr, scipy.sparse.coo_matrix(A.tocsc()[:, :]), C[:, :], b, f, dims[0], dims[1], YrA=YrA[:, :], img=Cn_init)
+
+#%% Prepare object for OnACID
+t_deep = time()
+cnm2 = deepcopy(cnm_init)
+timings['deep'] = time() - t_deep
+
+cnm2._prepare_object(np.asarray(Yr[:,:initbatch]), T1, expected_comps, idx_components=None, N_samples_exceptionality = int(N_samples),
+                         max_num_added = min_num_trial,
+                         min_num_trial = min_num_trial,
+                         sniper_mode = global_params['sniper_mode'],
+                         path_to_model = global_params['path_to_model'], use_peak_max = global_params['use_peak_max'])
+
+timings['init'] = time() - t_init
+cnm2.thresh_CNN_noisy = thresh_CNN_noisy
+#%% Run OnACID and optionally plot results in real time
+
+cnm2.max_comp_update_shape = np.inf
+cnm2.update_num_comps = True
+cnm2.A_epoch = []
+cnm2.added = []
+t = cnm2.initbatch
+tottime = []
+Cn = Cn_init.copy()
+
+remove_flag = global_params['rm_flag']
+T_rm = global_params['T_rm']
+rm_thr = 0.1
+plot_contours_flag = False               # flag for plotting contours of detected components at the end of each file
+play_reconstr = False                    # flag for showing video with results online (turn off flags for improving speed)
+save_movie = False                       # flag for saving movie (file could be quite large..)
+movie_name = params_movie[ind_dataset]['folder_name'] + 'output.avi' # name of movie to be saved
+resize_fact = 1.2                        # image resizing factor
+
+if online_files == 0:                    # check whether there are any additional files
+    process_files = fls[:init_files]     # end processing at this file
+    init_batc_iter = [initbatch]         # place where to start
+    end_batch = T1
+else:
+    process_files = fls[:init_files + online_files]     # additional files
+    init_batc_iter = [initbatch] + [0]*online_files     # where to start reading at each file
+
+shifts = []
+if save_movie and play_reconstr:
+    fourcc = cv2.VideoWriter_fourcc('8', 'B', 'P', 'S')
+    out = cv2.VideoWriter(movie_name,fourcc, 30.0, tuple([int(2*x*resize_fact) for x in cnm2.dims]))
+
+
+for iter in range(epochs):
+    t_epoc = time()
+    if iter > 0:
+        process_files = fls[:init_files + online_files]     # if not on first epoch process all files from scratch
+        init_batc_iter = [0]*(online_files+init_files)      #
+
+    for file_count, ffll in enumerate(process_files):  # np.array(fls)[np.array([1,2,3,4,5,-5,-4,-3,-2,-1])]:
+        print('Now processing file ' + ffll)
+        t_load = time()
+        Y_ = cm.load(ffll, subindices=slice(init_batc_iter[file_count],T1,None))
+        timings['load'] += time() - t_load
+
+        if plot_contours_flag:   # update max-correlation (and perform offline motion correction) just for illustration purposes
+            if ds_factor > 1:
+                Y_1 = Y_.resize(1. / ds_factor, 1. / ds_factor, 1)
+            else:
+                Y_1 = Y_.copy()
+                if mot_corr:
+                    templ = (cnm2.Ab.data[:cnm2.Ab.indptr[1]] * cnm2.C_on[0, t - 1]).reshape(cnm2.dims, order='F') * img_norm
+                    newcn = (Y_1 - img_min).motion_correct(max_shift, max_shift, template=templ)[0].local_correlations(swap_dim=False)
+                    Cn = np.maximum(Cn, newcn)
+                else:
+                    Cn = np.maximum(Cn, Y_1.local_correlations(swap_dim=False))
+
+        old_comps = cnm2.N                              # number of existing components
+        for frame_count, frame in enumerate(Y_):        # now process each file
+            if np.isnan(np.sum(frame)):
+                raise Exception('Frame ' + str(frame_count) + ' contains nan')
+            if t % 200 == 0:
+                print('Epoch: ' + str(iter+1) + '. ' + str(t)+' frames have beeen processed in total. '+str(cnm2.N - old_comps)+' new components were added. Total number of components is '+str(cnm2.Ab.shape[-1]-gnb))
+                old_comps = cnm2.N
+
+            t1 = time()                                 # count time only for the processing part
+            frame_ = frame.copy().astype(np.float32)    #
+            if ds_factor > 1:
+                frame_ = cv2.resize(frame_, img_norm.shape[::-1])   # downsample if necessary
+
+            frame_ -= img_min                                       # make data non-negative
+
+            if mot_corr:                                            # motion correct
+                templ = cnm2.Ab.dot(cnm2.C_on[:cnm2.M, t - 1]).reshape(cnm2.dims, order='F') * img_norm
+                frame_cor, shift = motion_correct_iteration_fast(frame_, templ, max_shift, max_shift)
+                shifts.append(shift)
+            else:
+                templ = None
+                frame_cor = frame_
+
+            frame_cor = frame_cor / img_norm                        # normalize data-frame
+            cnm2.fit_next(t, frame_cor.reshape(-1, order='F'))      # run OnACID on this frame
+            timings['fitn'] += time() - t1
+            tottime.append(time() - t1)                             # store time
+
+            t += 1
+            #    break
+
+            t_remv = time()
+            if t % T_rm == 0 and remove_flag and (t + 1000 < T1):
+                prd, _ = evaluate_components_CNN(cnm2.Ab[:, gnb:], dims, gSig)
+                ind_rem = np.where(prd[:, 1] < rm_thr)[0].tolist()
+                cnm2.remove_components(ind_rem)
+                print('Removing '+str(len(ind_rem))+' components')
+            timings['remv'] += time() - t_remv
+
+            if t % 1000 == 0 and plot_contours_flag:
+            #if t>=4500:tours_flag:
+                pl.cla()
+                A = cnm2.Ab[:, cnm2.gnb:]
+                crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)  # update the contour plot every 1000 frames
+                pl.pause(1)
+
+            if play_reconstr:                                               # generate movie with the results
+                A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
+                C, f = cnm2.C_on[cnm2.gnb:cnm2.M, :], cnm2.C_on[:cnm2.gnb, :]
+                comps_frame = A.dot(C[:,t-1]).reshape(cnm2.dims, order = 'F')*img_norm/np.max(img_norm)   # inferred activity due to components (no background)
+                comps_frame = np.reshape(cnm2.sv,dims)/np.max(img_norm)/5
+                bgkrnd_frame = b.dot(f[:,t-1]).reshape(cnm2.dims, order = 'F')*img_norm/np.max(img_norm)  # denoised frame (components + background)
+                all_comps = (np.array(A.sum(-1)).reshape(cnm2.dims, order = 'F'))                         # spatial shapes
+                frame_comp_1 = cv2.resize(np.concatenate([frame_/np.max(img_norm),all_comps*3.],axis = -1),(2*np.int(cnm2.dims[1]*resize_fact),np.int(cnm2.dims[0]*resize_fact) ))
+                frame_comp_2 = cv2.resize(np.concatenate([comps_frame*10.,comps_frame+bgkrnd_frame],axis = -1),(2*np.int(cnm2.dims[1]*resize_fact),np.int(cnm2.dims[0]*resize_fact) ))
+                frame_pn = np.concatenate([frame_comp_1,frame_comp_2],axis=0).T
+                vid_frame = np.repeat(frame_pn[:,:,None],3,axis=-1)
+                vid_frame = np.minimum((vid_frame*255.),255).astype('u1')
+                cv2.putText(vid_frame,'Raw Data',(5,20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
+                cv2.putText(vid_frame,'Inferred Activity',(np.int(cnm2.dims[0]*resize_fact) + 5,20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
+                cv2.putText(vid_frame,'Identified Components',(5,np.int(cnm2.dims[1]*resize_fact)  + 20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
+                cv2.putText(vid_frame,'Denoised Data',(np.int(cnm2.dims[0]*resize_fact) + 5 ,np.int(cnm2.dims[1]*resize_fact)  + 20),fontFace = 5, fontScale = 1.2, color = (0,255,0), thickness = 1)
+                cv2.putText(vid_frame,'Frame = '+str(t),(vid_frame.shape[1]//2-vid_frame.shape[1]//10,vid_frame.shape[0]-20),fontFace = 5, fontScale = 1.2, color = (0,255,255), thickness = 1)
+                if save_movie:
+                    out.write(vid_frame)
+                cv2.imshow('frame',vid_frame)
+                if cv2.waitKey(1) & 0xFF == ord('q'):
+                    break
+
+        print('Cumulative processing speed is ' + str((t - initbatch) / np.sum(tottime))[:5] + ' frames per second.')
+    cnm2.A_epoch.append(cnm2.Ab.copy())
+    timings['epoc'].append(time()-t_epoc)
+
+if save_movie:
+    out.release()
+cv2.destroyAllWindows()
+#%%  save results (optional)
+
+
+if save_results:
+    np.savez(params_movie[ind_dataset]['folder_name']+'results_analysis_online_sensitive_SLURM_01.npz',
+             Cn=Cn, Ab=cnm2.Ab, Cf=cnm2.C_on, b=cnm2.b, f=cnm2.f,
+             dims=cnm2.dims, tottime=tottime, noisyC=cnm2.noisyC, shifts=shifts, img=Cn,
+             params_movie = params_movie[ind_dataset], global_params = global_params, timings = timings)
+
+#%% extract results from the objects and do some plotting
+A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
+C, f = cnm2.C_on[cnm2.gnb:cnm2.M, t-t//epochs:t], cnm2.C_on[:cnm2.gnb, t-t//epochs:t]
+noisyC = cnm2.noisyC[:,t-t//epochs:t]
+if params_movie[ind_dataset]['p'] > 0:
+    b_trace = [osi.b for osi in cnm2.OASISinstances]
+if plot_on:
+    pl.figure()
+    crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
+    view_patches_bar(Yr, scipy.sparse.coo_matrix(A.tocsc()[:, :]), C[:, :], b, f,
+                 dims[0], dims[1], YrA=noisyC[cnm2.gnb:cnm2.M] - C, img=Cn)
+
+#%% load, threshold and filter for size ground truth
+#global_params['max_thr'] = 0.25
+c, dview, n_processes = cm.cluster.setup_cluster(backend='local', n_processes=None, single_thread = True)
+
+gt_file = os.path.join(os.path.split(params_movie[ind_dataset]['fname'])[0], os.path.split(params_movie[ind_dataset]['fname'])[1][:-4] + 'match_masks.npz')
+min_radius = max(gSig[0]/2.,2.)          # minimum acceptable radius
+max_radius = 2.*gSig[0]                  # maximum acceptable radius
+min_size_neuro = min_radius**2*np.pi
+max_size_neuro = max_radius**2*np.pi
+
+with np.load(gt_file, encoding = 'latin1') as ld:
+    print(ld.keys())
+    d1_or = int(ld['d1'])
+    d2_or = int(ld['d2'])
+    dims_or = (d1_or,d2_or)
+    A_gt = ld['A_gt'][()].toarray()
+    Cn_orig = ld['Cn']
+    #locals().update(ld)
+    #A_gt = scipy.sparse.coo_matrix(A_gt[()])
+    #dims = (d1,d2)
+
+if ds_factor > 1:
+    A_gt = cm.movie(np.reshape(A_gt,dims_or+(-1,),order='F')).transpose(2,0,1).resize(1./ds_factor,1./ds_factor)
+    if plot_on:
+        pl.figure(); pl.imshow(A_gt.sum(0))
+    A_gt2 = np.array(np.reshape(A_gt,(A_gt.shape[0],-1),order='F')).T
+    Cn_orig = cv2.resize(Cn_orig,None,fx=1./ds_factor,fy=1./ds_factor)
+else:
+    A_gt2 = A_gt.copy()
+
+A_gt_thr = cm.source_extraction.cnmf.spatial.threshold_components(A_gt2, dims, medw=None, thr_method='max', maxthr=global_params['max_thr'], extract_cc=True,
+                         se=None, ss=None, dview=None)
+
+A_gt_thr_bin = A_gt_thr > 0
+size_neurons_gt = A_gt_thr_bin.sum(0)
+idx_size_neurons_gt = np.where((size_neurons_gt>min_size_neuro) & (size_neurons_gt < max_size_neuro) )[0]
+print(A_gt_thr.shape)
+#%% filter for size found neurons
+
+A_thr = cm.source_extraction.cnmf.spatial.threshold_components(A.tocsc()[:,:].toarray(), dims, medw=None, thr_method='max', maxthr=global_params['max_thr'], extract_cc=True,
+                         se=None, ss=None, dview=dview)
+A_thr_bin = A_thr > 0
+size_neurons = A_thr_bin.sum(0)
+idx_size_neurons = np.where((size_neurons>min_size_neuro) & (size_neurons<max_size_neuro))[0]
+#A_thr = A_thr[:,idx_size_neuro]
+print(A_thr.shape)
+#%%
+duplicates_gt, indeces_keep_gt, indeces_remove_gt, D_gt, overlap_gt = detect_duplicates_and_subsets(
+        A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
+        predictions = None, r_values = None,
+        dist_thr=0.1, min_dist = 10,thresh_subset = 0.6)
+
+idx_components_gt = idx_size_neurons_gt.copy()
+
+if len(duplicates_gt) > 0:
+    if plot_on:
+        pl.figure()
+        pl.subplot(1,3,1)
+        pl.imshow(A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(duplicates_gt).flatten()].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,2)
+        pl.imshow(A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_keep_gt)[:]].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,3)
+        pl.imshow(A_gt_thr_bin[:,idx_size_neurons_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_remove_gt)[:]].sum(0))
+        pl.colorbar()
+        pl.pause(1)
+    idx_components_gt = np.delete(idx_components_gt,indeces_remove_gt)
+print('Duplicates gt:'+str(len(duplicates_gt)))
+
+#%% compute results
+use_cnn = True  # Use CNN classifier
+if use_cnn:
+    thresh_cnn = .10
+else:
+    thresh_cnn = 0
+
+
+from caiman.components_evaluation import evaluate_components_CNN
+predictions,final_crops = evaluate_components_CNN(A,dims,gSig,model_name = '/mnt/home/agiovann/SOFTWARE/CaImAn/use_cases/CaImAnpaper/cnn_model')
+
+idx_components_cnn = np.where(predictions[:,1]>=thresh_cnn)[0]
+idx_neurons = np.intersect1d(idx_components_cnn,idx_size_neurons)
+#%% detect duplicates
+
+duplicates, indeces_keep, indeces_remove, D, overlap = detect_duplicates_and_subsets(
+            A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
+            predictions[idx_neurons,1], r_values = None,
+            dist_thr=0.1, min_dist = 10, thresh_subset = 0.6)
+
+idx_components_cnmf = idx_neurons.copy()
+
+if len(duplicates) > 0:
+    if plot_on:
+
+        pl.figure()
+        pl.subplot(1,3,1)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.unique(duplicates).flatten()].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,2)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_keep)[:]].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,3)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_remove)[:]].sum(0))
+        pl.colorbar()
+        pl.pause(1)
+    idx_components_cnmf = np.delete(idx_components_cnmf,indeces_remove)
+
+print('Duplicates CNMF:'+str(len(duplicates)))
+
+
+#%%
+plot_results = False
+if plot_results:
+    pl.figure(figsize=(30,20))
+
+tp_gt, tp_comp, fn_gt, fp_comp, performance_cons_off =  cm.base.rois.nf_match_neurons_in_binary_masks(A_gt_thr_bin[:,idx_components_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
+                                                                              A_thr_bin[:,idx_components_cnmf].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,thresh_cost=.8, min_dist = 10,
+                                                                              print_assignment= False,plot_results=plot_results,Cn=Cn_orig, labels = ['GT','Offline'])
+
+pl.rcParams['pdf.fonttype'] = 42
+font = {'family' : 'Arial',
+        'weight' : 'regular',
+        'size'   : 20}
+
+pl.rc('font', **font)
+print(gt_file)
+print({a:b.astype(np.float16) for a,b in performance_cons_off.items()})
+
+#%% compute results
+use_cnn = False  # Use CNN classifier
+if use_cnn:
+    thresh_cnn = .10
+else:
+    thresh_cnn = 0
+
+
+from caiman.components_evaluation import evaluate_components_CNN
+predictions,final_crops = evaluate_components_CNN(A,dims,gSig,model_name = '/mnt/home/agiovann/SOFTWARE/CaImAn/use_cases/CaImAnpaper/cnn_model')
+
+idx_components_cnn = np.where(predictions[:,1]>=thresh_cnn)[0]
+idx_neurons = np.intersect1d(idx_components_cnn,idx_size_neurons)
+#%% detect duplicates
+from caiman.base.rois import detect_duplicates_and_subsets
+
+duplicates, indeces_keep, indeces_remove, D, overlap = detect_duplicates_and_subsets(
+            A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
+            predictions[idx_neurons,1], r_values = None,
+            dist_thr=0.1, min_dist = 10, thresh_subset = 0.6)
+
+idx_components_cnmf = idx_neurons.copy()
+
+if len(duplicates) > 0:
+    if plot_on:
+
+        pl.figure()
+        pl.subplot(1,3,1)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.unique(duplicates).flatten()].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,2)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_keep)[:]].sum(0))
+        pl.colorbar()
+        pl.subplot(1,3,3)
+        pl.imshow(A_thr_bin[:,idx_neurons].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])[np.array(indeces_remove)[:]].sum(0))
+        pl.colorbar()
+        pl.pause(1)
+    idx_components_cnmf = np.delete(idx_components_cnmf,indeces_remove)
+
+print('Duplicates CNMF:'+str(len(duplicates)))
+
+
+#%%
+plot_results = False
+if plot_results:
+    pl.figure(figsize=(30,20))
+
+tp_gt, tp_comp, fn_gt, fp_comp, performance_cons_off =  cm.base.rois.nf_match_neurons_in_binary_masks(A_gt_thr_bin[:,idx_components_gt].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,
+                                                                              A_thr_bin[:,idx_components_cnmf].reshape([dims[0],dims[1],-1],order = 'F').transpose([2,0,1])*1.,thresh_cost=.8, min_dist = 10,
+                                                                              print_assignment= False,plot_results=plot_results,Cn=Cn_orig, labels = ['GT','Offline'])
+
+pl.rcParams['pdf.fonttype'] = 42
+font = {'family' : 'Arial',
+        'weight' : 'regular',
+        'size'   : 20}
+
+pl.rc('font', **font)
+print(gt_file)
+print('NO CNN')
+print({a:b.astype(np.float16) for a,b in performance_cons_off.items()})
+#%%
+## =============================================================================
+##
+## =============================================================================
+#with np.load(params_movie[ind_dataset]['folder_name']+'results_analysis_online_standard.npz') as  ld:
+#    print(ld.keys())
+#    locals().update(ld)
+#Ab = Ab[()]
+##%%
+#
+#A, b = Ab[:, b.shape[-1]:], Ab[:, :b.shape[-1]].toarray()
+#C, f = Cf[b.shape[-1]:Ab.shape[-1], :], Cf[:b.shape[-1], :]
+##noisyC = noisyC[:,:]
+##if params_movie[ind_dataset]['p'] > 0:
+##    b_trace = [osi.b for osi in cnm2.OASISinstances]
+#A_us = np.array([cv2.resize(a.toarray().reshape(dims,order='F').T,Cn.shape).reshape(-1) for a in A.tocsc().T]).T
+#A_gt_thr_us = np.array([cv2.resize(a.reshape(dims,order='F').T,Cn.shape).reshape(-1) for a in A_gt_thr.T]).T
+#
+##%%
+#
+#
+#with np.load('/mnt/ceph/neuro/labeling/J115_2015-12-09_L01_ELS/images/final_map/Yr_d1_463_d2_472_d3_1_order_C_frames_90000_.results_analysis_after_merge_4.npz') as ld:
+#    print(ld.keys())
+#    Cn = ld['Cn']
+#    C_gt = ld['C_gt']
+#
+#
+#with np.load('/mnt/ceph/neuro/DataForPublications/caiman-paper/all_results_Jan_2018.npz') as ld:
+#     all_results = ld['all_results']
+#     all_results = all_results[()]
+#
+#ld = all_results['Datak53_20160530']
+#ag_idx = ld['idx_components_cnmf'][ld['tp_comp']][np.argsort(ld['predictionsCNN'][ld['idx_components_cnmf'][ld['tp_comp']]])[[-6,-5,-4,-3,-2]]]
+#[np.where(ld['tp_comp']==aaa)[0] for aaa in ag_idx]
+##pl.imshow(Cn)
+#
+##%%
+#pl.figure()
+#
+#pl.subplot(1,2,1)
+#
+#a1 = plot_contours(A_us[:, idx_components_cnmf[tp_comp]], Cn, thr=0.9, colors='yellow', vmax = 0.75, display_numbers=False,cmap = 'gray')
+#
+#a2 = plot_contours(A_gt_thr_us[:, idx_components_gt[tp_gt]], Cn, thr=0.9, vmax = 0.85, colors='r', display_numbers=False,cmap = 'gray')
+#
+#pl.subplot(1,2,2)
+#
+#a3 = plot_contours(A_us[:, idx_components_cnmf[fp_comp]], Cn, thr=0.9, colors='yellow', vmax = 0.75, display_numbers=False,cmap = 'gray')
+#
+#a4 = plot_contours(A_gt_thr_us[:, idx_components_gt[fn_gt]], Cn, thr=0.9, vmax = 0.85, colors='r', display_numbers=False,cmap = 'gray')
+#
+##%%
+#
+#pl.figure()
+#
+#pl.ylabel('spatial components')
+#
+#idx_comps_high_r = [np.argsort(predictions[:,1][idx_components_cnmf[tp_comp]])[[-6,-5,-4,-3,-2]]]
+#
+#idx_comps_high_r_cnmf = idx_components_cnmf[tp_comp][idx_comps_high_r]
+#
+#idx_comps_high_r_gt = idx_components_gt[tp_gt][idx_comps_high_r]
+#
+#images_nice = (A_us[:,idx_comps_high_r_cnmf].reshape(Cn.shape+(-1,),order = 'F')).transpose(2,0,1)
+#images_nice_gt =  (A_gt_thr_us[:,idx_comps_high_r_gt].reshape(Cn.shape+(-1,),order = 'F')).transpose(2,0,1)
+#
+#cms = np.array([scipy.ndimage.center_of_mass(img) for img in images_nice]).astype(np.int)
+#
+#images_nice_crop = [img[cm_[0]-15:cm_[0]+15,cm_[1]-15:cm_[1]+15] for  cm_,img in zip(cms,images_nice)]
+#
+#images_nice_crop_gt = [img[cm_[0]-15:cm_[0]+15,cm_[1]-15:cm_[1]+15] for  cm_,img in zip(cms,images_nice_gt)]
+#
+#
+#
+#indexes = [1,3,5,7,9,2,4,6,8,10]
+#
+#count = 0
+#
+#for img in images_nice_crop:
+#
+#    pl.subplot(5,2,indexes[count])
+#
+#    pl.imshow(img)
+#
+#    pl.axis('off')
+#
+#    count += 1
+#
+#
+#
+#for img in images_nice_crop_gt:
+#
+#
+#
+#    pl.subplot(5,2,indexes[count])
+#
+#    pl.imshow(img)
+#
+#    pl.axis('off')
+#
+#    count += 1
+#
+##%%
+#
+#pl.figure()
+#
+#traces_gt = C_gt[idx_comps_high_r_gt]# + YrA_gt[idx_comps_high_r_gt]
+#
+#traces_cnmf = C[idx_comps_high_r_cnmf]# + YrA[idx_comps_high_r_cnmf]
+#
+#traces_gt/=np.max(traces_gt,1)[:,None]
+#
+#traces_cnmf /=np.max(traces_cnmf,1)[:,None]
+#
+#pl.plot(scipy.signal.decimate(traces_cnmf,10,1).T-np.arange(5)*1,'y')
+#
+#pl.plot(scipy.signal.decimate(traces_gt,10,1).T-np.arange(5)*1,'k', linewidth = .5 )

--- a/use_cases/CaImAnpaper/slurm_mouse/mouse_slurm.sh
+++ b/use_cases/CaImAnpaper/slurm_mouse/mouse_slurm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Run 21 tasks, with ids 0..20. Have seven on a node 
+# The stdout (-o) and stderr (-e) files will be written to the submission directory with
+# names that follow the given templates (in this case, the names will include the
+# SLURM job identifier).
+#SBATCH -p ccb -N6 --ntasks-per-node=2 --exclusive -o sbExample.%j.out -e sbExample.%j.err
+
+# srun starts a process per task, 21 in this case. In the first example, we didn't explicitly set
+# a number of tasks, so srun assumed there would be one per node.
+srun bash -c 'KERAS_BACKEND=tensorflow CUDA_VISIBLE_DEVICES=-1 MKL_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 /mnt/xfs1/home/agiovann/anaconda3/envs/caiman_dev/bin/python /mnt/xfs1/home/agiovann/SOFTWARE/CaImAn/use_cases/CaImAnpaper/online_testing2_bk_slurm.py $SLURM_PROCID' 

--- a/use_cases/CaImAnpaper/slurm_mouse/mouse_slurm.sh
+++ b/use_cases/CaImAnpaper/slurm_mouse/mouse_slurm.sh
@@ -3,7 +3,7 @@
 # The stdout (-o) and stderr (-e) files will be written to the submission directory with
 # names that follow the given templates (in this case, the names will include the
 # SLURM job identifier).
-#SBATCH -p ccb -N6 --ntasks-per-node=2 --exclusive -o sbExample.%j.out -e sbExample.%j.err
+#SBATCH -p ib -N6 --ntasks-per-node=2 --exclusive -o sbExample.%j.out -e sbExample.%j.err
 
 # srun starts a process per task, 21 in this case. In the first example, we didn't explicitly set
 # a number of tasks, so srun assumed there would be one per node.


### PR DESCRIPTION
This turns on selective testing of the demos on Linux and OSX as part of the CI pipeline.
It adds a subcommand to caimanmanager called "demotest" that runs the demos. I kept this separate from the nose tests because it's considerably slower and noisier.

For now Windows does not participate in this; I had to write a separate runner for Windows (no bash) and I haven't tested it (I will land it with a second diff). The Windows runner is included (same command, different backend).