### PR TITLE
fix failing nosetests with new CNMFParms class

### DIFF
--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -82,10 +82,6 @@ class CNMF(object):
     @author andrea giovannucci
     """
 
-    def __init__(self, params):
-        assert isinstance(params, CNMFSetParms), "Input must be instance of CNMFParams"
-
-
     def __init__(self, n_processes, k=5, gSig=[4, 4], gSiz=None, merge_thresh=0.8, p=2, dview=None,
                  Ain=None, Cin=None, b_in=None, f_in=None, do_merge=True,
                  ssub=2, tsub=2, p_ssub=1, p_tsub=1, method_init='greedy_roi', alpha_snmf=None,

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -433,6 +433,23 @@ class CNMFSetParms(object):
         self.online['thresh_fitness_raw'] = scipy.special.log_ndtr(-self.online['min_SNR']) * self.online['N_samples_exceptionality']
         self.online['max_shifts'] = np.int(self.online['max_shifts']/self.online['ds_factor'])
 
+    def __eq__(self, other):
+
+        print('__eq__ being called in CNMFParms')
+        d1 = self.to_dict()
+        d2 = other.to_dict()
+
+        key_diff = np.setdiff1d(d1.keys(), d2.keys())
+        if len(key_diff) > 0:
+            return False
+        for k1,v1 in d1.items():
+            v2 = d2[k1]
+            if v1 != v2:
+                return False
+
+        print('__eq__ returning true...')
+        return True
+
     def to_dict(self):
         return {'spatial_params':self.spatial, 'temporal_params':self.temporal,
                 'init_params':self.init, 'preprocess_params':self.preprocess,

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -435,7 +435,6 @@ class CNMFSetParms(object):
 
     def __eq__(self, other):
 
-        print('__eq__ being called in CNMFParms')
         d1 = self.to_dict()
         d2 = other.to_dict()
 
@@ -447,7 +446,6 @@ class CNMFSetParms(object):
             if v1 != v2:
                 return False
 
-        print('__eq__ returning true...')
         return True
 
     def to_dict(self):


### PR DESCRIPTION
Nosetests were failing against ground truth because of the new CNMFParms class. The object instances were distinct, so the == operator was returning false. To fix this, we just needed to implement the __eq__ function in CNMFParms class.