### PR TITLE
enabling sliced cnmf

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -512,15 +512,18 @@ def parallel_dot_product(A, b, block_size=5000, dview=None, transpose=False, num
     if block_size < d1:
         for idx in range(0, d1 - block_size, block_size):
             idx_to_pass = list(range(idx, idx + block_size))
-            pars.append([A.filename, idx_to_pass, b, transpose])
+            #pars.append([A.filename, idx_to_pass, b, transpose])
+            pars.append([A, idx_to_pass, b, transpose])
 
         if (idx + block_size) < d1:
             idx_to_pass = list(range(idx + block_size, d1))
-            pars.append([A.filename, idx_to_pass, b, transpose])
+            #pars.append([A.filename, idx_to_pass, b, transpose])
+            pars.append([A, idx_to_pass, b, transpose])
 
     else:
         idx_to_pass = list(range(d1))
-        pars.append([A.filename, idx_to_pass, b, transpose])
+        #pars.append([A.filename, idx_to_pass, b, transpose])
+        pars.append([A, idx_to_pass, b, transpose])
 
     print('Start product')
     b = pickle.loads(b)
@@ -577,8 +580,13 @@ def dot_place_holder(par):
     # todo: todocument
 
     import pickle
+    import pdb
+    #pdb.set_trace()
     A_name, idx_to_pass, b_, transpose = par
-    A_, _, _ = load_memmap(A_name)
+    if isinstance(A_name, str):
+        A_, _, _ = load_memmap(A_name)
+    else:
+        A_ = A_name
     b_ = pickle.loads(b_).astype(np.float32)
 
     print((idx_to_pass[-1]))

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -394,11 +394,11 @@ class CNMF(object):
         print((T,) + dims)
 
         # Make sure filename is pointed correctly (numpy sets it to None sometimes)
-        try:
+        if images.filename is not None:
             Y.filename = images.filename
             Yr.filename = images.filename
-        except AttributeError:  # if no memmapping cause working with small data
-            pass
+        else: # if no memmapping cause working with small data
+            print("Warning: images.filename has no value; this may cause issues later in CNMF")
 
         # update/set all options that depend on data dimensions
         # number of rows, columns [and depths]

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -563,7 +563,7 @@ class CNMF(object):
             if self.alpha_snmf is not None:
                 options['init_params']['alpha_snmf'] = self.alpha_snmf
 
-            A, C, YrA, b, f, sn, optional_outputs = run_CNMF_patches(images.filename, dims + (T,),
+            A, C, YrA, b, f, sn, optional_outputs = run_CNMF_patches(images, dims + (T,),
                                                                      options, rf=self.rf, stride=self.stride,
                                                                      dview=self.dview, memory_fact=self.memory_fact,
                                                                      gnb=self.gnb, border_pix=self.border_pix,

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -394,11 +394,14 @@ class CNMF(object):
         print((T,) + dims)
 
         # Make sure filename is pointed correctly (numpy sets it to None sometimes)
-        if images.filename is not None:
-            Y.filename = images.filename
-            Yr.filename = images.filename
-        else: # if no memmapping cause working with small data
-            print("Warning: images.filename has no value; this may cause issues later in CNMF")
+        try:
+            if images.filename is not None:
+                Y.filename = images.filename
+                Yr.filename = images.filename
+            else: # if no memmapping cause working with small data
+                print("Warning: images.filename has no value; this may cause issues later in CNMF")
+        except AttributeError: # We got a filename instead of an object, which is fine
+            pass
 
         # update/set all options that depend on data dimensions
         # number of rows, columns [and depths]

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -359,8 +359,8 @@ class CNMF(object):
         """
         This method uses the cnmf algorithm to find sources in data.
 
-        it is calling everyfunction from the cnmf folder
-        you can find out more at how the functions are called and how they are laid out at the ipython notebook
+        it calls every function from the cnmf folder
+        you can find out more at how the functions are called and how they are laid out in the ipython notebook
 
         Parameters:
         ----------
@@ -389,7 +389,7 @@ class CNMF(object):
         Y = np.transpose(images, list(range(1, len(dims) + 1)) + [0])
         Yr = np.transpose(np.reshape(images, (T, -1), order='F'))
         if np.isfortran(Yr):
-            raise Exception('The file is in F order, it should be in C order (see save_memmap function')
+            raise Exception('The file is in F order, it should be in C order - see save_memmap function')
 
         print((T,) + dims)
 
@@ -400,6 +400,7 @@ class CNMF(object):
                 Yr.filename = images.filename
             else: # if no memmapping cause working with small data
                 print("Warning: images.filename has no value; this may cause issues later in CNMF")
+                print("Warning: images object: " + str(images))
         except AttributeError: # We got a filename instead of an object, which is fine
             pass
 
@@ -426,12 +427,6 @@ class CNMF(object):
                 self.n_pixels_per_process, np.prod(dims) // self.n_processes))
         self.options['preprocess_params']['n_pixels_per_process'] = self.n_pixels_per_process
         self.options['spatial_params']['n_pixels_per_process'] = self.n_pixels_per_process
-
-#        if self.block_size is None:
-#            self.block_size = self.n_pixels_per_process
-#
-#        if self.num_blocks_per_run is None:
-#           self.num_blocks_per_run = 20
 
         # number of pixels to process at the same time for dot product. Make it
         # smaller if memory problems

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -104,6 +104,8 @@ def cnmf_patches(args_in):
                 file_name[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
         Yr, dims, timesteps = load_memmap(file_name)
         images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
+    elif file_name.filename is None:
+        raise Exception("Internal error: file_name.filename has no value in map_reduce")
     else:
         name_log = os.path.basename(
                 file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -105,7 +105,7 @@ def cnmf_patches(args_in):
         Yr, dims, timesteps = load_memmap(file_name)
         images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
     elif file_name.filename is None:
-        raise Exception("Internal error: file_name.filename has no value in map_reduce")
+        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + args_in + ")")
     else:
         name_log = os.path.basename(
                 file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -100,15 +100,17 @@ def cnmf_patches(args_in):
     #logger.setLevel(logging.INFO)
 
     if isinstance(file_name, str):
-        name_log = os.path.basename(
-                file_name[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
+        if file_name.filename is None:
+            name_log = os.path.basename(
+                    file_name[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1]) 
         Yr, dims, timesteps = load_memmap(file_name)
         images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
-    elif file_name.filename is None:
-        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + str(file_name) + ")")
+    #elif file_name.filename is None:
+        #raise Exception("Internal error: file_name.filename has no value in map_reduce(" + str(file_name) + ")")
     else:
-        name_log = os.path.basename(
-                file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
+        name_log = 'LOG_'
+#        name_log = os.path.basename(
+#                file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
         images = file_name
         dims, timesteps = file_name.shape[1:], file_name.shape[0]
 

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -105,7 +105,7 @@ def cnmf_patches(args_in):
         Yr, dims, timesteps = load_memmap(file_name)
         images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
     elif file_name.filename is None:
-        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + args_in + ")")
+        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + str(args_in) + ")")
     else:
         name_log = os.path.basename(
                 file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -105,7 +105,7 @@ def cnmf_patches(args_in):
         Yr, dims, timesteps = load_memmap(file_name)
         images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
     elif file_name.filename is None:
-        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + str(args_in) + ")")
+        raise Exception("Internal error: file_name.filename has no value in map_reduce(" + str(file_name) + ")")
     else:
         name_log = os.path.basename(
                 file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -88,10 +88,10 @@ def cnmf_patches(args_in):
     import logging
     from . import cnmf
     file_name, idx_, shapes, options = args_in
+    p = options['temporal_params']['p']
 
     logger = logging.getLogger(__name__)
-    name_log = os.path.basename(
-        file_name[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
+    
     #logger = logging.getLogger(name_log)
     #hdlr = logging.FileHandler('./' + name_log)
     #formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
@@ -99,13 +99,19 @@ def cnmf_patches(args_in):
     #logger.addHandler(hdlr)
     #logger.setLevel(logging.INFO)
 
-    p = options['temporal_params']['p']
+    if isinstance(file_name, str):
+        name_log = os.path.basename(
+                file_name[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
+        Yr, dims, timesteps = load_memmap(file_name)
+        images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
+    else:
+        name_log = os.path.basename(
+                file_name.filename[:-5]) + '_LOG_ ' + str(idx_[0]) + '_' + str(idx_[-1])
+        images = file_name
+        dims, timesteps = file_name.shape[1:], file_name.shape[0]
 
     logger.debug(name_log+'START')
-
     logger.debug(name_log+'Read file')
-    Yr, dims, timesteps = load_memmap(file_name)
-
     # slicing array (takes the min and max index in n-dimensional space and cuts the box they define)
     # for 2d a rectangle/square, for 3d a rectangular cuboid/cube, etc.
     upper_left_corner = min(idx_)
@@ -116,7 +122,6 @@ def cnmf_patches(args_in):
     # insert slice for timesteps, equivalent to :
     slices.insert(0, slice(timesteps))
 
-    images = np.reshape(Yr.T, [timesteps] + list(dims), order='F')
     if options['patch_params']['in_memory']:
         images = np.array(images[slices],dtype=np.float32)
     else:

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -216,9 +216,9 @@ def update_temporal_components(Y, A, b, Cin, fin, bl=None, c1=None, g=None, sn=N
     print('Generating residuals')
 #    dview_res = None if block_size >= 500 else dview
     if 'memmap' in str(type(Y)):
-
-        YA = parallel_dot_product(Y, A, dview=dview, block_size=block_size,
-                                  transpose=True, num_blocks_per_run=num_blocks_per_run) * spdiags(old_div(1., nA), 0, nr + nb, nr + nb)
+        import pdb
+        #pdb.set_trace()
+        YA = parallel_dot_product(Y, A, dview=dview, block_size=block_size,transpose=True, num_blocks_per_run=num_blocks_per_run) * spdiags(old_div(1., nA), 0, nr + nb, nr + nb)
     else:
         YA = (A.T.dot(Y).T) * spdiags(old_div(1., nA), 0, nr + nb, nr + nb)
 


### PR DESCRIPTION
This is not meant to be merged at the moment.

I made a few targeted changes to enable running cnmf on arbitrarily sliced parts of the datasets.
e.g., try running demo_caiman_basic with cnm.fit(images[:1000])
Essentially instead of passing the filename of the memory mapped object to each process it passed the sliced loaded file itself. 
Before merging, we'll need to check whether this creates overhead with respect to memory and/or speed with some big files. If not some cleaning up will be needed before pushing.