### PR TITLE
add quality evaluation in the object

### DIFF
--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -35,7 +35,7 @@ from .initialization import initialize_components, imblur
 from .merging import merge_components
 from .spatial import update_spatial_components
 from .temporal import update_temporal_components, constrained_foopsi_parallel
-from .deconvolution import constrained_foopsi
+from caiman.components_evaluation import estimate_components_quality_auto, select_components_from_metrics
 from .map_reduce import run_CNMF_patches
 from .oasis import OASIS
 import caiman
@@ -1343,4 +1343,168 @@ class CNMF(object):
         self.neuron_sn = [results[6][i] for i in order]
         self.lam = [results[8][i] for i in order]
         self.YrA = F - self.C
+        return self
+
+    def evaluate_components(self, imgs, fr=None, decay_time=None, min_SNR=None,
+                            rval_thr=None, use_cnn=None, min_cnn_thr=None):
+        """Computes the quality metrics for each component and stores the
+        indeces of the components that pass user specified thresholds. The
+        various thresholds and parameters can be passed as inputs. If left
+        empty then they are read from self.options['quality']
+        Parameters:
+        -----------
+        imgs: np.array (possibly memory mapped, t,x,y[,z])
+            Imaging data
+
+        fr: float
+            Imaging rate
+
+        decay_time: float
+            length of decay of typical transient (in seconds)
+
+        min_SNR: float
+            trace SNR threshold
+
+        rval_thr: float
+            space correlation threshold
+
+        use_cnn: bool
+            flag for using the CNN classifier
+
+        min_cnn_thr: float
+            CNN classifier threshold
+
+        Returns:
+        --------
+        self: CNMF object
+            self.idx_components: np.array
+                indeces of accepted components
+            self.idx_components_bad: np.array
+                indeces of rejected components
+            self.SNR_comp: np.array
+                SNR values for each temporal trace
+            self.r_values: np.array
+                space correlation values for each component
+            self.cnn_preds: np.array
+                CNN classifier values for each component
+        """
+        dims = imgs.shape[1:]
+        fr = self.options['quality']['fr'] if fr is None else fr
+        decay_time = (self.options['quality']['decay_time']
+                      if decay_time is None else decay_time)
+        min_SNR = (self.options['quality']['min_SNR']
+                   if min_SNR is None else min_SNR)
+        rval_thr = (self.options['quality']['rval_thr']
+                    if rval_thr is None else rval_thr)
+        use_cnn = (self.options['quality']['use_cnn']
+                   if use_cnn is None else use_cnn)
+        min_cnn_thr = (self.options['quality']['min_cnn_thr']
+                       if min_cnn_thr is None else min_cnn_thr)
+
+        idx_components, idx_components_bad, SNR_comp, r_values, cnn_preds = \
+        estimate_components_quality_auto(imgs, self.A, self.C, self.b, self.f,
+                                         self.YrA, fr, decay_time, self.gSig,
+                                         dims, dview=self.dview,
+                                         min_SNR=min_SNR,
+                                         r_values_min=rval_thr,
+                                         use_cnn=use_cnn,
+                                         thresh_cnn_min=min_cnn_thr)
+        self.idx_components = idx_components
+        self.idx_components_bad = idx_components_bad
+        self.SNR_comp = SNR_comp
+        self.r_values = r_values
+        self.cnn_preds = cnn_preds
+
+        return self
+
+    def filter_components(self, imgs, fr=None, decay_time=None, min_SNR=None,
+                          SNR_lowest=None, rval_thr=None, rval_lowest=None,
+                          use_cnn=None, min_cnn_thr=None,
+                          cnn_lowest=None, gSig_range=None):
+        """Filters components based on given thresholds without re-computing
+        the quality metrics. If the quality metrics are not present then it 
+        calls self.evaluate components.
+        Parameters:
+        -----------
+        imgs: np.array (possibly memory mapped, t,x,y[,z])
+            Imaging data
+
+        fr: float
+            Imaging rate
+
+        decay_time: float
+            length of decay of typical transient (in seconds)
+
+        min_SNR: float
+            trace SNR threshold
+
+        SNR_lowest: float
+            minimum required trace SNR
+
+        rval_thr: float
+            space correlation threshold
+
+        rval_lowest: float
+            minimum required space correlation
+
+        use_cnn: bool
+            flag for using the CNN classifier
+
+        min_cnn_thr: float
+            CNN classifier threshold
+
+        cnn_lowest: float
+            minimum required CNN threshold
+
+        gSig_range: list
+            gSig scale values for CNN classifier
+
+        Returns:
+        --------
+        self: CNMF object
+            self.idx_components: np.array
+                indeces of accepted components
+            self.idx_components_bad: np.array
+                indeces of rejected components
+            self.SNR_comp: np.array
+                SNR values for each temporal trace
+            self.r_values: np.array
+                space correlation values for each component
+            self.cnn_preds: np.array
+                CNN classifier values for each component
+        """
+        dims = imgs.shape[1:]
+        fr = self.options['quality']['fr'] if fr is None else fr
+        decay_time = (self.options['quality']['decay_time']
+                      if decay_time is None else decay_time)
+        min_SNR = (self.options['quality']['min_SNR']
+                   if min_SNR is None else min_SNR)
+        SNR_lowest = (self.options['quality']['SNR_lowest']
+                      if SNR_lowest is None else SNR_lowest)
+        rval_thr = (self.options['quality']['rval_thr']
+                    if rval_thr is None else rval_thr)
+        rval_lowest = (self.options['quality']['rval_lowest']
+                       if rval_lowest is None else rval_lowest)
+        use_cnn = (self.options['quality']['use_cnn']
+                   if use_cnn is None else use_cnn)
+        min_cnn_thr = (self.options['quality']['min_cnn_thr']
+                       if min_cnn_thr is None else min_cnn_thr)
+        cnn_lowest = (self.options['quality']['cnn_lowest']
+                      if cnn_lowest is None else cnn_lowest)
+        gSig_range = (self.options['quality']['gSig_range']
+                      if gSig_range is None else gSig_range)
+
+        if not hasattr(self, 'idx_components'):
+            self.evaluate_components(imgs, fr=fr, decay_time=decay_time,
+                                     min_SNR=min_SNR, rval_thr=rval_thr,
+                                     use_cnn=use_cnn,
+                                     min_cnn_thr=min_cnn_thr)
+
+        self.idx_components, self.idx_components_bad, self.cnn_preds = \
+        select_components_from_metrics(self.A, dims, self.gSig, self.r_values,
+                                       self.SNR_comp, rval_thr, rval_lowest,
+                                       min_SNR, SNR_lowest, min_cnn_thr,
+                                       cnn_lowest, use_cnn,
+                                       gSig_range)
+
         return self

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -49,80 +49,81 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], gSiz=None, ssub=2, tsub=2, p
     by the dictionary default options
 
     PRE-PROCESS PARAMS#############
