### PR TITLE
Modify demos so they always run the same cell-based or as programs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,6 +123,7 @@ pipeline {
             CONDA_ENV = "${env.WORKSPACE}\\test\\${env.STAGE_NAME}"
           }
           steps {
+            bat '%ANACONDA%\\scripts\\conda info'
             bat '%ANACONDA%\\scripts\\conda env create -q -f environment.yml -p %CONDA_ENV%'
             bat '%CONDA_ENV%\\scripts\\activate %CONDA_ENV% && pip install . && copy caimanmanager.py %TEMP% && cd %TEMP% && set "CAIMAN_DATA=%TEMP%\\caiman_data" && (if exist caiman_data (rmdir caiman_data /s /q) else (echo "Host is fresh")) && python caimanmanager.py install && python caimanmanager.py test'
           }

--- a/demos/general/demo_OnACID.py
+++ b/demos/general/demo_OnACID.py
@@ -21,121 +21,127 @@ from copy import deepcopy
 from scipy.special import log_ndtr
 from caiman.paths import caiman_datadir
 
+#%%
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
 #%% load data
 
-fname = os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')
-Y = cm.load(fname).astype(np.float32)                   #
-# used as a background image
-Cn = cm.local_correlations(Y.transpose(1, 2, 0))
-
+    fname = os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')
+    Y = cm.load(fname).astype(np.float32)                   #
+    # used as a background image
+    Cn = cm.local_correlations(Y.transpose(1, 2, 0))
 #%% set up some parameters
 
-# frame rate (Hz)
-fr = 10
-# approximate length of transient event in seconds
-decay_time = 0.5
-# expected half size of neurons
-gSig = [6, 6]
-# order of AR indicator dynamics
-p = 1
-# minimum SNR for accepting new components
-min_SNR = 3.5
-# correlation threshold for new component inclusion
-rval_thr = 0.90
-# number of background components
-gnb = 3
+    # frame rate (Hz)
+    fr = 10
+    # approximate length of transient event in seconds
+    decay_time = 0.5
+    # expected half size of neurons
+    gSig = [6, 6]
+    # order of AR indicator dynamics
+    p = 1
+    # minimum SNR for accepting new components
+    min_SNR = 3.5
+    # correlation threshold for new component inclusion
+    rval_thr = 0.90
+    # number of background components
+    gnb = 3
 
-# set up some additional supporting parameters needed for the algorithm (these are default values but change according to dataset characteristics)
+    # set up some additional supporting parameters needed for the algorithm (these are default values but change according to dataset characteristics)
 
-# number of shapes to be updated each time (put this to a finite small value to increase speed)
-max_comp_update_shape = np.inf
-# maximum number of expected components used for memory pre-allocation (exaggerate here)
-expected_comps = 50
-# number of timesteps to consider when testing new neuron candidates
-N_samples = np.ceil(fr * decay_time)
-# exceptionality threshold
-thresh_fitness_raw = log_ndtr(-min_SNR) * N_samples
-# total length of file
-T1 = Y.shape[0]
+    # number of shapes to be updated each time (put this to a finite small value to increase speed)
+    max_comp_update_shape = np.inf
+    # maximum number of expected components used for memory pre-allocation (exaggerate here)
+    expected_comps = 50
+    # number of timesteps to consider when testing new neuron candidates
+    N_samples = np.ceil(fr * decay_time)
+    # exceptionality threshold
+    thresh_fitness_raw = log_ndtr(-min_SNR) * N_samples
+    # total length of file
+    T1 = Y.shape[0]
 
-# set up CNMF initialization parameters
+    # set up CNMF initialization parameters
 
-# merging threshold, max correlation allowed
-merge_thresh = 0.8
-# number of frames for initialization (presumably from the first file)
-initbatch = 400
-# size of patch
-patch_size = 32
-# amount of overlap between patches
-stride = 3
-# max number of components in each patch
-K = 4
+    # merging threshold, max correlation allowed
+    merge_thresh = 0.8
+    # number of frames for initialization (presumably from the first file)
+    initbatch = 400
+    # size of patch
+    patch_size = 32
+    # amount of overlap between patches
+    stride = 3
+    # max number of components in each patch
+    K = 4
 
 #%% obtain initial batch file used for initialization
+    # memory map file (not needed)
+    fname_new = Y[:initbatch].save(os.path.join(caiman_datadir(), 'example_movies', 'demo.mmap'), order='C')
+    Yr, dims, T = cm.load_memmap(fname_new)
+    images = np.reshape(Yr.T, [T] + list(dims), order='F')
+    Cn_init = cm.local_correlations(np.reshape(Yr, dims + (T,), order='F'))
 
-# memory map file (not needed)
-fname_new = Y[:initbatch].save(os.path.join(caiman_datadir(), 'example_movies', 'demo.mmap'), order='C')
-Yr, dims, T = cm.load_memmap(fname_new)
-images = np.reshape(Yr.T, [T] + list(dims), order='F')
-Cn_init = cm.local_correlations(np.reshape(Yr, dims + (T,), order='F'))
+    #%% RUN (offline) CNMF algorithm on the initial batch
+    pl.close('all')
+    cnm_init = cnmf.CNMF(2, k=K, gSig=gSig, merge_thresh=merge_thresh,
+                         p=p, rf=patch_size // 2, stride=stride, skip_refinement=False,
+                         normalize_init=False, options_local_NMF=None,
+                         minibatch_shape=100, minibatch_suff_stat=5,
+                         update_num_comps=True, rval_thr=rval_thr,
+                         thresh_fitness_delta=-50, gnb=gnb,
+                         thresh_fitness_raw=thresh_fitness_raw,
+                         batch_update_suff_stat=True, max_comp_update_shape=max_comp_update_shape)
 
+    cnm_init = cnm_init.fit(images)
 
-#%% RUN (offline) CNMF algorithm on the initial batch
-pl.close('all')
-cnm_init = cnmf.CNMF(2, k=K, gSig=gSig, merge_thresh=merge_thresh,
-                     p=p, rf=patch_size // 2, stride=stride, skip_refinement=False,
-                     normalize_init=False, options_local_NMF=None,
-                     minibatch_shape=100, minibatch_suff_stat=5,
-                     update_num_comps=True, rval_thr=rval_thr,
-                     thresh_fitness_delta=-50, gnb=gnb,
-                     thresh_fitness_raw=thresh_fitness_raw,
-                     batch_update_suff_stat=True, max_comp_update_shape=max_comp_update_shape)
+    print(('Number of components:' + str(cnm_init.A.shape[-1])))
 
-cnm_init = cnm_init.fit(images)
-
-print(('Number of components:' + str(cnm_init.A.shape[-1])))
-
-pl.figure()
-crd = plot_contours(cnm_init.A.tocsc(), Cn_init, thr=0.9)
-
+    pl.figure()
+    crd = plot_contours(cnm_init.A.tocsc(), Cn_init, thr=0.9)
 
 #%% run (online) OnACID algorithm
 
-cnm = deepcopy(cnm_init)
-cnm._prepare_object(np.asarray(Yr), T1, expected_comps)
-t = cnm.initbatch
+    cnm = deepcopy(cnm_init)
+    cnm._prepare_object(np.asarray(Yr), T1, expected_comps)
+    t = cnm.initbatch
 
-Y_ = cm.load(fname)[initbatch:].astype(np.float32)
-for frame_count, frame in enumerate(Y_):
-    cnm.fit_next(t, frame.copy().reshape(-1, order='F'))
-    t += 1
+    Y_ = cm.load(fname)[initbatch:].astype(np.float32)
+    for frame_count, frame in enumerate(Y_):
+        cnm.fit_next(t, frame.copy().reshape(-1, order='F'))
+        t += 1
 
 #%% extract the results
 
-C, f = cnm.C_on[cnm.gnb:cnm.M], cnm.C_on[:cnm.gnb]
-A, b = cnm.Ab[:, cnm.gnb:cnm.M], cnm.Ab[:, :cnm.gnb]
-print(('Number of components:' + str(A.shape[-1])))
+    C, f = cnm.C_on[cnm.gnb:cnm.M], cnm.C_on[:cnm.gnb]
+    A, b = cnm.Ab[:, cnm.gnb:cnm.M], cnm.Ab[:, :cnm.gnb]
+    print(('Number of components:' + str(A.shape[-1])))
 
 #%% pass through the CNN classifier with a low threshold (keeps clearer neuron shapes and excludes processes)
-use_CNN = True
-if use_CNN:
-    # threshold for CNN classifier
-    thresh_cnn = 0.1
-    from caiman.components_evaluation import evaluate_components_CNN
-    predictions, final_crops = evaluate_components_CNN(
-        A, dims, gSig, model_name=os.path.join(caiman_datadir(), 'model', 'cnn_model'))
-    A_exclude, C_exclude = A[:, predictions[:, 1] <
-                             thresh_cnn], C[predictions[:, 1] < thresh_cnn]
-    A, C = A[:, predictions[:, 1] >=
-             thresh_cnn], C[predictions[:, 1] >= thresh_cnn]
-    noisyC = cnm.noisyC[cnm.gnb:cnm.M]
-    YrA = noisyC[predictions[:, 1] >= thresh_cnn] - C
-else:
-    YrA = cnm.noisyC[cnm.gnb:cnm.M] - C
+    use_CNN = True
+    if use_CNN:
+        # threshold for CNN classifier
+        thresh_cnn = 0.1
+        from caiman.components_evaluation import evaluate_components_CNN
+        predictions, final_crops = evaluate_components_CNN(
+            A, dims, gSig, model_name=os.path.join(caiman_datadir(), 'model', 'cnn_model'))
+        A_exclude, C_exclude = A[:, predictions[:, 1] <
+                                 thresh_cnn], C[predictions[:, 1] < thresh_cnn]
+        A, C = A[:, predictions[:, 1] >=
+                 thresh_cnn], C[predictions[:, 1] >= thresh_cnn]
+        noisyC = cnm.noisyC[cnm.gnb:cnm.M]
+        YrA = noisyC[predictions[:, 1] >= thresh_cnn] - C
+    else:
+        YrA = cnm.noisyC[cnm.gnb:cnm.M] - C
 
 #%% plot results
-pl.figure()
-crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
+    pl.figure()
+    crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
 
-view_patches_bar(Yr, A, C, b, f,
-                 dims[0], dims[1], YrA, img=Cn)
+    view_patches_bar(Yr, A, C, b, f,
+                     dims[0], dims[1], YrA, img=Cn)
+
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()

--- a/demos/general/demo_OnACID_mesoscope.py
+++ b/demos/general/demo_OnACID_mesoscope.py
@@ -37,350 +37,359 @@ from caiman.source_extraction.cnmf.online_cnmf import bare_initialization
 from caiman.source_extraction.cnmf.utilities import detrend_df_f_auto
 from caiman.paths import caiman_datadir
 
+#%%
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
 #%%  download and list all files to be processed
 
-# folder inside ./example_movies where files will be saved
-fld_name = 'Mesoscope'
-download_demo('Tolias_mesoscope_1.hdf5', fld_name)
-download_demo('Tolias_mesoscope_2.hdf5', fld_name)
-download_demo('Tolias_mesoscope_3.hdf5', fld_name)
+    # folder inside ./example_movies where files will be saved
+    fld_name = 'Mesoscope'
+    download_demo('Tolias_mesoscope_1.hdf5', fld_name)
+    download_demo('Tolias_mesoscope_2.hdf5', fld_name)
+    download_demo('Tolias_mesoscope_3.hdf5', fld_name)
 
-# folder where files are located
-folder_name = os.path.join(caiman_datadir(), 'example_movies', fld_name)
-extension = 'hdf5'                                  # extension of files
-# read all files to be processed
-fls = glob.glob(folder_name + '/*' + extension)
+    # folder where files are located
+    folder_name = os.path.join(caiman_datadir(), 'example_movies', fld_name)
+    extension = 'hdf5'                                  # extension of files
+    # read all files to be processed
+    fls = glob.glob(folder_name + '/*' + extension)
 
-# your list of files should look something like this
-print(fls)
+    # your list of files should look something like this
+    print(fls)
 
 #%%   Set up some parameters
 
-# frame rate (Hz)
-fr = 15
-# approximate length of transient event in seconds
-decay_time = 0.5
-# expected half size of neurons
-gSig = (3, 3)
-# order of AR indicator dynamics
-p = 1
-# minimum SNR for accepting new components
-min_SNR = 2.5
-# correlation threshold for new component inclusion
-rval_thr = 0.85
-# spatial downsampling factor (increases speed but may lose some fine structure)
-ds_factor = 1
-# number of background components
-gnb = 2
-# recompute gSig if downsampling is involved
-gSig = tuple(np.ceil(np.array(gSig) / ds_factor).astype('int'))
-# flag for online motion correction
-mot_corr = True
-# maximum allowed shift during motion correction
-max_shift = np.ceil(10. / ds_factor).astype('int')
+    # frame rate (Hz)
+    fr = 15
+    # approximate length of transient event in seconds
+    decay_time = 0.5
+    # expected half size of neurons
+    gSig = (3, 3)
+    # order of AR indicator dynamics
+    p = 1
+    # minimum SNR for accepting new components
+    min_SNR = 2.5
+    # correlation threshold for new component inclusion
+    rval_thr = 0.85
+    # spatial downsampling factor (increases speed but may lose some fine structure)
+    ds_factor = 1
+    # number of background components
+    gnb = 2
+    # recompute gSig if downsampling is involved
+    gSig = tuple(np.ceil(np.array(gSig) / ds_factor).astype('int'))
+    # flag for online motion correction
+    mot_corr = True
+    # maximum allowed shift during motion correction
+    max_shift = np.ceil(10. / ds_factor).astype('int')
 
