### PR TITLE
Set preferred tifffile in motion_correction.py

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -63,9 +63,11 @@ except:
 
 try:
     import tifffile
+    from tifffile import imread
 except:
     print('tifffile package not found, using skimage.external.tifffile')
     from skimage.external import tifffile as tifffile
+    from skimage.external.tifffile import imread
 
 import gc
 import os
@@ -87,7 +89,6 @@ try:
 except:
     def profile(a): return a
 
-from skimage.external.tifffile import imread
 #%%
 
 


### PR DESCRIPTION
Original file will import sklearn's tifffile no matter what. It should be preferred to import the `tiffffile` package when available.