-    sn: None,
-        noise level for each pixel
 
-    noise_range: [0.25, 0.5]
-             range of normalized frequencies over which to average
-
-    noise_method': 'mean'
-             averaging method ('mean','median','logmexp')
-
-    max_num_samples_fft': 3*1024
-
-    n_pixels_per_process: 1000
-
-    compute_g': False
-        flag for estimating global time constant
-
-    p : 2
-         order of AR indicator dynamics
-
-    lags: 5
-        number of autocovariance lags to be considered for time constant estimation
-
-    include_noise: False
-            flag for using noise values when estimating g
-
-    pixels: None
-         pixels to be excluded due to saturation
-
-    check_nan: True
+        sn: None,
+            noise level for each pixel
+    
+        noise_range: [0.25, 0.5]
+                 range of normalized frequencies over which to average
+    
+        noise_method': 'mean'
+                 averaging method ('mean','median','logmexp')
+    
+        max_num_samples_fft': 3*1024
+    
+        n_pixels_per_process: 1000
+    
+        compute_g': False
+            flag for estimating global time constant
+    
+        p : 2
+             order of AR indicator dynamics
+    
+        lags: 5
+            number of autocovariance lags to be considered for time constant estimation
+    
+        include_noise: False
+                flag for using noise values when estimating g
+    
+        pixels: None
+             pixels to be excluded due to saturation
+    
+        check_nan: True
 
     INIT PARAMS###############
 