-# set up some additional supporting parameters needed for the algorithm (these are default values but change according to dataset characteristics)
+    # set up some additional supporting parameters needed for the algorithm (these are default values but change according to dataset characteristics)
 
-# number of shapes to be updated each time (put this to a finite small value to increase speed)
-max_comp_update_shape = np.inf
-# number of files used for initialization
-init_files = 1
-# number of files used for online
-online_files = len(fls) - 1
-# number of frames for initialization (presumably from the first file)
-initbatch = 200
-# maximum number of expected components used for memory pre-allocation (exaggerate here)
-expected_comps = 300
-# initial number of components
-K = 2
-# number of timesteps to consider when testing new neuron candidates
-N_samples = np.ceil(fr * decay_time)
-# exceptionality threshold
-thresh_fitness_raw = scipy.special.log_ndtr(-min_SNR) * N_samples
-# number of passes over the data
-epochs = 2
-# upper bound for number of frames in each file (used right below)
-len_file = 1000
-# total length of all files (if not known use a large number, then truncate at the end)
-T1 = len(fls) * len_file * epochs
+    # number of shapes to be updated each time (put this to a finite small value to increase speed)
+    max_comp_update_shape = np.inf
+    # number of files used for initialization
+    init_files = 1
+    # number of files used for online
+    online_files = len(fls) - 1
+    # number of frames for initialization (presumably from the first file)
+    initbatch = 200
+    # maximum number of expected components used for memory pre-allocation (exaggerate here)
+    expected_comps = 300
+    # initial number of components
+    K = 2
+    # number of timesteps to consider when testing new neuron candidates
+    N_samples = np.ceil(fr * decay_time)
+    # exceptionality threshold
+    thresh_fitness_raw = scipy.special.log_ndtr(-min_SNR) * N_samples
+    # number of passes over the data
+    epochs = 2
+    # upper bound for number of frames in each file (used right below)
+    len_file = 1000
+    # total length of all files (if not known use a large number, then truncate at the end)
+    T1 = len(fls) * len_file * epochs
 
 #%%    Initialize movie
 
-# load only the first initbatch frames and possibly downsample them
-if ds_factor > 1:
-    Y = cm.load(fls[0], subindices=slice(0, initbatch, None)).astype(
-        np.float32).resize(1. / ds_factor, 1. / ds_factor)
-else:
-    Y = cm.load(fls[0], subindices=slice(
-        0, initbatch, None)).astype(np.float32)
+    # load only the first initbatch frames and possibly downsample them
+    if ds_factor > 1:
+        Y = cm.load(fls[0], subindices=slice(0, initbatch, None)).astype(
+            np.float32).resize(1. / ds_factor, 1. / ds_factor)
+    else:
+        Y = cm.load(fls[0], subindices=slice(
+            0, initbatch, None)).astype(np.float32)
 
-if mot_corr:                                        # perform motion correction on the first initbatch frames
-    mc = Y.motion_correct(max_shift, max_shift)
-    Y = mc[0].astype(np.float32)
-    borders = np.max(mc[1])
-else:
-    Y = Y.astype(np.float32)
+    if mot_corr:                                        # perform motion correction on the first initbatch frames
+        mc = Y.motion_correct(max_shift, max_shift)
+        Y = mc[0].astype(np.float32)
+        borders = np.max(mc[1])
+    else:
+        Y = Y.astype(np.float32)
 
-# minimum value of movie. Subtract it to make the data non-negative
-img_min = Y.min()
-Y -= img_min
-img_norm = np.std(Y, axis=0)
-# normalizing factor to equalize the FOV
-img_norm += np.median(img_norm)
-Y = Y / img_norm[None, :, :]                        # normalize data
+    # minimum value of movie. Subtract it to make the data non-negative
+    img_min = Y.min()
+    Y -= img_min
+    img_norm = np.std(Y, axis=0)
+    # normalizing factor to equalize the FOV
+    img_norm += np.median(img_norm)
+    Y = Y / img_norm[None, :, :]                        # normalize data
 
-_, d1, d2 = Y.shape
-dims = (d1, d2)                                     # dimensions of FOV
-Yr = Y.to_2D().T                                    # convert data into 2D array
+    _, d1, d2 = Y.shape
+    dims = (d1, d2)                                     # dimensions of FOV
+    Yr = Y.to_2D().T                                    # convert data into 2D array
 
-Cn_init = Y.local_correlations(swap_dim=False)    # compute correlation image
-#pl.imshow(Cn_init)
-#pl.title('Correlation Image on initial batch')
-#pl.colorbar()
+    Cn_init = Y.local_correlations(swap_dim=False)    # compute correlation image
+    #pl.imshow(Cn_init)
+    #pl.title('Correlation Image on initial batch')
+    #pl.colorbar()
 
-bnd_Y = np.percentile(Y,(0.001,100-0.001))  # plotting boundaries for Y
+    bnd_Y = np.percentile(Y,(0.001,100-0.001))  # plotting boundaries for Y
 
 #%% initialize OnACID with bare initialization
 
-cnm_init = bare_initialization(Y[:initbatch].transpose(1, 2, 0), init_batch=initbatch, k=K, gnb=gnb,
-                               gSig=gSig, p=p, minibatch_shape=100, minibatch_suff_stat=5,
-                               update_num_comps=True, rval_thr=rval_thr,
-                               thresh_fitness_raw=thresh_fitness_raw,
-                               batch_update_suff_stat=True, max_comp_update_shape=max_comp_update_shape,
-                               deconv_flag=False, use_dense=False,
-                               simultaneously=False, n_refit=0)
+    cnm_init = bare_initialization(Y[:initbatch].transpose(1, 2, 0), init_batch=initbatch, k=K, gnb=gnb,
+                                   gSig=gSig, p=p, minibatch_shape=100, minibatch_suff_stat=5,
+                                   update_num_comps=True, rval_thr=rval_thr,
+                                   thresh_fitness_raw=thresh_fitness_raw,
+                                   batch_update_suff_stat=True, max_comp_update_shape=max_comp_update_shape,
+                                   deconv_flag=False, use_dense=False,
+                                   simultaneously=False, n_refit=0)
 
 #%% Plot initialization results
 
-crd = plot_contours(cnm_init.A.tocsc(), Cn_init, thr=0.9)
-A, C, b, f, YrA, sn = cnm_init.A, cnm_init.C, cnm_init.b, cnm_init.f, cnm_init.YrA, cnm_init.sn
-view_patches_bar(Yr, scipy.sparse.coo_matrix(
-    A.tocsc()[:, :]), C[:, :], b, f, dims[0], dims[1], YrA=YrA[:, :], img=Cn_init)
+    crd = plot_contours(cnm_init.A.tocsc(), Cn_init, thr=0.9)
+    A, C, b, f, YrA, sn = cnm_init.A, cnm_init.C, cnm_init.b, cnm_init.f, cnm_init.YrA, cnm_init.sn
+    view_patches_bar(Yr, scipy.sparse.coo_matrix(
+        A.tocsc()[:, :]), C[:, :], b, f, dims[0], dims[1], YrA=YrA[:, :], img=Cn_init)
 
-bnd_AC = np.percentile(A.dot(C),(0.001,100-0.005))
-bnd_BG = np.percentile(b.dot(f),(0.001,100-0.001))
+    bnd_AC = np.percentile(A.dot(C),(0.001,100-0.005))
+    bnd_BG = np.percentile(b.dot(f),(0.001,100-0.001))
 
 #%% create a function for plotting results in real time if needed
 
