### PR TITLE
Use numpy's .tofile() method instead of managing files ourselves. Sli…

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -430,9 +430,8 @@ def save_memmap(filenames, base_name='Yr', resize_fact=(1, 1, 1), remove_init=0,
                     big_mov[:, Ttot:Ttot + T] = Yr
                     del big_mov
                 else:
-                    print('SAVING WITH f.write()')
-                    with open(fname_tot, 'wb') as f:
-                        f.write(Yr)
+                    print('SAVING WITH numpy.tofile()')
+                    Yr.tofile(fname_tot)
             else:
                 big_mov = np.memmap(fname_tot, dtype=np.float32, mode='r+',
                                     shape=(np.prod(dims), Ttot + T), order=order)


### PR DESCRIPTION
Use numpy's .tofile() method instead of managing files ourselves.
Slightly faster in most cases, and avoids
https://bugs.python.org/issue24658

(which limits file.write() on OSX to ~2G - was hitting us for larger datasets).
We will still need to watch out for other invocations of file.write() that might hit the limit. 