-    K:     30
-        number of components
-
-    gSig: [5, 5]
-          size of bounding box
-
-    gSiz: [int(round((x * 2) + 1)) for x in gSig],
-
-    ssub:   2
-        spatial downsampling factor
-
-    tsub:   2
-        temporal downsampling factor
-
-    nIter: 5
-        number of refinement iterations
-
-    kernel: None
-        user specified template for greedyROI
-
-    maxIter: 5
-        number of HALS iterations
-
-    method: method_init
-        can be greedy_roi or sparse_nmf, local_NMF
-
-    max_iter_snmf : 500
-
-    alpha_snmf: 10e2
-
-    sigma_smooth_snmf : (.5,.5,.5)
-
-    perc_baseline_snmf: 20
-
-    nb:  1
-        number of background components
-
-    normalize_init:
-        whether to pixelwise equalize the movies during initialization
-
-    options_local_NMF:
-        dictionary with parameters to pass to local_NMF initializer
+        K:     30
+            number of components
+    
+        gSig: [5, 5]
+              size of bounding box
+    
+        gSiz: [int(round((x * 2) + 1)) for x in gSig],
+    
+        ssub:   2
+            spatial downsampling factor
+    
+        tsub:   2
+            temporal downsampling factor
+    
+        nIter: 5
+            number of refinement iterations
+    
+        kernel: None
+            user specified template for greedyROI
+    
+        maxIter: 5
+            number of HALS iterations
+    
+        method: method_init
+            can be greedy_roi or sparse_nmf, local_NMF
+    
+        max_iter_snmf : 500
+    
+        alpha_snmf: 10e2
+    
+        sigma_smooth_snmf : (.5,.5,.5)
+    
+        perc_baseline_snmf: 20
+    
+        nb:  1
+            number of background components
+    
+        normalize_init:
+            whether to pixelwise equalize the movies during initialization
+    
+        options_local_NMF:
+            dictionary with parameters to pass to local_NMF initializer
 
     SPATIAL PARAMS##########
 
@@ -171,7 +172,7 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], gSiz=None, ssub=2, tsub=2, p
             'lasso_lars' lasso lars function from scikit learn
             'lasso_lars_old' lasso lars from old implementation, will be deprecated
 
-        TEMPORAL PARAMS###########
+    TEMPORAL PARAMS###########
 
         ITER: 2
             block coordinate descent iterations
@@ -347,6 +348,18 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], gSiz=None, ssub=2, tsub=2, p
     }
     options['merging'] = {
         'thr': thr,
+    }
+    options['quality'] = {
+        'decay_time': 0.5,  # length of decay of typical transient (in seconds)
+        'min_SNR': 2.5,  # transient SNR threshold
+        'SNR_lowest': 0.5,  # minimum accepted SNR value
+        'rval_thr': 0.8,  # space correlation threshold
+        'rval_lowest': -1,  # minimum accepted space correlation
+        'fr': 30,  # imaging frame rate
+        'use_cnn': True,  # use CNN based classifier
+        'min_cnn_thr': 0.9,  # threshold for CNN classifier
+        'cnn_lowest': 0.1,  # minimum accepted value for CNN classifier
+        'gSig_range': None  # range for gSig scale for CNN classifier
     }
     return options
 

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -210,6 +210,39 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], gSiz=None, ssub=2, tsub=2, p
 
         block_size : block_size
             number of pixels to process at the same time for dot product. Make it smaller if memory problems
+            
+    QUALITY EVALUATION PARAMETERS###########
+
+        fr: 30
+            Imaging rate
+
+        decay_time: 0.5
+            length of decay of typical transient (in seconds)
+
+        min_SNR: 2.5
+            trace SNR threshold
+
+        SNR_lowest: 0.5
+            minimum required trace SNR
+
+        rval_thr: 0.8
+            space correlation threshold
+
+        rval_lowest: -1
+            minimum required space correlation
+
+        use_cnn: True
+            flag for using the CNN classifier
+
+        min_cnn_thr: 0.9
+            CNN classifier threshold
+
+        cnn_lowest: 0.1
+            minimum required CNN threshold
+
+        gSig_range: None
+            gSig scale values for CNN classifier
+    
     """
 
     if type(Y) is tuple:


### PR DESCRIPTION
There are two new methods for the cnmf object:

- `cnmf.evaluate_components` will call `estimate_components_quality_auto`
- `cnmf.filter_components` will adjust `idx_components` and `idx_components_bad` based on new threshold values without re-computing the metrics. It uses `select_components_from_metrics` which unfortunately calls the cnn classifier every time.

The various threshold parameters can be passed in as inputs. If they're not provided defaults values are being read from `cnmf.options['quality']` which is newly added.