-def create_frame(cnm2, img_norm, captions):
-    A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
-    C, f = cnm2.C_on[cnm2.gnb:cnm2.M, :], cnm2.C_on[:cnm2.gnb, :]
-    # inferred activity due to components (no background)
-    frame_plot = (frame_cor.copy() - bnd_Y[0])/np.diff(bnd_Y)
-    comps_frame = A.dot(C[:, t - 1]).reshape(cnm2.dims, order='F')        
-    bgkrnd_frame = b.dot(f[:, t - 1]).reshape(cnm2.dims, order='F')  # denoised frame (components + background)
-    denoised_frame = comps_frame + bgkrnd_frame
-    denoised_frame = (denoised_frame.copy() - bnd_Y[0])/np.diff(bnd_Y)
-    comps_frame = (comps_frame.copy() - bnd_AC[0])/np.diff(bnd_AC)
-    
-    if show_residuals:
-        #all_comps = np.reshape(cnm2.Yres_buf.mean(0), cnm2.dims, order='F')
-        all_comps = np.reshape(cnm2.mean_buff, cnm2.dims, order='F')
-        all_comps = np.minimum(np.maximum(all_comps, 0)*2 + 0.25, 255)
-    else:
-        all_comps = np.array(A.sum(-1)).reshape(cnm2.dims, order='F')
-                                              # spatial shapes
-    frame_comp_1 = cv2.resize(np.concatenate([frame_plot, all_comps * 1.], axis=-1),
-                              (2 * np.int(cnm2.dims[1] * resize_fact), np.int(cnm2.dims[0] * resize_fact)))
-    frame_comp_2 = cv2.resize(np.concatenate([comps_frame, denoised_frame], axis=-1), 
-                              (2 * np.int(cnm2.dims[1] * resize_fact), np.int(cnm2.dims[0] * resize_fact)))
-    frame_pn = np.concatenate([frame_comp_1, frame_comp_2], axis=0).T
-    vid_frame = np.repeat(frame_pn[:, :, None], 3, axis=-1)
-    vid_frame = np.minimum((vid_frame * 255.), 255).astype('u1')
-    
-    if show_residuals and cnm2.ind_new:
-        add_v = np.int(cnm2.dims[1]*resize_fact)
-        for ind_new in cnm2.ind_new:
-            cv2.rectangle(vid_frame,(int(ind_new[0][1]*resize_fact),int(ind_new[1][1]*resize_fact)+add_v),
-                                         (int(ind_new[0][0]*resize_fact),int(ind_new[1][0]*resize_fact)+add_v),(255,0,255),2)
-    
-    cv2.putText(vid_frame, captions[0], (5, 20), fontFace=5, fontScale=0.8, color=(
-        0, 255, 0), thickness=1)
-    cv2.putText(vid_frame, captions[1], (np.int(
-        cnm2.dims[0] * resize_fact) + 5, 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
-    cv2.putText(vid_frame, captions[2], (5, np.int(
-        cnm2.dims[1] * resize_fact) + 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
-    cv2.putText(vid_frame, captions[3], (np.int(cnm2.dims[0] * resize_fact) + 5, np.int(
-        cnm2.dims[1] * resize_fact) + 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
-    cv2.putText(vid_frame, 'Frame = ' + str(t), (vid_frame.shape[1] // 2 - vid_frame.shape[1] //
-                                                 10, vid_frame.shape[0] - 20), fontFace=5, fontScale=0.8, color=(0, 255, 255), thickness=1)
-    return vid_frame
+    def create_frame(cnm2, img_norm, captions):
+        A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
+        C, f = cnm2.C_on[cnm2.gnb:cnm2.M, :], cnm2.C_on[:cnm2.gnb, :]
+        # inferred activity due to components (no background)
+        frame_plot = (frame_cor.copy() - bnd_Y[0])/np.diff(bnd_Y)
+        comps_frame = A.dot(C[:, t - 1]).reshape(cnm2.dims, order='F')        
+        bgkrnd_frame = b.dot(f[:, t - 1]).reshape(cnm2.dims, order='F')  # denoised frame (components + background)
+        denoised_frame = comps_frame + bgkrnd_frame
+        denoised_frame = (denoised_frame.copy() - bnd_Y[0])/np.diff(bnd_Y)
+        comps_frame = (comps_frame.copy() - bnd_AC[0])/np.diff(bnd_AC)
 
+        if show_residuals:
+            #all_comps = np.reshape(cnm2.Yres_buf.mean(0), cnm2.dims, order='F')
+            all_comps = np.reshape(cnm2.mean_buff, cnm2.dims, order='F')
+            all_comps = np.minimum(np.maximum(all_comps, 0)*2 + 0.25, 255)
+        else:
+            all_comps = np.array(A.sum(-1)).reshape(cnm2.dims, order='F')
+                                                  # spatial shapes
+        frame_comp_1 = cv2.resize(np.concatenate([frame_plot, all_comps * 1.], axis=-1),
+                                  (2 * np.int(cnm2.dims[1] * resize_fact), np.int(cnm2.dims[0] * resize_fact)))
+        frame_comp_2 = cv2.resize(np.concatenate([comps_frame, denoised_frame], axis=-1), 
+                                  (2 * np.int(cnm2.dims[1] * resize_fact), np.int(cnm2.dims[0] * resize_fact)))
+        frame_pn = np.concatenate([frame_comp_1, frame_comp_2], axis=0).T
+        vid_frame = np.repeat(frame_pn[:, :, None], 3, axis=-1)
+        vid_frame = np.minimum((vid_frame * 255.), 255).astype('u1')
+
+        if show_residuals and cnm2.ind_new:
+            add_v = np.int(cnm2.dims[1]*resize_fact)
+            for ind_new in cnm2.ind_new:
+                cv2.rectangle(vid_frame,(int(ind_new[0][1]*resize_fact),int(ind_new[1][1]*resize_fact)+add_v),
+                                             (int(ind_new[0][0]*resize_fact),int(ind_new[1][0]*resize_fact)+add_v),(255,0,255),2)
+
+        cv2.putText(vid_frame, captions[0], (5, 20), fontFace=5, fontScale=0.8, color=(
+            0, 255, 0), thickness=1)
+        cv2.putText(vid_frame, captions[1], (np.int(
+            cnm2.dims[0] * resize_fact) + 5, 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
+        cv2.putText(vid_frame, captions[2], (5, np.int(
+            cnm2.dims[1] * resize_fact) + 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
+        cv2.putText(vid_frame, captions[3], (np.int(cnm2.dims[0] * resize_fact) + 5, np.int(
+            cnm2.dims[1] * resize_fact) + 20), fontFace=5, fontScale=0.8, color=(0, 255, 0), thickness=1)
+        cv2.putText(vid_frame, 'Frame = ' + str(t), (vid_frame.shape[1] // 2 - vid_frame.shape[1] //
+                                                     10, vid_frame.shape[0] - 20), fontFace=5, fontScale=0.8, color=(0, 255, 255), thickness=1)
+        return vid_frame
 
 #%% Prepare object for OnACID
-cnm2 = deepcopy(cnm_init)
+    cnm2 = deepcopy(cnm_init)
 
-save_init = False     # flag for saving initialization object. Useful if you want to check OnACID with different parameters but same initialization
-if save_init:
-    cnm_init.dview = None
-    save_object(cnm_init, fls[0][:-4] + '_DS_' + str(ds_factor) + '.pkl')
-    cnm_init = load_object(fls[0][:-4] + '_DS_' + str(ds_factor) + '.pkl')
+    save_init = False     # flag for saving initialization object. Useful if you want to check OnACID with different parameters but same initialization
+    if save_init:
+        cnm_init.dview = None
+        save_object(cnm_init, fls[0][:-4] + '_DS_' + str(ds_factor) + '.pkl')
+        cnm_init = load_object(fls[0][:-4] + '_DS_' + str(ds_factor) + '.pkl')
 
-path_to_cnn_residual = os.path.join(caiman_datadir(), 'model', 'cnn_model_online.h5')
+    path_to_cnn_residual = os.path.join(caiman_datadir(), 'model', 'cnn_model_online.h5')
 
-cnm2._prepare_object(np.asarray(Yr), T1, expected_comps, idx_components=None,
-                         min_num_trial=3, max_num_added = 3, N_samples_exceptionality=int(N_samples),
-                         path_to_model = path_to_cnn_residual,
-                         sniper_mode = False, use_peak_max=False, q=0.5)
-cnm2.thresh_CNN_noisy = 0.5
+    cnm2._prepare_object(np.asarray(Yr), T1, expected_comps, idx_components=None,
+                             min_num_trial=3, max_num_added = 3, N_samples_exceptionality=int(N_samples),
+                             path_to_model = path_to_cnn_residual,
+                             sniper_mode = False, use_peak_max=False, q=0.5)
+    cnm2.thresh_CNN_noisy = 0.5
 
 #%% Run OnACID and optionally plot results in real time
-epochs = 1
-cnm2.Ab_epoch = []                       # save the shapes at the end of each epoch
-t = cnm2.initbatch                       # current timestep
-tottime = []
-Cn = Cn_init.copy()
+    epochs = 1
+    cnm2.Ab_epoch = []                       # save the shapes at the end of each epoch
+    t = cnm2.initbatch                       # current timestep
+    tottime = []
+    Cn = Cn_init.copy()
 
-# flag for removing components with bad shapes
-remove_flag = False
-T_rm = 650    # remove bad components every T_rm frames
-rm_thr = 0.1  # CNN classifier removal threshold
-# flag for plotting contours of detected components at the end of each file
-plot_contours_flag = False
-# flag for showing results video online (turn off flags for improving speed)
-play_reconstr = True
-# flag for saving movie (file could be quite large..)
-save_movie = False
-movie_name = os.path.join(folder_name, 'sniper_meso_0.995_new.avi')  # name of movie to be saved
-resize_fact = 1.2                        # image resizing factor
+    # flag for removing components with bad shapes
+    remove_flag = False
+    T_rm = 650    # remove bad components every T_rm frames
+    rm_thr = 0.1  # CNN classifier removal threshold
+    # flag for plotting contours of detected components at the end of each file
+    plot_contours_flag = False
+    # flag for showing results video online (turn off flags for improving speed)
+    play_reconstr = True
+    # flag for saving movie (file could be quite large..)
+    save_movie = False
+    movie_name = os.path.join(folder_name, 'sniper_meso_0.995_new.avi')  # name of movie to be saved
+    resize_fact = 1.2                        # image resizing factor
 
-if online_files == 0:                    # check whether there are any additional files
-    process_files = fls[:init_files]     # end processing at this file
-    init_batc_iter = [initbatch]         # place where to start
-    end_batch = T1
-else:
-    process_files = fls[:init_files + online_files]     # additional files
-    # where to start reading at each file
-    init_batc_iter = [initbatch] + [0] * online_files
+    if online_files == 0:                    # check whether there are any additional files
+        process_files = fls[:init_files]     # end processing at this file
+        init_batc_iter = [initbatch]         # place where to start
+        end_batch = T1
+    else:
+        process_files = fls[:init_files + online_files]     # additional files
+        # where to start reading at each file
+        init_batc_iter = [initbatch] + [0] * online_files
 
 
-shifts = []
-show_residuals = True
-if show_residuals:
-    caption = 'Mean Residual Buffer'
-else:
-    caption = 'Identified Components'
-captions = ['Raw Data', 'Inferred Activity', caption, 'Denoised Data']
-if save_movie and play_reconstr:
-    fourcc = cv2.VideoWriter_fourcc('8', 'B', 'P', 'S')
-#    fourcc = cv2.VideoWriter_fourcc(*'XVID')
-    out = cv2.VideoWriter(movie_name, fourcc, 30.0, tuple(
-        [int(2 * x * resize_fact) for x in cnm2.dims]))
+    shifts = []
+    show_residuals = True
+    if show_residuals:
+        caption = 'Mean Residual Buffer'
+    else:
+        caption = 'Identified Components'
+    captions = ['Raw Data', 'Inferred Activity', caption, 'Denoised Data']
+    if save_movie and play_reconstr:
+        fourcc = cv2.VideoWriter_fourcc('8', 'B', 'P', 'S')
+    #    fourcc = cv2.VideoWriter_fourcc(*'XVID')
+        out = cv2.VideoWriter(movie_name, fourcc, 30.0, tuple(
+            [int(2 * x * resize_fact) for x in cnm2.dims]))
 
-for iter in range(epochs):
-    if iter > 0:
-        # if not on first epoch process all files from scratch
-        process_files = fls[:init_files + online_files]
-        init_batc_iter = [0] * (online_files + init_files)
+    for iter in range(epochs):
+        if iter > 0:
+            # if not on first epoch process all files from scratch
+            process_files = fls[:init_files + online_files]
+            init_batc_iter = [0] * (online_files + init_files)
 
-    # np.array(fls)[np.array([1,2,3,4,5,-5,-4,-3,-2,-1])]:
-    for file_count, ffll in enumerate(process_files):
-        print('Now processing file ' + ffll)
-        Y_ = cm.load(ffll, subindices=slice(
-            init_batc_iter[file_count], T1, None))
+        # np.array(fls)[np.array([1,2,3,4,5,-5,-4,-3,-2,-1])]:
+        for file_count, ffll in enumerate(process_files):
+            print('Now processing file ' + ffll)
+            Y_ = cm.load(ffll, subindices=slice(
+                init_batc_iter[file_count], T1, None))
 
-        # update max-correlation (and perform offline motion correction) just for illustration purposes
-        if plot_contours_flag:
-            if ds_factor > 1:
-                Y_1 = Y_.resize(1. / ds_factor, 1. / ds_factor, 1)
-            else:
-                Y_1 = Y_.copy()
-            if mot_corr:
-                templ = (cnm2.Ab.data[:cnm2.Ab.indptr[1]] * cnm2.C_on[0, t - 1]).reshape(cnm2.dims, order='F') * img_norm
-                newcn = (Y_1 - img_min).motion_correct(max_shift, max_shift,
-                                                       template=templ)[0].local_correlations(swap_dim=False)
-                Cn = np.maximum(Cn, newcn)
-            else:
-                Cn = np.maximum(Cn, Y_1.local_correlations(swap_dim=False))
+            # update max-correlation (and perform offline motion correction) just for illustration purposes
+            if plot_contours_flag:
+                if ds_factor > 1:
+                    Y_1 = Y_.resize(1. / ds_factor, 1. / ds_factor, 1)
+                else:
+                    Y_1 = Y_.copy()
+                if mot_corr:
+                    templ = (cnm2.Ab.data[:cnm2.Ab.indptr[1]] * cnm2.C_on[0, t - 1]).reshape(cnm2.dims, order='F') * img_norm
+                    newcn = (Y_1 - img_min).motion_correct(max_shift, max_shift,
+                                                           template=templ)[0].local_correlations(swap_dim=False)
+                    Cn = np.maximum(Cn, newcn)
+                else:
+                    Cn = np.maximum(Cn, Y_1.local_correlations(swap_dim=False))
 
-        old_comps = cnm2.N                              # number of existing components
-        for frame_count, frame in enumerate(Y_):        # now process each file
-            if np.isnan(np.sum(frame)):
-                raise Exception('Frame ' + str(frame_count) + ' contains nan')
-            if t % 100 == 0:
-                print('Epoch: ' + str(iter + 1) + '. ' + str(t) + ' frames have beeen processed in total. ' + str(cnm2.N -
-                                                                                                                  old_comps) + ' new components were added. Total number of components is ' + str(cnm2.Ab.shape[-1] - gnb))
-                old_comps = cnm2.N
+            old_comps = cnm2.N                              # number of existing components
+            for frame_count, frame in enumerate(Y_):        # now process each file
+                if np.isnan(np.sum(frame)):
+                    raise Exception('Frame ' + str(frame_count) + ' contains nan')
+                if t % 100 == 0:
+                    print('Epoch: ' + str(iter + 1) + '. ' + str(t) + ' frames have beeen processed in total. ' + str(cnm2.N -
+                                                                                                                      old_comps) + ' new components were added. Total number of components is ' + str(cnm2.Ab.shape[-1] - gnb))
+                    old_comps = cnm2.N
 
-            t1 = time()                                 # count time only for the processing part
-            frame_ = frame.copy().astype(np.float32)    #
-            if ds_factor > 1:
-                frame_ = cv2.resize(
-                    frame_, img_norm.shape[::-1])   # downsampling
+                t1 = time()                                 # count time only for the processing part
+                frame_ = frame.copy().astype(np.float32)    #
+                if ds_factor > 1:
+                    frame_ = cv2.resize(
+                        frame_, img_norm.shape[::-1])   # downsampling
 
-            frame_ -= img_min                                       # make data non-negative
+                frame_ -= img_min                                       # make data non-negative
 
-            if mot_corr:                                            # motion correct
-                templ = cnm2.Ab.dot(
-                    cnm2.C_on[:cnm2.M, t - 1]).reshape(cnm2.dims, order='F') * img_norm
-                frame_cor, shift = motion_correct_iteration_fast(
-                    frame_, templ, max_shift, max_shift)
-                shifts.append(shift)
-            else:
-                templ = None
-                frame_cor = frame_
+                if mot_corr:                                            # motion correct
+                    templ = cnm2.Ab.dot(
+                        cnm2.C_on[:cnm2.M, t - 1]).reshape(cnm2.dims, order='F') * img_norm
+                    frame_cor, shift = motion_correct_iteration_fast(
+                        frame_, templ, max_shift, max_shift)
+                    shifts.append(shift)
+                else:
+                    templ = None
+                    frame_cor = frame_
 
-            frame_cor = frame_cor / img_norm                        # normalize data-frame
-            cnm2.fit_next(t, frame_cor.reshape(-1, order='F'))      # run OnACID on this frame
-            # store time
-            tottime.append(time() - t1)
-            
-            t += 1
-            
-            if t % T_rm == 0 and remove_flag:
-                prd, _ = evaluate_components_CNN(cnm2.Ab[:, gnb:], dims, gSig)
-                ind_rem = np.where(prd[:, 1] < rm_thr)[0].tolist()
-                cnm2.remove_components(ind_rem)
-                print('Removing '+str(len(ind_rem))+' components')
+                frame_cor = frame_cor / img_norm                        # normalize data-frame
+                cnm2.fit_next(t, frame_cor.reshape(-1, order='F'))      # run OnACID on this frame
+                # store time
+                tottime.append(time() - t1)
+                
+                t += 1
+                
+                if t % T_rm == 0 and remove_flag:
+                    prd, _ = evaluate_components_CNN(cnm2.Ab[:, gnb:], dims, gSig)
+                    ind_rem = np.where(prd[:, 1] < rm_thr)[0].tolist()
+                    cnm2.remove_components(ind_rem)
+                    print('Removing '+str(len(ind_rem))+' components')
 
-            if t % 1000 == 0 and plot_contours_flag:
-                pl.cla()
-                A = cnm2.Ab[:, cnm2.gnb:]
-                # update the contour plot every 1000 frames
-                crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
-                pl.pause(1)
+                if t % 1000 == 0 and plot_contours_flag:
+                    pl.cla()
+                    A = cnm2.Ab[:, cnm2.gnb:]
+                    # update the contour plot every 1000 frames
+                    crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
+                    pl.pause(1)
 
-            if play_reconstr:                                               # generate movie with the results
-                vid_frame = create_frame(cnm2, img_norm, captions)
-                if save_movie:
-                    out.write(vid_frame)
+                if play_reconstr:                                               # generate movie with the results
+                    vid_frame = create_frame(cnm2, img_norm, captions)
+                    if save_movie:
+                        out.write(vid_frame)
+                        if t-initbatch < 100:
+                            #for rp in np.int32(np.ceil(np.exp(-np.arange(1,100)/30)*20)):
+                            for rp in range(len(cnm2.ind_new)*2):
+                                out.write(vid_frame)
+                    cv2.imshow('frame', vid_frame)
                     if t-initbatch < 100:
-                        #for rp in np.int32(np.ceil(np.exp(-np.arange(1,100)/30)*20)):
-                        for rp in range(len(cnm2.ind_new)*2):
-                            out.write(vid_frame)
-                cv2.imshow('frame', vid_frame)
-                if t-initbatch < 100:
-                        for rp in range(len(cnm2.ind_new)*2):
-                            cv2.imshow('frame', vid_frame)
-                if cv2.waitKey(1) & 0xFF == ord('q'):
-                    break
+                            for rp in range(len(cnm2.ind_new)*2):
+                                cv2.imshow('frame', vid_frame)
+                    if cv2.waitKey(1) & 0xFF == ord('q'):
+                        break
 
-        print('Cumulative processing speed is ' + str((t - initbatch) /
-                                                      np.sum(tottime))[:5] + ' frames per second.')
-    # save the shapes at the end of each epoch
-    cnm2.Ab_epoch.append(cnm2.Ab.copy())
+            print('Cumulative processing speed is ' + str((t - initbatch) /
+                                                          np.sum(tottime))[:5] + ' frames per second.')
+        # save the shapes at the end of each epoch
+        cnm2.Ab_epoch.append(cnm2.Ab.copy())
 
-if save_movie:
-    out.release()
-cv2.destroyAllWindows()
+    if save_movie:
+        out.release()
+    cv2.destroyAllWindows()
 
 #%%  save results (optional)
-save_results = False
+    save_results = False
 
-if save_results:
-    np.savez('results_analysis_online_MOT_CORR.npz',
-             Cn=Cn, Ab=cnm2.Ab, Cf=cnm2.C_on, b=cnm2.b, f=cnm2.f,
-             dims=cnm2.dims, tottime=tottime, noisyC=cnm2.noisyC, shifts=shifts)
+    if save_results:
+        np.savez('results_analysis_online_MOT_CORR.npz',
+                 Cn=Cn, Ab=cnm2.Ab, Cf=cnm2.C_on, b=cnm2.b, f=cnm2.f,
+                 dims=cnm2.dims, tottime=tottime, noisyC=cnm2.noisyC, shifts=shifts)
 
-#%% extract results from the objects and do some plotting
-A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
-C, f = cnm2.C_on[cnm2.gnb:cnm2.M, t - t //
-                 epochs:t], cnm2.C_on[:cnm2.gnb, t - t // epochs:t]
-noisyC = cnm2.noisyC[:, t - t // epochs:t]
-b_trace = [osi.b for osi in cnm2.OASISinstances] if hasattr(
-    cnm2, 'OASISinstances') else [0] * C.shape[0]
+    #%% extract results from the objects and do some plotting
+    A, b = cnm2.Ab[:, cnm2.gnb:], cnm2.Ab[:, :cnm2.gnb].toarray()
+    C, f = cnm2.C_on[cnm2.gnb:cnm2.M, t - t //
+                     epochs:t], cnm2.C_on[:cnm2.gnb, t - t // epochs:t]
+    noisyC = cnm2.noisyC[:, t - t // epochs:t]
+    b_trace = [osi.b for osi in cnm2.OASISinstances] if hasattr(
+        cnm2, 'OASISinstances') else [0] * C.shape[0]
 
-pl.figure()
-crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
-view_patches_bar(Yr, scipy.sparse.coo_matrix(A.tocsc()[:, :]), C[:, :], b, f,
-                 dims[0], dims[1], YrA=noisyC[cnm2.gnb:cnm2.M] - C, img=Cn)
+    pl.figure()
+    crd = cm.utils.visualization.plot_contours(A, Cn, thr=0.9)
+    view_patches_bar(Yr, scipy.sparse.coo_matrix(A.tocsc()[:, :]), C[:, :], b, f,
+                     dims[0], dims[1], YrA=noisyC[cnm2.gnb:cnm2.M] - C, img=Cn)
+
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()

--- a/demos/general/demo_behavior.py
+++ b/demos/general/demo_behavior.py
@@ -35,83 +35,89 @@ try:
 except NameError:
     pass
 
-import caiman as cm
-import numpy as np
-import time
-import pylab as pl
-import psutil
+import copy
 from ipyparallel import Client
+import numpy as np
+import psutil
+import pylab as pl
+import time
 from skimage.external.tifffile import TiffFile
 import scipy
-import copy
+from scipy.sparse import coo_matrix
 
-pl.ion()
-#%
+import caiman as cm
 from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.components_evaluation import evaluate_components
 from caiman.utils.visualization import plot_contours, view_patches_bar
 from caiman.base.rois import extract_binary_masks_blob
 from caiman.behavior import behavior
-from scipy.sparse import coo_matrix
 from caiman.utils.utils import download_demo
 
 #%%
-fname = [u'demo_behavior.h5']
-if fname[0] in ['demo_behavior.h5']:
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
+#%%
+    pl.ion()
+
+    fname = [u'demo_behavior.h5']
+    if fname[0] in ['demo_behavior.h5']:
+        # TODO: todocument
+        fname = [download_demo(fname[0])]
     # TODO: todocument
-    fname = [download_demo(fname[0])]
-# TODO: todocument
-m = cm.load(fname[0], is_behavior=True)
+    m = cm.load(fname[0], is_behavior=True)
 
 #%% load, rotate and eliminate useless pixels
-m = m.transpose([0, 2, 1])
-m = m[:, 150:, :]
+    m = m.transpose([0, 2, 1])
+    m = m[:, 150:, :]
 #%% visualize movie
-m.play()
+    m.play()
 #%% select interesting portion of the FOV (draw a polygon on the figure that pops up, when done press enter)
-mask = np.array(behavior.select_roi(np.median(m[::100], 0), 1)[0], np.float32)
+    print("Please draw a polygon delimiting the ROI on the image that will be displayed after the image; press enter when done")
+    mask = np.array(behavior.select_roi(np.median(m[::100], 0), 1)[0], np.float32)
 #%%
-n_components = 4  # number of movement looked for
-resize_fact = 0.5  # for computational efficiency movies are downsampled
-# number of standard deviations above mean for the magnitude that are considered enough to measure the angle in polar coordinates
-num_std_mag_for_angle = .6
-only_magnitude = False  # if onlu interested in factorizing over the magnitude
-method_factorization = 'dict_learn'  # could also use nmf
-# number of iterations for the dictionary learning algorithm (Marial et al, 2010)
-max_iter_DL = -30
+    n_components = 4  # number of movement looked for
+    resize_fact = 0.5  # for computational efficiency movies are downsampled
+    # number of standard deviations above mean for the magnitude that are considered enough to measure the angle in polar coordinates
+    num_std_mag_for_angle = .6
+    only_magnitude = False  # if onlu interested in factorizing over the magnitude
+    method_factorization = 'dict_learn'  # could also use nmf
+    # number of iterations for the dictionary learning algorithm (Marial et al, 2010)
+    max_iter_DL = -30
 
-spatial_filter_, time_trace_, of_or = cm.behavior.behavior.extract_motor_components_OF(m, n_components, mask=mask,
-                                                                                       resize_fact=resize_fact, only_magnitude=only_magnitude, verbose=True, method_factorization='dict_learn', max_iter_DL=max_iter_DL)
+    spatial_filter_, time_trace_, of_or = cm.behavior.behavior.extract_motor_components_OF(m, n_components, mask=mask,
+                                                                                           resize_fact=resize_fact, only_magnitude=only_magnitude, verbose=True, method_factorization='dict_learn', max_iter_DL=max_iter_DL)
 
 #%%
-mags, dircts, dircts_thresh, spatial_masks_thrs = cm.behavior.behavior.extract_magnitude_and_angle_from_OF(
-    spatial_filter_, time_trace_, of_or, num_std_mag_for_angle=num_std_mag_for_angle, sav_filter_size=3, only_magnitude=only_magnitude)
+    mags, dircts, dircts_thresh, spatial_masks_thrs = cm.behavior.behavior.extract_magnitude_and_angle_from_OF(
+        spatial_filter_, time_trace_, of_or, num_std_mag_for_angle=num_std_mag_for_angle, sav_filter_size=3, only_magnitude=only_magnitude)
 #%%
-idd = 0
-axlin = pl.subplot(n_components, 2, 2)
-for mag, dirct, spatial_filter in zip(mags, dircts_thresh, spatial_filter_):
-    pl.subplot(n_components, 2, 1 + idd * 2)
-    min_x, min_y = np.min(np.where(mask), 1)
-#            max_x,max_y = np.max(np.where(mask),1)
+    idd = 0
+    axlin = pl.subplot(n_components, 2, 2)
+    for mag, dirct, spatial_filter in zip(mags, dircts_thresh, spatial_filter_):
+        pl.subplot(n_components, 2, 1 + idd * 2)
+        min_x, min_y = np.min(np.where(mask), 1)
 
-    spfl = spatial_filter
-    spfl = cm.movie(spfl[None, :, :]).resize(
-        1 / resize_fact, 1 / resize_fact, 1).squeeze()
-    max_x, max_y = np.add((min_x, min_y), np.shape(spfl))
+        spfl = spatial_filter
+        spfl = cm.movie(spfl[None, :, :]).resize(
+            1 / resize_fact, 1 / resize_fact, 1).squeeze()
+        max_x, max_y = np.add((min_x, min_y), np.shape(spfl))
 
-    mask[min_x:max_x, min_y:max_y] = spfl
-    mask[mask < np.nanpercentile(spfl, 70)] = np.nan
-#            spfl = ld['spatial_filter'][idd]
-    pl.imshow(m[0], cmap='gray')
-    pl.imshow(mask, alpha=.5)
-    pl.axis('off')
+        mask[min_x:max_x, min_y:max_y] = spfl
+        mask[mask < np.nanpercentile(spfl, 70)] = np.nan
+        pl.imshow(m[0], cmap='gray')
+        pl.imshow(mask, alpha=.5)
+        pl.axis('off')
 
-    axelin = pl.subplot(n_components, 2, 2 + idd * 2, sharex=axlin)
-    pl.plot(mag / 10, 'k')
-    dirct[mag < 0.5 * np.std(mag)] = np.nan
-    pl.plot(dirct, 'r-', linewidth=2)
+        axelin = pl.subplot(n_components, 2, 2 + idd * 2, sharex=axlin)
+        pl.plot(mag / 10, 'k')
+        dirct[mag < 0.5 * np.std(mag)] = np.nan
+        pl.plot(dirct, 'r-', linewidth=2)
 
-#            gt_pix_2 = scipy.signal.savgol_filter(np.diff(np.array(pts[8]).T,axis=0)[2:],3,1)
-#            gt_pix_2 = np.diff(np.array(pts[8]).T,axis=0)[2:]
+        idd += 1
 
-    idd += 1
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()

--- a/demos/general/demo_caiman_basic.py
+++ b/demos/general/demo_caiman_basic.py
@@ -44,123 +44,130 @@ from caiman.components_evaluation import estimate_components_quality_auto
 from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.paths import caiman_datadir
 
+#%%
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
 #%% start a cluster
 
-c, dview, n_processes =\
-    cm.cluster.setup_cluster(backend='local', n_processes=None,
-                             single_thread=False)
+    c, dview, n_processes =\
+        cm.cluster.setup_cluster(backend='local', n_processes=None,
+                                 single_thread=False)
 
 #%% save files to be processed
 
-# This datafile is distributed with Caiman
-fnames = [os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')]
-# location of dataset  (can actually be a list of filed to be concatenated)
-add_to_movie = -np.min(cm.load(fnames[0], subindices=range(200))).astype(float)
-# determine minimum value on a small chunk of data
-add_to_movie = np.maximum(add_to_movie, 0)
-# if minimum is negative subtract to make the data non-negative
-base_name = 'Yr'
-name_new = cm.save_memmap_each(fnames, dview=dview, base_name=base_name,
-                               add_to_movie=add_to_movie)
-name_new.sort()
-fname_new = cm.save_memmap_join(name_new, base_name='Yr', dview=dview)
+    # This datafile is distributed with Caiman
+    fnames = [os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')]
+    # location of dataset  (can actually be a list of filed to be concatenated)
+    add_to_movie = -np.min(cm.load(fnames[0], subindices=range(200))).astype(float)
+    # determine minimum value on a small chunk of data
+    add_to_movie = np.maximum(add_to_movie, 0)
+    # if minimum is negative subtract to make the data non-negative
+    base_name = 'Yr'
+    name_new = cm.save_memmap_each(fnames, dview=dview, base_name=base_name,
+                                   add_to_movie=add_to_movie)
+    name_new.sort()
+    fname_new = cm.save_memmap_join(name_new, base_name='Yr', dview=dview)
 #%% LOAD MEMORY MAPPABLE FILE
-Yr, dims, T = cm.load_memmap(fname_new)
-d1, d2 = dims
-images = np.reshape(Yr.T, [T] + list(dims), order='F')
+    Yr, dims, T = cm.load_memmap(fname_new)
+    d1, d2 = dims
+    images = np.reshape(Yr.T, [T] + list(dims), order='F')
 
 #%% play movie, press q to quit
-play_movie = False
-if play_movie:
-    cm.movie(images[1400:]).play(fr=50, magnification=4, gain=3.)
+    play_movie = False
+    if play_movie:
+        cm.movie(images[1400:]).play(fr=50, magnification=4, gain=3.)
 
 #%% correlation image. From here infer neuron size and density
-Cn = cm.movie(images).local_correlations(swap_dim=False)
-plt.imshow(Cn, cmap='gray')
-plt.title('Correlation Image')
+    Cn = cm.movie(images).local_correlations(swap_dim=False)
+    plt.imshow(Cn, cmap='gray')
+    plt.title('Correlation Image')
 
 #%% set up some parameters
 
-is_patches = True      # flag for processing in patches or not
-
-if is_patches:          # PROCESS IN PATCHES AND THEN COMBINE
-    rf = 10             # half size of each patch
-    stride = 4          # overlap between patches
-    K = 4               # number of components in each patch
-else:                   # PROCESS THE WHOLE FOV AT ONCE
-    rf = None           # setting these parameters to None
-    stride = None       # will run CNMF on the whole FOV
-    K = 30              # number of neurons expected (in the whole FOV)
-
-gSig = [6, 6]           # expected half size of neurons
-merge_thresh = 0.80     # merging threshold, max correlation allowed
-p = 2                   # order of the autoregressive system
-gnb = 2                 # global background order
+    is_patches = True      # flag for processing in patches or not
+    
+    if is_patches:          # PROCESS IN PATCHES AND THEN COMBINE
+        rf = 10             # half size of each patch
+        stride = 4          # overlap between patches
+        K = 4               # number of components in each patch
+    else:                   # PROCESS THE WHOLE FOV AT ONCE
+        rf = None           # setting these parameters to None
+        stride = None       # will run CNMF on the whole FOV
+        K = 30              # number of neurons expected (in the whole FOV)
+    
+    gSig = [6, 6]           # expected half size of neurons
+    merge_thresh = 0.80     # merging threshold, max correlation allowed
+    p = 2                   # order of the autoregressive system
+    gnb = 2                 # global background order
 
 
 #%% Now RUN CNMF
-cnm = cnmf.CNMF(n_processes, method_init='greedy_roi', k=K, gSig=gSig,
-                merge_thresh=merge_thresh, p=p, dview=dview, gnb=gnb,
-                rf=rf, stride=stride, rolling_sum=False)
-cnm = cnm.fit(images)
+    cnm = cnmf.CNMF(n_processes, method_init='greedy_roi', k=K, gSig=gSig,
+                    merge_thresh=merge_thresh, p=p, dview=dview, gnb=gnb,
+                    rf=rf, stride=stride, rolling_sum=False)
+    cnm = cnm.fit(images)
 
 #%% plot contour plots of components
 
-plt.figure()
-crd = cm.utils.visualization.plot_contours(cnm.A, Cn, thr=0.9)
-plt.title('Contour plots of components')
-
-
-
+    plt.figure()
+    crd = cm.utils.visualization.plot_contours(cnm.A, Cn, thr=0.9)
+    plt.title('Contour plots of components')
 
 #%%
-A_in, C_in, b_in, f_in = cnm.A[:,:], cnm.C[:], cnm.b, cnm.f
-cnm2 = cnmf.CNMF(n_processes=1, k=A_in.shape[-1], gSig=gSig, p=p, dview=dview,
-                 merge_thresh=merge_thresh, Ain=A_in, Cin=C_in, b_in=b_in,
-                 f_in=f_in, rf=None, stride=None, gnb=gnb,
-                 method_deconvolution='oasis', check_nan=True)
-
-cnm2 = cnm2.fit(images)
+    A_in, C_in, b_in, f_in = cnm.A[:,:], cnm.C[:], cnm.b, cnm.f
+    cnm2 = cnmf.CNMF(n_processes=1, k=A_in.shape[-1], gSig=gSig, p=p, dview=dview,
+                     merge_thresh=merge_thresh, Ain=A_in, Cin=C_in, b_in=b_in,
+                     f_in=f_in, rf=None, stride=None, gnb=gnb,
+                     method_deconvolution='oasis', check_nan=True)
+    
+    cnm2 = cnm2.fit(images)
 #%% COMPONENT EVALUATION
-# the components are evaluated in three ways:
-#   a) the shape of each component must be correlated with the data
-#   b) a minimum peak SNR is required over the length of a transient
-#   c) each shape passes a CNN based classifier (this will pick up only neurons
-#           and filter out active processes)
-fr = 10             # approximate frame rate of data
-decay_time = 5.0    # length of transient
-min_SNR = 2.5       # peak SNR for accepted components (if above this, acept)
-rval_thr = 0.90     # space correlation threshold (if above this, accept)
-use_cnn = True     # use the CNN classifier
-min_cnn_thr = 0.95  # if cnn classifier predicts below this value, reject
-
-idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
-    estimate_components_quality_auto(images, cnm.A, cnm.C, cnm.b, cnm.f,
-                                     cnm.YrA, fr, decay_time, gSig, dims,
-                                     dview=dview, min_SNR=min_SNR,
-                                     r_values_min=rval_thr, use_cnn=use_cnn,
-                                     thresh_cnn_min=min_cnn_thr)
+    # the components are evaluated in three ways:
+    #   a) the shape of each component must be correlated with the data
+    #   b) a minimum peak SNR is required over the length of a transient
+    #   c) each shape passes a CNN based classifier (this will pick up only neurons
+    #           and filter out active processes)
+    fr = 10             # approximate frame rate of data
+    decay_time = 5.0    # length of transient
+    min_SNR = 2.5       # peak SNR for accepted components (if above this, acept)
+    rval_thr = 0.90     # space correlation threshold (if above this, accept)
+    use_cnn = True     # use the CNN classifier
+    min_cnn_thr = 0.95  # if cnn classifier predicts below this value, reject
+    
+    idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
+        estimate_components_quality_auto(images, cnm.A, cnm.C, cnm.b, cnm.f,
+                                         cnm.YrA, fr, decay_time, gSig, dims,
+                                         dview=dview, min_SNR=min_SNR,
+                                         r_values_min=rval_thr, use_cnn=use_cnn,
+                                         thresh_cnn_min=min_cnn_thr)
 #%% visualize selected and rejected components
-plt.figure()
-plt.subplot(1, 2, 1)
-cm.utils.visualization.plot_contours(cnm2.A[:, idx_components], Cn, thr=0.9)
-plt.title('Selected components')
-plt.subplot(1, 2, 2)
-plt.title('Discaded components')
-cm.utils.visualization.plot_contours(cnm2.A[:, idx_components_bad], Cn, thr=0.9)
+    plt.figure()
+    plt.subplot(1, 2, 1)
+    cm.utils.visualization.plot_contours(cnm2.A[:, idx_components], Cn, thr=0.9)
+    plt.title('Selected components')
+    plt.subplot(1, 2, 2)
+    plt.title('Discaded components')
+    cm.utils.visualization.plot_contours(cnm2.A[:, idx_components_bad], Cn, thr=0.9)
 
 #%%
-plt.figure()
-crd = cm.utils.visualization.plot_contours(cnm2.A.tocsc()[:,idx_components], Cn, thr=0.9)
-plt.title('Contour plots of components')
+    plt.figure()
+    crd = cm.utils.visualization.plot_contours(cnm2.A.tocsc()[:,idx_components], Cn, thr=0.9)
+    plt.title('Contour plots of components')
 #%% visualize selected components
-cm.utils.visualization.view_patches_bar(Yr, cnm2.A.tocsc()[:, idx_components],
-                                        cnm2.C[idx_components, :], cnm2.b, cnm2.f,
-                                        dims[0], dims[1],
-                                        YrA=cnm2.YrA[idx_components, :], img=Cn)
+    cm.utils.visualization.view_patches_bar(Yr, cnm2.A.tocsc()[:, idx_components],
+                                            cnm2.C[idx_components, :], cnm2.b, cnm2.f,
+                                            dims[0], dims[1],
+                                            YrA=cnm2.YrA[idx_components, :], img=Cn)
 #%% STOP CLUSTER and clean up log files
-cm.stop_server()
+    cm.stop_server()
+    
+    log_files = glob.glob('Yr*_LOG_*')
+    for log_file in log_files:
+        os.remove(log_file)
 
-log_files = glob.glob('Yr*_LOG_*')
-for log_file in log_files:
-    os.remove(log_file)
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()

--- a/demos/general/demo_pipeline.py
+++ b/demos/general/demo_pipeline.py
@@ -38,11 +38,11 @@ try:
 except NameError:
     pass
 
-import caiman as cm
+import matplotlib.pyplot as plt
 import numpy as np
 import time
-import matplotlib.pyplot as plt
 
+import caiman as cm
 from caiman.utils.utils import download_demo
 from caiman.utils.visualization import plot_contours, view_patches_bar
 from caiman.source_extraction.cnmf import cnmf as cnmf
@@ -50,203 +50,213 @@ from caiman.motion_correction import MotionCorrect
 from caiman.source_extraction.cnmf.utilities import detrend_df_f
 from caiman.components_evaluation import estimate_components_quality_auto
 
+#%%
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
 #%% First setup some parameters
 
-# dataset dependent parameters
-display_images = False              # Set this to true to show movies and plots
-fname = ['Sue_2x_3000_40_-46.tif']  # filename to be processed
-fr = 30                             # imaging rate in frames per second
-decay_time = 0.4                    # length of a typical transient in seconds
+    # dataset dependent parameters
+    display_images = False              # Set this to true to show movies and plots
+    fname = ['Sue_2x_3000_40_-46.tif']  # filename to be processed
+    fr = 30                             # imaging rate in frames per second
+    decay_time = 0.4                    # length of a typical transient in seconds
 
-# motion correction parameters
-niter_rig = 1               # number of iterations for rigid motion correction
-max_shifts = (6, 6)         # maximum allow rigid shift
-# for parallelization split the movies in  num_splits chuncks across time
-splits_rig = 56
-# start a new patch for pw-rigid motion correction every x pixels
-strides = (48, 48)
-# overlap between pathes (size of patch strides+overlaps)
-overlaps = (24, 24)
-# for parallelization split the movies in  num_splits chuncks across time
-splits_els = 56
-upsample_factor_grid = 4    # upsample factor to avoid smearing when merging patches
-# maximum deviation allowed for patch with respect to rigid shifts
-max_deviation_rigid = 3
+    # motion correction parameters
+    niter_rig = 1               # number of iterations for rigid motion correction
+    max_shifts = (6, 6)         # maximum allow rigid shift
+    # for parallelization split the movies in  num_splits chuncks across time
+    splits_rig = 56
+    # start a new patch for pw-rigid motion correction every x pixels
+    strides = (48, 48)
+    # overlap between pathes (size of patch strides+overlaps)
+    overlaps = (24, 24)
+    # for parallelization split the movies in  num_splits chuncks across time
+    splits_els = 56
+    upsample_factor_grid = 4    # upsample factor to avoid smearing when merging patches
+    # maximum deviation allowed for patch with respect to rigid shifts
+    max_deviation_rigid = 3
 
-# parameters for source extraction and deconvolution
-p = 1                       # order of the autoregressive system
-gnb = 2                     # number of global background components
-merge_thresh = 0.8          # merging threshold, max correlation allowed
-# half-size of the patches in pixels. e.g., if rf=25, patches are 50x50
-rf = 15
-stride_cnmf = 6             # amount of overlap between the patches in pixels
-K = 4                       # number of components per patch
-gSig = [4, 4]               # expected half size of neurons
-# initialization method (if analyzing dendritic data using 'sparse_nmf')
-init_method = 'greedy_roi'
-is_dendrites = False        # flag for analyzing dendritic data
-# sparsity penalty for dendritic data analysis through sparse NMF
-alpha_snmf = None
+    # parameters for source extraction and deconvolution
+    p = 1                       # order of the autoregressive system
+    gnb = 2                     # number of global background components
+    merge_thresh = 0.8          # merging threshold, max correlation allowed
+    # half-size of the patches in pixels. e.g., if rf=25, patches are 50x50
+    rf = 15
+    stride_cnmf = 6             # amount of overlap between the patches in pixels
+    K = 4                       # number of components per patch
+    gSig = [4, 4]               # expected half size of neurons
+    # initialization method (if analyzing dendritic data using 'sparse_nmf')
+    init_method = 'greedy_roi'
+    is_dendrites = False        # flag for analyzing dendritic data
+    # sparsity penalty for dendritic data analysis through sparse NMF
+    alpha_snmf = None
 
-# parameters for component evaluation
-min_SNR = 2.5               # signal to noise ratio for accepting a component
-rval_thr = 0.8              # space correlation threshold for accepting a component
-cnn_thr = 0.8               # threshold for CNN based classifier
+    # parameters for component evaluation
+    min_SNR = 2.5               # signal to noise ratio for accepting a component
+    rval_thr = 0.8              # space correlation threshold for accepting a component
+    cnn_thr = 0.8               # threshold for CNN based classifier
 
 #%% download the dataset if it's not present in your folder
-if fname[0] in ['Sue_2x_3000_40_-46.tif', 'demoMovie.tif']:
-    fname = [download_demo(fname[0])]
+    if fname[0] in ['Sue_2x_3000_40_-46.tif', 'demoMovie.tif']:
+        fname = [download_demo(fname[0])]
 
 #%% play the movie
-# playing the movie using opencv. It requires loading the movie in memory. To
-# close the video press q
+    # playing the movie using opencv. It requires loading the movie in memory. To
+    # close the video press q
 
-m_orig = cm.load_movie_chain(fname[:1])
-downsample_ratio = 0.2
-offset_mov = -np.min(m_orig[:100])
-moviehandle = m_orig.resize(1, 1, downsample_ratio)
-if display_images:
-    moviehandle.play(gain=10, offset=offset_mov, fr=30, magnification=2)
+    m_orig = cm.load_movie_chain(fname[:1])
+    downsample_ratio = 0.2
+    offset_mov = -np.min(m_orig[:100])
+    moviehandle = m_orig.resize(1, 1, downsample_ratio)
+    if display_images:
+        moviehandle.play(gain=10, offset=offset_mov, fr=30, magnification=2)
 
 #%% start a cluster for parallel processing
-c, dview, n_processes = cm.cluster.setup_cluster(
-    backend='local', n_processes=None, single_thread=False)
+    c, dview, n_processes = cm.cluster.setup_cluster(
+        backend='local', n_processes=None, single_thread=False)
 
 
 #%%% MOTION CORRECTION
-# first we create a motion correction object with the parameters specified
-min_mov = cm.load(fname[0], subindices=range(200)).min()
-# this will be subtracted from the movie to make it non-negative
+    # first we create a motion correction object with the parameters specified
+    min_mov = cm.load(fname[0], subindices=range(200)).min()
+    # this will be subtracted from the movie to make it non-negative
 
-mc = MotionCorrect(fname[0], min_mov,
-                   dview=dview, max_shifts=max_shifts, niter_rig=niter_rig,
-                   splits_rig=splits_rig,
-                   strides=strides, overlaps=overlaps, splits_els=splits_els,
-                   upsample_factor_grid=upsample_factor_grid,
-                   max_deviation_rigid=max_deviation_rigid,
-                   shifts_opencv=True, nonneg_movie=True)
-# note that the file is not loaded in memory
+    mc = MotionCorrect(fname[0], min_mov,
+                       dview=dview, max_shifts=max_shifts, niter_rig=niter_rig,
+                       splits_rig=splits_rig,
+                       strides=strides, overlaps=overlaps, splits_els=splits_els,
+                       upsample_factor_grid=upsample_factor_grid,
+                       max_deviation_rigid=max_deviation_rigid,
+                       shifts_opencv=True, nonneg_movie=True)
+    # note that the file is not loaded in memory
 
 #%% Run piecewise-rigid motion correction using NoRMCorre
-mc.motion_correct_pwrigid(save_movie=True)
-m_els = cm.load(mc.fname_tot_els)
-bord_px_els = np.ceil(np.maximum(np.max(np.abs(mc.x_shifts_els)),
-                                 np.max(np.abs(mc.y_shifts_els)))).astype(np.int)
-# maximum shift to be used for trimming against NaNs
+    mc.motion_correct_pwrigid(save_movie=True)
+    m_els = cm.load(mc.fname_tot_els)
+    bord_px_els = np.ceil(np.maximum(np.max(np.abs(mc.x_shifts_els)),
+                                     np.max(np.abs(mc.y_shifts_els)))).astype(np.int)
+    # maximum shift to be used for trimming against NaNs
 #%% compare with original movie
-moviehandle = cm.concatenate([m_orig.resize(1, 1, downsample_ratio) + offset_mov,
-                m_els.resize(1, 1, downsample_ratio)],
-               axis=2)
-display_images = False
-if display_images:
-    moviehandle.play(fr=60, q_max=99.5, magnification=2, offset=0)  # press q to exit
+    moviehandle = cm.concatenate([m_orig.resize(1, 1, downsample_ratio) + offset_mov,
+                    m_els.resize(1, 1, downsample_ratio)],
+                   axis=2)
+    display_images = False
+    if display_images:
+        moviehandle.play(fr=60, q_max=99.5, magnification=2, offset=0)  # press q to exit
 
 #%% MEMORY MAPPING
-# memory map the file in order 'C'
-fnames = mc.fname_tot_els   # name of the pw-rigidly corrected file.
-border_to_0 = bord_px_els     # number of pixels to exclude
-fname_new = cm.save_memmap(fnames, base_name='memmap_', order='C',
-                           border_to_0=bord_px_els)  # exclude borders
+    # memory map the file in order 'C'
+    fnames = mc.fname_tot_els   # name of the pw-rigidly corrected file.
+    border_to_0 = bord_px_els     # number of pixels to exclude
+    fname_new = cm.save_memmap(fnames, base_name='memmap_', order='C',
+                               border_to_0=bord_px_els)  # exclude borders
 
-# now load the file
-Yr, dims, T = cm.load_memmap(fname_new)
-d1, d2 = dims
-images = np.reshape(Yr.T, [T] + list(dims), order='F')
-# load frames in python format (T x X x Y)
+    # now load the file
+    Yr, dims, T = cm.load_memmap(fname_new)
+    d1, d2 = dims
+    images = np.reshape(Yr.T, [T] + list(dims), order='F')
+    # load frames in python format (T x X x Y)
 
 #%% restart cluster to clean up memory
-dview.terminate()
-c, dview, n_processes = cm.cluster.setup_cluster(
-    backend='local', n_processes=None, single_thread=False)
+    dview.terminate()
+    c, dview, n_processes = cm.cluster.setup_cluster(
+        backend='local', n_processes=None, single_thread=False)
 
 #%% RUN CNMF ON PATCHES
 
-# First extract spatial and temporal components on patches and combine them
-# for this step deconvolution is turned off (p=0)
-t1 = time.time()
+    # First extract spatial and temporal components on patches and combine them
+    # for this step deconvolution is turned off (p=0)
+    t1 = time.time()
 
-cnm = cnmf.CNMF(n_processes=1, k=K, gSig=gSig, merge_thresh=merge_thresh,
-                p=0, dview=dview, rf=rf, stride=stride_cnmf, memory_fact=1,
-                method_init=init_method, alpha_snmf=alpha_snmf,
-                only_init_patch=False, gnb=gnb, border_pix=bord_px_els)
-cnm = cnm.fit(images)
+    cnm = cnmf.CNMF(n_processes=1, k=K, gSig=gSig, merge_thresh=merge_thresh,
+                    p=0, dview=dview, rf=rf, stride=stride_cnmf, memory_fact=1,
+                    method_init=init_method, alpha_snmf=alpha_snmf,
+                    only_init_patch=False, gnb=gnb, border_pix=bord_px_els)
+    cnm = cnm.fit(images)
 
 #%% plot contours of found components
-Cn = cm.local_correlations(images.transpose(1, 2, 0))
-Cn[np.isnan(Cn)] = 0
-plt.figure()
-crd = plot_contours(cnm.A, Cn, thr=0.9)
-plt.title('Contour plots of found components')
+    Cn = cm.local_correlations(images.transpose(1, 2, 0))
+    Cn[np.isnan(Cn)] = 0
+    plt.figure()
+    crd = plot_contours(cnm.A, Cn, thr=0.9)
+    plt.title('Contour plots of found components')
 
 
 #%% COMPONENT EVALUATION
-# the components are evaluated in three ways:
-#   a) the shape of each component must be correlated with the data
-#   b) a minimum peak SNR is required over the length of a transient
-#   c) each shape passes a CNN based classifier
+    # the components are evaluated in three ways:
+    #   a) the shape of each component must be correlated with the data
+    #   b) a minimum peak SNR is required over the length of a transient
+    #   c) each shape passes a CNN based classifier
 
-idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
-    estimate_components_quality_auto(images, cnm.A, cnm.C, cnm.b, cnm.f,
-                                     cnm.YrA, fr, decay_time, gSig, dims,
-                                     dview=dview, min_SNR=min_SNR,
-                                     r_values_min=rval_thr, use_cnn=False,
-                                     thresh_cnn_min=cnn_thr)
+    idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
+        estimate_components_quality_auto(images, cnm.A, cnm.C, cnm.b, cnm.f,
+                                         cnm.YrA, fr, decay_time, gSig, dims,
+                                         dview=dview, min_SNR=min_SNR,
+                                         r_values_min=rval_thr, use_cnn=False,
+                                         thresh_cnn_min=cnn_thr)
 
 #%% PLOT COMPONENTS
 
-if display_images:
-    plt.figure()
-    plt.subplot(121)
-    crd_good = cm.utils.visualization.plot_contours(
-        cnm.A[:, idx_components], Cn, thr=.8, vmax=0.75)
-    plt.title('Contour plots of accepted components')
-    plt.subplot(122)
-    crd_bad = cm.utils.visualization.plot_contours(
-        cnm.A[:, idx_components_bad], Cn, thr=.8, vmax=0.75)
-    plt.title('Contour plots of rejected components')
+    if display_images:
+        plt.figure()
+        plt.subplot(121)
+        crd_good = cm.utils.visualization.plot_contours(
+            cnm.A[:, idx_components], Cn, thr=.8, vmax=0.75)
+        plt.title('Contour plots of accepted components')
+        plt.subplot(122)
+        crd_bad = cm.utils.visualization.plot_contours(
+            cnm.A[:, idx_components_bad], Cn, thr=.8, vmax=0.75)
+        plt.title('Contour plots of rejected components')
 
 #%% VIEW TRACES (accepted and rejected)
 
-if display_images:
-    view_patches_bar(Yr, cnm.A.tocsc()[:, idx_components], cnm.C[idx_components],
-                     cnm.b, cnm.f, dims[0], dims[1], YrA=cnm.YrA[idx_components],
-                     img=Cn)
+    if display_images:
+        view_patches_bar(Yr, cnm.A.tocsc()[:, idx_components], cnm.C[idx_components],
+                         cnm.b, cnm.f, dims[0], dims[1], YrA=cnm.YrA[idx_components],
+                         img=Cn)
 
-    view_patches_bar(Yr, cnm.A.tocsc()[:, idx_components_bad], cnm.C[idx_components_bad],
-                     cnm.b, cnm.f, dims[0], dims[1], YrA=cnm.YrA[idx_components_bad],
-                     img=Cn)
+        view_patches_bar(Yr, cnm.A.tocsc()[:, idx_components_bad], cnm.C[idx_components_bad],
+                         cnm.b, cnm.f, dims[0], dims[1], YrA=cnm.YrA[idx_components_bad],
+                         img=Cn)
 
 #%% RE-RUN seeded CNMF on accepted patches to refine and perform deconvolution
-A_in, C_in, b_in, f_in = cnm.A[:,
-                               idx_components], cnm.C[idx_components], cnm.b, cnm.f
-cnm2 = cnmf.CNMF(n_processes=1, k=A_in.shape[-1], gSig=gSig, p=p, dview=dview,
-                 merge_thresh=merge_thresh, Ain=A_in, Cin=C_in, b_in=b_in,
-                 f_in=f_in, rf=None, stride=None, gnb=gnb,
-                 method_deconvolution='oasis', check_nan=True)
+    A_in, C_in, b_in, f_in = cnm.A[:,
+                                   idx_components], cnm.C[idx_components], cnm.b, cnm.f
+    cnm2 = cnmf.CNMF(n_processes=1, k=A_in.shape[-1], gSig=gSig, p=p, dview=dview,
+                     merge_thresh=merge_thresh, Ain=A_in, Cin=C_in, b_in=b_in,
+                     f_in=f_in, rf=None, stride=None, gnb=gnb,
+                     method_deconvolution='oasis', check_nan=True)
 
-cnm2 = cnm2.fit(images)
+    cnm2 = cnm2.fit(images)
 
 #%% Extract DF/F values
 
-F_dff = detrend_df_f(cnm2.A, cnm2.b, cnm2.C, cnm2.f, YrA=cnm2.YrA,
-                     quantileMin=8, frames_window=250)
+    F_dff = detrend_df_f(cnm2.A, cnm2.b, cnm2.C, cnm2.f, YrA=cnm2.YrA,
+                         quantileMin=8, frames_window=250)
 
 #%% Show final traces
-cnm2.view_patches(Yr, dims=dims, img=Cn)
+    cnm2.view_patches(Yr, dims=dims, img=Cn)
 
 #%% STOP CLUSTER and clean up log files
-cm.stop_server(dview=dview)
-log_files = glob.glob('*_LOG_*')
-for log_file in log_files:
-    os.remove(log_file)
+    cm.stop_server(dview=dview)
+    log_files = glob.glob('*_LOG_*')
+    for log_file in log_files:
+        os.remove(log_file)
 
 #%% reconstruct denoised movie
-denoised = cm.movie(cnm2.A.dot(cnm2.C) +
-                    cnm2.b.dot(cnm2.f)).reshape(dims + (-1,), order='F').transpose([2, 0, 1])
+    denoised = cm.movie(cnm2.A.dot(cnm2.C) +
+                        cnm2.b.dot(cnm2.f)).reshape(dims + (-1,), order='F').transpose([2, 0, 1])
 
 #%% play along side original data
-moviehandle = cm.concatenate([m_els.resize(1, 1, downsample_ratio),
-                denoised.resize(1, 1, downsample_ratio)],
-               axis=2)
-if display_images:
-        moviehandle.play(fr=60, gain=15, magnification=2, offset=0)  # press q to exit
+    moviehandle = cm.concatenate([m_els.resize(1, 1, downsample_ratio),
+                    denoised.resize(1, 1, downsample_ratio)],
+                   axis=2)
+    if display_images:
+            moviehandle.play(fr=60, gain=15, magnification=2, offset=0)  # press q to exit
+
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()

--- a/demos/general/demo_pipeline_cnmfE.py
+++ b/demos/general/demo_pipeline_cnmfE.py
@@ -10,14 +10,19 @@ Demo is also available as a jupyter notebook (see demo_pipeline_cnmfE.ipynb)
 from __future__ import division
 from __future__ import print_function
 
-try:
-    get_ipython().magic(u'load_ext autoreload')
-    get_ipython().magic(u'autoreload 2')
-except:
-    print('Not launched under iPython')
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+try:
+    if __IPYTHON__:
+        print('Detected iPython')
+        # this is used for debugging purposes only. allows to reload classes when changed
+        get_ipython().magic('load_ext autoreload')
+        get_ipython().magic('autoreload 2')
+except NameError:
+    pass
+
 import caiman as cm
 from caiman.source_extraction import cnmf
 from caiman.utils.utils import download_demo
@@ -25,233 +30,240 @@ from caiman.utils.visualization import inspect_correlation_pnr
 from caiman.components_evaluation import estimate_components_quality_auto
 from caiman.motion_correction import motion_correct_oneP_rigid, motion_correct_oneP_nonrigid
 
+#%%
+def main():
+    pass # For compatibility between running under Spyder and the CLI
+
 #%% First setup some parameters
 
-# dataset dependent parameters
-display_images = False           # Set to true to show movies and images
-fnames = ['data_endoscope.tif']  # filename to be processed
-frate = 10                       # movie frame rate
-decay_time = 0.4                 # length of a typical transient in seconds
-
-# motion correction parameters
-do_motion_correction_nonrigid = True
-do_motion_correction_rigid = False  # in this case it will also save a rigid motion corrected movie
-gSig_filt = (3, 3)   # size of filter, in general gSig (see below),
-#                      change this one if algorithm does not work
-max_shifts = (5, 5)  # maximum allowed rigid shift
-splits_rig = 10      # for parallelization split the movies in  num_splits chuncks across time
-strides = (48, 48)   # start a new patch for pw-rigid motion correction every x pixels
-overlaps = (24, 24)  # overlap between pathes (size of patch strides+overlaps)
-# for parallelization split the movies in  num_splits chuncks across time
-# (remember that it should hold that length_movie/num_splits_to_process_rig>100)
-splits_els = 10
-upsample_factor_grid = 4    # upsample factor to avoid smearing when merging patches
-# maximum deviation allowed for patch with respect to rigid shifts
-max_deviation_rigid = 3
-
-# parameters for source extraction and deconvolution
-p = 1               # order of the autoregressive system
-K = None            # upper bound on number of components per patch, in general None
-gSig = 3            # gaussian width of a 2D gaussian kernel, which approximates a neuron
-gSiz = 13           # average diameter of a neuron, in general 4*gSig+1
-merge_thresh = .7   # merging threshold, max correlation allowed
-rf = 40             # half-size of the patches in pixels. e.g., if rf=40, patches are 80x80
-stride_cnmf = 20    # amount of overlap between the patches in pixels
-#                     (keep it at least large as gSiz, i.e 4 times the neuron size gSig)
-tsub = 2            # downsampling factor in time for initialization,
-#                     increase if you have memory problems
-ssub = 1            # downsampling factor in space for initialization,
-#                     increase if you have memory problems
-Ain = None          # if you want to initialize with some preselected components
-#                     you can pass them here as boolean vectors
-low_rank_background = None  # None leaves background of each patch intact,
-#                             True performs global low-rank approximation 
-gnb = -1            # number of background components (rank) if positive,
-#                     else exact ring model with following settings
-#                         gnb=-2: Return background as b and W
-#                         gnb=-1: Return full rank background B
-#                         gnb= 0: Don't return background
-nb_patch = -1       # number of background components (rank) per patch,
-#                     use 0 or -1 for exact background of ring model (cf. gnb)
-min_corr = .8       # min peak value from correlation image
-min_pnr = 10        # min peak to noise ration from PNR image
-ssub_B = 2          # additional downsampling factor in space for background
-ring_size_factor = 1.4  # radius of ring is gSiz*ring_size_factor
-
-# parameters for component evaluation
-min_SNR = 3            # adaptive way to set threshold on the transient size
-r_values_min = 0.85    # threshold on space consistency (if you lower more components
-#                        will be accepted, potentially with worst quality)
+    # dataset dependent parameters
+    display_images = False           # Set to true to show movies and images
+    fnames = ['data_endoscope.tif']  # filename to be processed
+    frate = 10                       # movie frame rate
+    decay_time = 0.4                 # length of a typical transient in seconds
+    
+    # motion correction parameters
+    do_motion_correction_nonrigid = True
+    do_motion_correction_rigid = False  # in this case it will also save a rigid motion corrected movie
+    gSig_filt = (3, 3)   # size of filter, in general gSig (see below),
+    #                      change this one if algorithm does not work
+    max_shifts = (5, 5)  # maximum allowed rigid shift
+    splits_rig = 10      # for parallelization split the movies in  num_splits chuncks across time
+    strides = (48, 48)   # start a new patch for pw-rigid motion correction every x pixels
+    overlaps = (24, 24)  # overlap between pathes (size of patch strides+overlaps)
+    # for parallelization split the movies in  num_splits chuncks across time
+    # (remember that it should hold that length_movie/num_splits_to_process_rig>100)
+    splits_els = 10
+    upsample_factor_grid = 4    # upsample factor to avoid smearing when merging patches
+    # maximum deviation allowed for patch with respect to rigid shifts
+    max_deviation_rigid = 3
+    
+    # parameters for source extraction and deconvolution
+    p = 1               # order of the autoregressive system
+    K = None            # upper bound on number of components per patch, in general None
+    gSig = 3            # gaussian width of a 2D gaussian kernel, which approximates a neuron
+    gSiz = 13           # average diameter of a neuron, in general 4*gSig+1
+    merge_thresh = .7   # merging threshold, max correlation allowed
+    rf = 40             # half-size of the patches in pixels. e.g., if rf=40, patches are 80x80
+    stride_cnmf = 20    # amount of overlap between the patches in pixels
+    #                     (keep it at least large as gSiz, i.e 4 times the neuron size gSig)
+    tsub = 2            # downsampling factor in time for initialization,
+    #                     increase if you have memory problems
+    ssub = 1            # downsampling factor in space for initialization,
+    #                     increase if you have memory problems
+    Ain = None          # if you want to initialize with some preselected components
+    #                     you can pass them here as boolean vectors
+    low_rank_background = None  # None leaves background of each patch intact,
+    #                             True performs global low-rank approximation 
+    gnb = -1            # number of background components (rank) if positive,
+    #                     else exact ring model with following settings
+    #                         gnb=-2: Return background as b and W
+    #                         gnb=-1: Return full rank background B
+    #                         gnb= 0: Don't return background
+    nb_patch = -1       # number of background components (rank) per patch,
+    #                     use 0 or -1 for exact background of ring model (cf. gnb)
+    min_corr = .8       # min peak value from correlation image
+    min_pnr = 10        # min peak to noise ration from PNR image
+    ssub_B = 2          # additional downsampling factor in space for background
+    ring_size_factor = 1.4  # radius of ring is gSiz*ring_size_factor
+    
+    # parameters for component evaluation
+    min_SNR = 3            # adaptive way to set threshold on the transient size
+    r_values_min = 0.85    # threshold on space consistency (if you lower more components
+    #                        will be accepted, potentially with worst quality)
 
 #%% start the cluster
-try:
-    dview.terminate()  # stop it if it was running
-except:
-    pass
-
-c, dview, n_processes = cm.cluster.setup_cluster(backend='local',  # use this one
-                                                 n_processes=24,  # number of process to use, if you go out of memory try to reduce this one
-                                                 single_thread=False)
+    try:
+        dview.terminate()  # stop it if it was running
+    except:
+        pass
+    
+    c, dview, n_processes = cm.cluster.setup_cluster(backend='local',  # use this one
+                                                     n_processes=24,  # number of process to use, if you go out of memory try to reduce this one
+                                                     single_thread=False)
 
 #%% download demo file
-fnames = [download_demo(fnames[0])]
-filename_reorder = fnames
-
+    fnames = [download_demo(fnames[0])]
+    filename_reorder = fnames
 
 #%% MOTION CORRECTION
-if do_motion_correction_nonrigid or do_motion_correction_rigid:
-    # do motion correction rigid
-    mc = motion_correct_oneP_rigid(fnames,
-                                   gSig_filt=gSig_filt,
-                                   max_shifts=max_shifts,
-                                   dview=dview,
-                                   splits_rig=splits_rig,
-                                   save_movie=not(do_motion_correction_nonrigid)
-                                   )
-
-    new_templ = mc.total_template_rig
-
-    plt.subplot(1, 2, 1)
-    plt.imshow(new_templ)  # % plot template
-    plt.subplot(1, 2, 2)
-    plt.plot(mc.shifts_rig)  # % plot rigid shifts
-    plt.legend(['x shifts', 'y shifts'])
-    plt.xlabel('frames')
-    plt.ylabel('pixels')
-
-    # borders to eliminate from movie because of motion correction
-    bord_px = np.ceil(np.max(np.abs(mc.shifts_rig))).astype(np.int)
-    filename_reorder = mc.fname_tot_rig
-
-    # do motion correction nonrigid
-    if do_motion_correction_nonrigid:
-        mc = motion_correct_oneP_nonrigid(
-            fnames,
-            gSig_filt=gSig_filt,
-            max_shifts=max_shifts,
-            strides=strides,
-            overlaps=overlaps,
-            splits_els=splits_els,
-            upsample_factor_grid=upsample_factor_grid,
-            max_deviation_rigid=max_deviation_rigid,
-            dview=dview,
-            splits_rig=None,
-            save_movie=True,  # whether to save movie in memory mapped format
-            new_templ=new_templ  # template to initialize motion correction
-        )
-
-        filename_reorder = mc.fname_tot_els
-        bord_px = np.ceil(
-            np.maximum(np.max(np.abs(mc.x_shifts_els)),
-                       np.max(np.abs(mc.y_shifts_els)))).astype(np.int)
-
-# create memory mappable file in the right order on the hard drive (C order)
-fname_new = cm.save_memmap_each(
-    filename_reorder,
-    base_name='memmap_',
-    order='C',
-    border_to_0=bord_px,
-    dview=dview)
-fname_new = cm.save_memmap_join(fname_new, base_name='memmap_', dview=dview)
-
-
-# load memory mappable file
-Yr, dims, T = cm.load_memmap(fname_new)
-Y = Yr.T.reshape((T,) + dims, order='F')
+    if do_motion_correction_nonrigid or do_motion_correction_rigid:
+        # do motion correction rigid
+        mc = motion_correct_oneP_rigid(fnames,
+                                       gSig_filt=gSig_filt,
+                                       max_shifts=max_shifts,
+                                       dview=dview,
+                                       splits_rig=splits_rig,
+                                       save_movie=not(do_motion_correction_nonrigid)
+                                       )
+    
+        new_templ = mc.total_template_rig
+    
+        plt.subplot(1, 2, 1)
+        plt.imshow(new_templ)  # % plot template
+        plt.subplot(1, 2, 2)
+        plt.plot(mc.shifts_rig)  # % plot rigid shifts
+        plt.legend(['x shifts', 'y shifts'])
+        plt.xlabel('frames')
+        plt.ylabel('pixels')
+    
+        # borders to eliminate from movie because of motion correction
+        bord_px = np.ceil(np.max(np.abs(mc.shifts_rig))).astype(np.int)
+        filename_reorder = mc.fname_tot_rig
+    
+        # do motion correction nonrigid
+        if do_motion_correction_nonrigid:
+            mc = motion_correct_oneP_nonrigid(
+                fnames,
+                gSig_filt=gSig_filt,
+                max_shifts=max_shifts,
+                strides=strides,
+                overlaps=overlaps,
+                splits_els=splits_els,
+                upsample_factor_grid=upsample_factor_grid,
+                max_deviation_rigid=max_deviation_rigid,
+                dview=dview,
+                splits_rig=None,
+                save_movie=True,  # whether to save movie in memory mapped format
+                new_templ=new_templ  # template to initialize motion correction
+            )
+    
+            filename_reorder = mc.fname_tot_els
+            bord_px = np.ceil(
+                np.maximum(np.max(np.abs(mc.x_shifts_els)),
+                           np.max(np.abs(mc.y_shifts_els)))).astype(np.int)
+    
+    # create memory mappable file in the right order on the hard drive (C order)
+    fname_new = cm.save_memmap_each(
+        filename_reorder,
+        base_name='memmap_',
+        order='C',
+        border_to_0=bord_px,
+        dview=dview)
+    fname_new = cm.save_memmap_join(fname_new, base_name='memmap_', dview=dview)
+    
+    
+    # load memory mappable file
+    Yr, dims, T = cm.load_memmap(fname_new)
+    Y = Yr.T.reshape((T,) + dims, order='F')
 #%% compute some summary images (correlation and peak to noise)
-# change swap dim if output looks weird, it is a problem with tiffile
-cn_filter, pnr = cm.summary_images.correlation_pnr(Y, gSig=gSig, swap_dim=False)
-# inspect the summary images and set the parameters
-inspect_correlation_pnr(cn_filter, pnr)
-# print parameters set above, modify them if necessary based on summary images
-print(min_corr) # min correlation of peak (from correlation image)
-print(min_pnr)  # min peak to noise ratio
-
+    # change swap dim if output looks weird, it is a problem with tiffile
+    cn_filter, pnr = cm.summary_images.correlation_pnr(Y, gSig=gSig, swap_dim=False)
+    # inspect the summary images and set the parameters
+    inspect_correlation_pnr(cn_filter, pnr)
+    # print parameters set above, modify them if necessary based on summary images
+    print(min_corr) # min correlation of peak (from correlation image)
+    print(min_pnr)  # min peak to noise ratio
 
 #%% RUN CNMF ON PATCHES
-cnm = cnmf.CNMF(
-    n_processes=n_processes,
-    method_init='corr_pnr',             # use this for 1 photon
-    k=K,
-    gSig=(gSig, gSig),
-    gSiz=(gSiz, gSiz),
-    merge_thresh=merge_thresh,
-    p=p,
-    dview=dview,
-    tsub=tsub,
-    ssub=ssub,
-    Ain=Ain,
-    rf=rf,
-    stride=stride_cnmf,
-    only_init_patch=True,               # just leave it as is
-    gnb=gnb,
-    nb_patch=nb_patch,
-    method_deconvolution='oasis',       # could use 'cvxpy' alternatively
-    low_rank_background=low_rank_background,
-    update_background_components=True,  # sometimes setting to False improve the results
-    min_corr=min_corr,
-    min_pnr=min_pnr,
-    normalize_init=False,               # just leave as is
-    center_psf=True,                    # leave as is for 1 photon
-    ssub_B=ssub_B,
-    ring_size_factor=ring_size_factor,
-    del_duplicates=True,                # whether to remove duplicates from initialization
-    border_pix=bord_px)                 # number of pixels to not consider in the borders
-cnm.fit(Y)
+    cnm = cnmf.CNMF(
+        n_processes=n_processes,
+        method_init='corr_pnr',             # use this for 1 photon
+        k=K,
+        gSig=(gSig, gSig),
+        gSiz=(gSiz, gSiz),
+        merge_thresh=merge_thresh,
+        p=p,
+        dview=dview,
+        tsub=tsub,
+        ssub=ssub,
+        Ain=Ain,
+        rf=rf,
+        stride=stride_cnmf,
+        only_init_patch=True,               # just leave it as is
+        gnb=gnb,
+        nb_patch=nb_patch,
+        method_deconvolution='oasis',       # could use 'cvxpy' alternatively
+        low_rank_background=low_rank_background,
+        update_background_components=True,  # sometimes setting to False improve the results
+        min_corr=min_corr,
+        min_pnr=min_pnr,
+        normalize_init=False,               # just leave as is
+        center_psf=True,                    # leave as is for 1 photon
+        ssub_B=ssub_B,
+        ring_size_factor=ring_size_factor,
+        del_duplicates=True,                # whether to remove duplicates from initialization
+        border_pix=bord_px)                 # number of pixels to not consider in the borders
+    cnm.fit(Y)
 
 
 #%% DISCARD LOW QUALITY COMPONENTS
-idx_components, idx_components_bad, comp_SNR, r_values, pred_CNN = \
-    estimate_components_quality_auto(
-        Y, cnm.A, cnm.C, cnm.b, cnm.f, cnm.YrA, frate,
-        decay_time, gSig, dims, dview=dview,
-        min_SNR=min_SNR, r_values_min=r_values_min, use_cnn=False)
-
-print(' ***** ')
-print((len(cnm.C)))
-print((len(idx_components)))
-
-cm.stop_server(dview=dview)
-
+    idx_components, idx_components_bad, comp_SNR, r_values, pred_CNN = \
+        estimate_components_quality_auto(
+            Y, cnm.A, cnm.C, cnm.b, cnm.f, cnm.YrA, frate,
+            decay_time, gSig, dims, dview=dview,
+            min_SNR=min_SNR, r_values_min=r_values_min, use_cnn=False)
+    
+    print(' ***** ')
+    print((len(cnm.C)))
+    print((len(idx_components)))
+    
+    cm.stop_server(dview=dview)
 
 #%% PLOT COMPONENTS
-if display_images:
-    plt.figure(figsize=(12, 6))
-    plt.subplot(121)
-    crd_good = cm.utils.visualization.plot_contours(
-        cnm.A[:, idx_components], cn_filter, thr=.8, vmax=0.95)
-    plt.title('Contour plots of accepted components')
-    plt.subplot(122)
-    crd_bad = cm.utils.visualization.plot_contours(
-        cnm.A[:, idx_components_bad], cn_filter, thr=.8, vmax=0.95)
-    plt.title('Contour plots of rejected components')
+    if display_images:
+        plt.figure(figsize=(12, 6))
+        plt.subplot(121)
+        crd_good = cm.utils.visualization.plot_contours(
+            cnm.A[:, idx_components], cn_filter, thr=.8, vmax=0.95)
+        plt.title('Contour plots of accepted components')
+        plt.subplot(122)
+        crd_bad = cm.utils.visualization.plot_contours(
+            cnm.A[:, idx_components_bad], cn_filter, thr=.8, vmax=0.95)
+        plt.title('Contour plots of rejected components')
 
 #%% VISUALIZE IN DETAILS COMPONENTS
-    cm.utils.visualization.view_patches_bar(
-        Yr, cnm.A[:, idx_components], cnm.C[idx_components], cnm.b, cnm.f,
-        dims[0], dims[1], YrA=cnm.YrA[idx_components], img=cn_filter)
+        cm.utils.visualization.view_patches_bar(
+            Yr, cnm.A[:, idx_components], cnm.C[idx_components], cnm.b, cnm.f,
+            dims[0], dims[1], YrA=cnm.YrA[idx_components], img=cn_filter)
 
 
 #%% MOVIES
-if display_images:
-    B = cnm.b.dot(cnm.f)
-    if 'sparse' in str(type(B)):
-        B = B.toarray()
-# denoised movie
-    cm.movie(np.reshape(cnm.A.tocsc()[:, idx_components].dot(cnm.C[idx_components]) + B,
-                        dims + (-1,), order='F').transpose(2, 0, 1)).play(magnification=3, gain=1.)
-# only neurons
-    cm.movie(np.reshape(cnm.A.tocsc()[:, idx_components].dot(
-        cnm.C[idx_components]), dims + (-1,), order='F').transpose(2, 0, 1)
-    ).play(magnification=3, gain=10.)
-# only the background
-    cm.movie(np.reshape(B, dims + (-1,), order='F').transpose(2, 0, 1)
-             ).play(magnification=3, gain=1.)
-# residuals
-    cm.movie(np.array(Y) - np.reshape(cnm.A.tocsc()[:, :].dot(cnm.C[:]) + B,
-                                      dims + (-1,), order='F').transpose(2, 0, 1)
-             ).play(magnification=3, gain=10., fr=10)
-# eventually, you can rerun the algorithm on the residuals
-    plt.imshow(cm.movie(np.array(Y) - np.reshape(cnm.A.tocsc()[:, :].dot(cnm.C[:]) + B,
-                                                 dims + (-1,), order='F').transpose(2, 0, 1)
-                        ).local_correlations(swap_dim=False))
+    if display_images:
+        B = cnm.b.dot(cnm.f)
+        if 'sparse' in str(type(B)):
+            B = B.toarray()
+    # denoised movie
+        cm.movie(np.reshape(cnm.A.tocsc()[:, idx_components].dot(cnm.C[idx_components]) + B,
+                            dims + (-1,), order='F').transpose(2, 0, 1)).play(magnification=3, gain=1.)
+    # only neurons
+        cm.movie(np.reshape(cnm.A.tocsc()[:, idx_components].dot(
+            cnm.C[idx_components]), dims + (-1,), order='F').transpose(2, 0, 1)
+        ).play(magnification=3, gain=10.)
+    # only the background
+        cm.movie(np.reshape(B, dims + (-1,), order='F').transpose(2, 0, 1)
+                 ).play(magnification=3, gain=1.)
+    # residuals
+        cm.movie(np.array(Y) - np.reshape(cnm.A.tocsc()[:, :].dot(cnm.C[:]) + B,
+                                          dims + (-1,), order='F').transpose(2, 0, 1)
+                 ).play(magnification=3, gain=10., fr=10)
+    # eventually, you can rerun the algorithm on the residuals
+        plt.imshow(cm.movie(np.array(Y) - np.reshape(cnm.A.tocsc()[:, :].dot(cnm.C[:]) + B,
+                                                     dims + (-1,), order='F').transpose(2, 0, 1)
+                            ).local_correlations(swap_dim=False))
+
+#%%
+# This is to mask the differences between running this demo in Spyder
+# versus from the CLI
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This diff does some mild trickery to get our demos running the same way under the program model and the notebook model.

As a notebook, each cell is "pasted over" to the interpreter outside of function context. In this case, the cell boundaries are crafted so there is a main() function that just does a pass. In this case, Spyder manages multiprocessing so we don't need main() block protection.

As a program, it's parsed in a way where there's a long main() function that is invoked (with __main__ gating) at the end. This gating protects the code on platforms where forkserver/spawns would otherwise do a forkbomb, getting them to behave correctly (Windows was particularly affected).

Provided we maintain the demos in this form, this is a viable path forward that entirely eliminates self-forkbombing as a concern (and Windows demos work from the commandline again).

I have tested this code from the CLI and spyder on Linux, and from the commandline on Windows.

Apologies for people who have to manage a merge of any pending changes to the notebooks; that will not be pretty.