### PR TITLE
Always promote shapes we pass to numpy.memmap to uint64 to prevent an overflow

### DIFF
--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -272,7 +272,7 @@ class timeseries(np.ndarray):
                 1 if len(dims) == 2 else dims[2]) + '_order_' + str(order) + '_frames_' + str(T) + '_.mmap'
             fname_tot = os.path.join(os.path.split(file_name)[0], fname_tot)
             big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                                shape=(np.prod(dims), T), order=order)
+                                shape=(np.uint64(np.prod(dims)), np.uint64(T)), order=order)
 
             big_mov[:] = np.asarray(input_arr, dtype=np.float32)
             big_mov.flush()

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -29,6 +29,13 @@ except ImportError:
     from skimage.external import tifffile as tifffile
 
 
+def prepare_shape(mytuple):
+    """ This promotes the elements inside a shape into np.uint64. It is intended to prevent overflows
+        with some numpy operations that are sensitive to it, e.g. np.memmap """
+    if not isinstance(mytuple, tuple):
+        raise Exception("Internal error: prepare_shape() passed a non-tuple")
+    return tuple(map(lambda x: np.uint64(x), mytuple))
+
 #%%
 def load_memmap(filename, mode='r'):
     """ Load a memory mapped file created by the function save_memmap
@@ -65,8 +72,8 @@ def load_memmap(filename, mode='r'):
         fpart = filename.split('_')[1:-1] # The filename encodes the structure of the map
         d1, d2, d3, T, order = int(fpart[-9]), int(fpart[-7]
                                                    ), int(fpart[-5]), int(fpart[-1]), fpart[-3]
-        Yr = np.memmap(file_to_load, mode=mode, shape=(
-            d1 * d2 * d3, T), dtype=np.float32, order=order)
+        Yr = np.memmap(file_to_load, mode=mode, shape=prepare_shape((
+            d1 * d2 * d3, T)), dtype=np.float32, order=order)
         return (Yr, (d1, d2), T) if d3 == 1 else (Yr, (d1, d2, d3), T)
     else:
         print(filename)
@@ -187,7 +194,7 @@ def save_memmap_join(mmap_fnames, base_name=None, n_chunks=20, dview=None):
     print(fname_tot)
 
     big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                        shape=(d, tot_frames), order='C')
+                        shape=prepare_shape((d, tot_frames)), order='C')
 
     step = np.int(old_div(d, n_chunks))
     pars = []
@@ -270,7 +277,7 @@ def save_portion(pars):
 
     if use_mmap_save:
         big_mov = np.memmap(big_mov, mode='r+', dtype=np.float32,
-                            shape=(d, tot_frames), order='C')
+                            shape=prepare_shape((d, tot_frames)), order='C')
         big_mov[idx_start:idx_end, :] = Yr_tot
         del big_mov
     else:
@@ -432,7 +439,7 @@ def save_memmap(filenames, base_name='Yr', resize_fact=(1, 1, 1), remove_init=0,
                     fname_tot = os.path.join(os.path.split(f)[0], fname_tot)
                 if len(filenames) > 1:
                     big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                                    shape=(np.prod(dims), T), order=order)
+                                    shape=prepare_shape((np.prod(dims), T)), order=order)
                     big_mov[:, Ttot:Ttot + T] = Yr
                     del big_mov
                 else:
@@ -440,7 +447,7 @@ def save_memmap(filenames, base_name='Yr', resize_fact=(1, 1, 1), remove_init=0,
                     Yr.tofile(fname_tot)
             else:
                 big_mov = np.memmap(fname_tot, dtype=np.float32, mode='r+',
-                                    shape=(np.prod(dims), Ttot + T), order=order)
+                                    shape=prepare_shape((np.prod(dims), Ttot + T)), order=order)
 
                 big_mov[:, Ttot:Ttot + T] = Yr
                 del big_mov
@@ -586,7 +593,7 @@ def save_tif_to_mmap_online(movie_iterable, save_base_name='YrOL_', order='C',
                  '_frames_' + str(dims[0]) + '_.mmap')
 
     big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                        shape=(np.prod(dims[1:]), dims[0]), order=order)
+                        shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
 
     for page in movie_iterable:
         if count % 100 == 0:

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -56,6 +56,8 @@ import h5py
 import collections
 import caiman as cm
 
+from .mmapping import prepare_shape
+
 try:
     cv2.setNumThreads(0)
 except:
@@ -416,7 +418,7 @@ def apply_shift_online(movie_iterable, xy_shifts, save_base_name=None, order='F'
             1 if len(dims) == 3 else dims[3]) + '_order_' + str(order) + '_frames_' + str(dims[0]) + '_.mmap'
 
         big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                            shape=(np.prod(dims[1:]), dims[0]), order=order)
+                            shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
 
     for page, shift in zip(movie_iterable, xy_shifts):
         if 'tifffile' in str(type(movie_iterable[0])):
@@ -659,7 +661,7 @@ def motion_correct_online(movie_iterable, add_to_movie, max_shift_w=25, max_shif
             fname_tot = save_base_name + '_d1_' + str(dims[1]) + '_d2_' + str(dims[2]) + '_d3_' + str(
                 1 if len(dims) == 3 else dims[3]) + '_order_' + str(order) + '_frames_' + str(dims[0]) + '_.mmap'
             big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                                shape=(np.prod(dims[1:]), dims[0]), order=order)
+                                shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
 
         else:
             fname_tot = None
@@ -2386,7 +2388,7 @@ def tile_and_correct_wrapper(params):
 
     if out_fname is not None:
         outv = np.memmap(out_fname, mode='r+', dtype=np.float32,
-                         shape=shape_mov, order='F')
+                         shape=prepare_shape(shape_mov), order='F')
         if nonneg_movie:
             bias = np.float32(add_to_movie)
         else:
@@ -2481,7 +2483,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
             1 if len(dims) == 2 else dims[2]) + '_order_' + str(order) + '_frames_' + str(T) + '_.mmap'
         fname_tot = os.path.join(os.path.split(fname)[0], fname_tot)
         np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                  shape=shape_mov, order=order)
+                  shape=prepare_shape(shape_mov), order=order)
     else:
         fname_tot = None
 

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import argparse
 import distutils.dir_util
 import filecmp
@@ -169,6 +170,8 @@ def main():
 			do_nt_run_demotests(cfg.userdir)
 		else:
 			do_run_demotests(cfg.userdir)
+	elif cfg.command == 'help':
+		print("The following are valid subcommands: install, check, test, demotest")
 	else:
 		raise Exception("Unknown command")
 


### PR DESCRIPTION
We only saw this overflow so far on Windows, but it may be possible in some circumstances on other platforms.

I'm going to follow up on this with a PR (or at least a bug report) to the numpy project (which should do this internally)