### PR TITLE
inplace support for caimanmanager's check function

### DIFF
--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import distutils.dir_util
 import filecmp
 import os
 import shutil
@@ -38,14 +39,20 @@ standard_movies = [
 ###############
 # commands
 
-def do_install_to(targdir, inplace=False):
-	if os.path.isdir(targdir):
+def do_install_to(targdir, inplace=False, force=False):
+	if os.path.isdir(targdir) and not force:
 		raise Exception(targdir + " already exists")
 	if not inplace: # In this case we rely on what setup.py put in the share directory for the module
-		shutil.copytree(sourcedir_base, targdir)
+		if not force:
+			shutil.copytree(sourcedir_base, targdir)
+		else:
+			distutils.dir_util.copy_tree(sourcedir_base, targdir)
 	else: # here we recreate the other logical path here. Maintenance concern: Keep these reasonably in sync with what's in setup.py
 		for copydir in extra_dirs:
-			shutil.copytree(copydir, os.path.join(targdir, copydir))
+			if not force:
+				shutil.copytree(copydir, os.path.join(targdir, copydir))
+			else:
+				distutils.dir_util.copy_tree(copydir, os.path.join(targdir, copydir))
 		os.makedirs(os.path.join(targdir, 'example_movies'), exist_ok=True)
 		for stdmovie in standard_movies:
 			shutil.copy(stdmovie, os.path.join(targdir, 'example_movies'))
@@ -148,7 +155,7 @@ def runcmd(cmdlist, ignore_error=False, verbose=True):
 def main():
 	cfg = handle_args()
 	if   cfg.command == 'install':
-		do_install_to(cfg.userdir, cfg.inplace)
+		do_install_to(cfg.userdir, cfg.inplace, cfg.force)
 	elif cfg.command == 'check':
 		do_check_install(cfg.userdir, cfg.inplace)
 	elif cfg.command == 'test':
@@ -165,6 +172,7 @@ def handle_args():
 	parser = argparse.ArgumentParser(description="Tool to manage Caiman data directory")
 	parser.add_argument("command", help="Subcommand to run. install/check/test/demotest")
 	parser.add_argument("--inplace", action='store_true', help="Use only if you did an inplace install of caiman rather than a pure one")
+	parser.add_argument("--force", action='store_true', help="In installs, overwrite parts of an old caiman dir that changed upstream")
 	cfg = parser.parse_args()
 	if cfg.inplace:
 		# In this configuration, the user did a "pip install -e ." and so the share directory was not made.


### PR DESCRIPTION
This builds a codepath for caimanmanager to be able to do a check on a datadir installed from a Caiman install done with `pip install -e .`