### PR TITLE
Remove fallback for missing tifffile, cleanup some imports along the way

### DIFF
--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -21,15 +21,17 @@ Class representing a time series.
 author: Andrea Giovannucci
 """
 
-from __future__ import print_function
 #%%
-import os
-import warnings
-import numpy as np
+from __future__ import print_function
 import cv2
 import h5py
+import numpy as np
+import os
 import pylab as plt
 import pickle as cpk
+from scipy.io import savemat
+import tifffile
+import warnings
 
 try:
     cv2.setNumThreads(0)
@@ -40,13 +42,6 @@ try:
     plt.ion()
 except:
     pass
-
-from scipy.io import savemat
-try:
-    import tifffile
-    print('tifffile package not found, using skimage instead for imsave')
-except:
-    from skimage.external import tifffile
 
 #%%
 class timeseries(np.ndarray):

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -17,16 +17,11 @@ from past.utils import old_div
 import numpy as np
 import os
 import sys
+import tifffile
 import ipyparallel as parallel
 from itertools import chain
 
 import caiman as cm
-
-try:
-    import tifffile
-except ImportError:
-    print('tifffile not found, using skimage.externals')
-    from skimage.external import tifffile as tifffile
 
 
 def prepare_shape(mytuple):

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -48,14 +48,18 @@ from builtins import map
 from builtins import str
 from builtins import range
 from past.utils import old_div
-import numpy as np
-import pylab as pl
-import cv2
-import h5py
-
 import collections
-import caiman as cm
+import cv2
+import gc
+import h5py
+import itertools
+import numpy as np
+from numpy.fft import ifftshift
+import os
+import pylab as pl
+import tifffile
 
+import caiman as cm
 from .mmapping import prepare_shape
 
 try:
@@ -63,33 +67,23 @@ try:
 except:
     pass
 
-try:
-    import tifffile
-except:
-    print('tifffile package not found, using skimage.external.tifffile')
-    from skimage.external import tifffile as tifffile
-
-import gc
-import os
 from cv2 import dft as fftn
 from cv2 import idft as ifftn
 opencv = True
+
 try:
     import pycuda.gpuarray as gpuarray
     import pycuda.driver as cudadrv
     import atexit
     HAS_CUDA = True
-
 except ImportError:
     HAS_CUDA = False
-from numpy.fft import ifftshift
-import itertools
+
 try:
     profile
 except:
     def profile(a): return a
 
-from skimage.external.tifffile import imread
 #%%
 
 

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import scipy
 import os
 from scipy.ndimage.filters import gaussian_filter
+from tifffile import TiffFile
 import cv2
 
 try:
@@ -164,23 +165,9 @@ def get_image_description_SI(fname):
 
         image_description: information of the image
 
-    Raise:
-    -----
-        ('tifffile package not found, using skimage.external.tifffile')
-
-
     """
 
     image_descriptions = []
-
-    try:
-        # todo check this unresolved reference
-        from tifffile import TiffFile
-
-    except:
-
-        print('tifffile package not found, using skimage.external.tifffile')
-        from skimage.external.tifffile import TiffFile
 
     tf = TiffFile(fname)
 


### PR DESCRIPTION
We had a lot of code that would try importing tifffile and fall back to skimage if it failed. That should never happen anymore (conda takes care of it); this diff simplifies the code by removing the conditionality.

I also alphabetised some of the imports for files I touched to make them easier to look through.