### PR TITLE
Fix motion correct imread import

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -63,9 +63,11 @@ except:
 
 try:
     import tifffile
+    from tifffile import imread
 except:
     print('tifffile package not found, using skimage.external.tifffile')
     from skimage.external import tifffile as tifffile
+    from skimage.external.tifffile import imread
 
 import gc
 import os
@@ -87,7 +89,6 @@ try:
 except:
     def profile(a): return a
 
-from skimage.external.tifffile import imread
 #%%
 
 


### PR DESCRIPTION
Originally it attempts to import `tiffffile` and if it fails will load `skimage.external.tifffile` but below that it imports `skimage`'s `imread` function. This was causing issues with some tif files. It is highly preferable to use the `tifffile` package when possible.