### PR TITLE
1p background

### DIFF
--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -511,7 +511,7 @@ class CNMF(object):
             if self.params.get('init', 'center_psf'):  # merge taking best neuron
                 if self.params.get('patch', 'nb_patch') > 0:
 
-                    while len(self.merged_ROIs) > 0:
+                    while len(self.estimates.merged_ROIs) > 0:
                         self.merge_comps(Yr, mx=np.Inf, fast_merge=True)
 
                     print("update temporal")

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -533,10 +533,10 @@ class CNMF(object):
                                                        np.array([self.estimates.YrA[m].mean(0) for m in self.estimates.merged_ROIs])])
                     if self.params.get('init', 'nb') == 0:
                         self.estimates.W, self.estimates.b0 = compute_W(
-                            Yr, self.estimates.A, self.estimates.C, self.dims,
+                            Yr, self.estimates.A.toarray(), self.estimates.C, self.dims,
                             self.params.get('init', 'ring_size_factor') *
                             self.params.get('init', 'gSiz')[0],
-                            self.params.get('init', 'ssub_B'))
+                            ssub=self.params.get('init', 'ssub_B'))
             else:
                 
                 while len(self.estimates.merged_ROIs) > 0:

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -531,15 +531,12 @@ class CNMF(object):
                                                       np.unique(np.concatenate(self.estimates.merged_ROIs)))
                             self.estimates.YrA = np.concatenate([self.estimates.YrA[not_merged],
                                                        np.array([self.estimates.YrA[m].mean(0) for m in self.estimates.merged_ROIs])])
-                    import pdb;pdb.set_trace()
                     if self.params.get('init', 'nb') == 0:
-                        # self.estimates.b0 = Yr.mean(1) - self.estimates.A.dot(
-                        #     self.estimates.C.mean(1))
                         self.estimates.W, self.estimates.b0 = compute_W(
                             Yr, self.estimates.A, self.estimates.C, self.dims,
                             self.params.get('init', 'ring_size_factor') *
-                            np.array(self.params.get('init', 'gSiz')),
-                            ssub=self.params.get('init', 'ssub_B'))
+                            self.params.get('init', 'gSiz')[0],
+                            self.params.get('init', 'ssub_B'))
             else:
                 
                 while len(self.estimates.merged_ROIs) > 0:

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -44,7 +44,7 @@ from .estimates import Estimates
 from .utilities import update_order, normalize_AC, get_file_size
 from .params import CNMFParams
 from .pre_processing import preprocess_data
-from .initialization import initialize_components, imblur, downscale
+from .initialization import initialize_components, imblur, downscale, compute_W
 from .merging import merge_components
 from .spatial import update_spatial_components
 from .temporal import update_temporal_components, constrained_foopsi_parallel
@@ -531,6 +531,15 @@ class CNMF(object):
                                                       np.unique(np.concatenate(self.estimates.merged_ROIs)))
                             self.estimates.YrA = np.concatenate([self.estimates.YrA[not_merged],
                                                        np.array([self.estimates.YrA[m].mean(0) for m in self.estimates.merged_ROIs])])
+                    import pdb;pdb.set_trace()
+                    if self.params.get('init', 'nb') == 0:
+                        # self.estimates.b0 = Yr.mean(1) - self.estimates.A.dot(
+                        #     self.estimates.C.mean(1))
+                        self.estimates.W, self.estimates.b0 = compute_W(
+                            Yr, self.estimates.A, self.estimates.C, self.dims,
+                            self.params.get('init', 'ring_size_factor') *
+                            np.array(self.params.get('init', 'gSiz')),
+                            ssub=self.params.get('init', 'ssub_B'))
             else:
                 
                 while len(self.estimates.merged_ROIs) > 0:

--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -320,8 +320,6 @@ class Estimates(object):
         """
         if 'csc_matrix' not in str(type(self.A)):
             self.A = scipy.sparse.csc_matrix(self.A)
-        if 'array' not in str(type(self.b)):
-            self.b = self.b.toarray()
         if 'array' not in str(type(self.C)):
             self.C = self.C.toarray()
         if 'array' not in str(type(self.f)):
@@ -343,7 +341,8 @@ class Estimates(object):
         if self.neurons_sn is not None:
             self.neurons_sn = nA * self.neurons_sn
 
-        nB = np.sqrt(np.ravel((self.b**2).sum(axis=0)))
+        nB = np.sqrt(np.ravel((self.b.power(2) if scipy.sparse.issparse(self.b)
+                     else self.b**2).sum(axis=0)))
         nB_mat = scipy.sparse.spdiags(nB, 0, nB.shape[0], nB.shape[0])
         nB_inv_mat = scipy.sparse.spdiags(1. / nB, 0, nB.shape[0], nB.shape[0])
         self.b = self.b * nB_inv_mat

--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -322,7 +322,7 @@ class Estimates(object):
             self.A = scipy.sparse.csc_matrix(self.A)
         if 'array' not in str(type(self.C)):
             self.C = self.C.toarray()
-        if 'array' not in str(type(self.f)):
+        if 'array' not in str(type(self.f)) and self.f is not None:
             self.f = self.f.toarray()
 
         nA = np.sqrt(np.ravel(self.A.power(2).sum(axis=0)))
@@ -341,12 +341,13 @@ class Estimates(object):
         if self.neurons_sn is not None:
             self.neurons_sn = nA * self.neurons_sn
 
-        nB = np.sqrt(np.ravel((self.b.power(2) if scipy.sparse.issparse(self.b)
-                     else self.b**2).sum(axis=0)))
-        nB_mat = scipy.sparse.spdiags(nB, 0, nB.shape[0], nB.shape[0])
-        nB_inv_mat = scipy.sparse.spdiags(1. / nB, 0, nB.shape[0], nB.shape[0])
-        self.b = self.b * nB_inv_mat
-        self.f = nB_mat * self.f
+        if self.f is not None:  # 1p with exact ring-model
+            nB = np.sqrt(np.ravel((self.b.power(2) if scipy.sparse.issparse(self.b)
+                         else self.b**2).sum(axis=0)))
+            nB_mat = scipy.sparse.spdiags(nB, 0, nB.shape[0], nB.shape[0])
+            nB_inv_mat = scipy.sparse.spdiags(1. / nB, 0, nB.shape[0], nB.shape[0])
+            self.b = self.b * nB_inv_mat
+            self.f = nB_mat * self.f
         return self
 
     def select_components(self, idx_components=None, use_object=False):

--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -142,8 +142,6 @@ class Estimates(object):
         """
         if 'csc_matrix' not in str(type(self.A)):
             self.A = scipy.sparse.csc_matrix(self.A)
-        if 'array' not in str(type(self.b)):
-            self.b = self.b.toarray()
 
         plt.ion()
         nr, T = self.C.shape

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -169,10 +169,6 @@ try:
 except:
     def profile(a): return a
 
-if sys.version_info >= (3, 0):
-    def xrange(*args, **kwargs):
-        return iter(range(*args, **kwargs))
-
 
 def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter=5, maxIter=5, nb=1,
                           kernel=None, use_hals=True, normalize_init=True, img=None, method='greedy_roi',
@@ -1722,7 +1718,7 @@ def compute_W(Y, A, C, dims, radius, data_fits_in_memory=True, ssub=1, tsub=1):
     indices = []
     data = []
     indptr = [0]
-    for p in xrange(len(X)):
+    for p in range(len(X)):
         index = get_indices_of_pixels_on_ring(p)
         indices += list(index)
         B = Y[index] - A[index].dot(C) - \

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -306,7 +306,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None, memory_fact=1,
     if params.get('init', 'center_psf'):
         S_tot = np.zeros((count, T), dtype=np.float32)
     else:
-         S_tot = None
+        S_tot = None
     YrA_tot = np.zeros((count, T), dtype=np.float32)
     F_tot = np.zeros((max(0, num_patches * nb_patch), T), dtype=np.float32)
     mask = np.zeros(d, dtype=np.uint8)
@@ -339,19 +339,16 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None, memory_fact=1,
 
             if scipy.sparse.issparse(b):
                 b = scipy.sparse.csc_matrix(b)
-            for ii in range(np.shape(b)[-1]):
-                if scipy.sparse.issparse(b):
-                    bb = b[:, ii].toarray().ravel()
-                    nonzero = (bb != 0)
-                    b_tot.append(bb[nonzero])
-                    idx_tot_B.append(idx_[nonzero])
-                    idx_ptr_B.append(len(idx_[nonzero]))
-                else:
+                b_tot.append(b.data)
+                idx_ptr_B += list(b.indptr[1:] - b.indptr[:-1])
+                idx_tot_B.append(idx_[b.indices])
+            else:
+                for ii in range(np.shape(b)[-1]):
                     b_tot.append(b[:, ii])
                     idx_tot_B.append(idx_)
                     idx_ptr_B.append(len(idx_))
-                # F_tot[patch_id, :] = f[ii, :]
-                count_bgr += 1
+                    # F_tot[patch_id, :] = f[ii, :]
+            count_bgr += b.shape[-1]
             if nb_patch >= 0:
                 F_tot[patch_id * nb_patch:(patch_id + 1) * nb_patch] = f
             else:  # full background per patch

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -337,10 +337,19 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None, memory_fact=1,
             shapes_tot.append(shapes)
             mask[idx_] += 1
 
+            if scipy.sparse.issparse(b):
+                b = scipy.sparse.csc_matrix(b)
             for ii in range(np.shape(b)[-1]):
-                b_tot.append(b[:, ii])
-                idx_tot_B.append(idx_)
-                idx_ptr_B.append(len(idx_))
+                if scipy.sparse.issparse(b):
+                    bb = b[:, ii].toarray().ravel()
+                    nonzero = (bb != 0)
+                    b_tot.append(bb[nonzero])
+                    idx_tot_B.append(idx_[nonzero])
+                    idx_ptr_B.append(len(idx_[nonzero]))
+                else:
+                    b_tot.append(b[:, ii])
+                    idx_tot_B.append(idx_)
+                    idx_ptr_B.append(len(idx_))
                 # F_tot[patch_id, :] = f[ii, :]
                 count_bgr += 1
             if nb_patch >= 0:

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -419,7 +419,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None, memory_fact=1,
         f = None
     elif low_rank_background is None:
         b = Im.dot(B_tot)
-        f = scipy.sparse.csr_matrix(F_tot)
+        f = F_tot
         print("Leaving background components intact")
     elif low_rank_background:
         print("Compressing background components with a low rank NMF")

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -438,6 +438,12 @@ class CNMFParams(object):
         if self.init['gSiz'] is None:
             self.init['gSiz'] = [2*gs + 1 for gs in self.init['gSig']]
 
+        if gnb <= 0:
+            logging.warning("gnb={}, hence setting keys nb_patch and low_rank_background ".format(gnb) +
+                            "in group patch automatically.")
+            self.set('patch', {'nb_patch': gnb, 'low_rank_background': None})
+
+
     def set(self, group, val_dict, set_if_not_exists=False):
         """ Add key-value pairs to a group. Existing key-value pairs will be overwritten
             if specified in val_dict, but not deleted.

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -811,11 +811,9 @@ def view_patches_bar(Yr, A, C, b, f, d1, d2, YrA=None, img=None):
     pl.ion()
     if 'csc_matrix' not in str(type(A)):
         A = csc_matrix(A)
-    if 'array' not in str(type(b)):
-        b = b.toarray()
 
     nr, T = C.shape
-    nb = f.shape[0]
+    nb = 0 if f is None else f.shape[0]
     nA2 = np.sqrt(np.array(A.power(2).sum(axis=0))).squeeze()
 
     if YrA is None:

--- a/demos/general/demo_pipeline_cnmfE.py
+++ b/demos/general/demo_pipeline_cnmfE.py
@@ -149,14 +149,14 @@ def main():
     #                     increase if you have memory problems
     #                     you can pass them here as boolean vectors
     low_rank_background = None  # None leaves background of each patch intact,
-    #                             True performs global low-rank approximation 
-    gnb = -1            # number of background components (rank) if positive,
+    #                             True performs global low-rank approximation if gnb>0
+    gnb = 0             # number of background components (rank) if positive,
     #                     else exact ring model with following settings
     #                         gnb= 0: Return background as b and W
     #                         gnb=-1: Return full rank background B
     #                         gnb<-1: Don't return background
-    nb_patch = -1       # number of background components (rank) per patch,
-    #                     use 0 or -1 for exact background of ring model (cf. gnb)
+    nb_patch = 0        # number of background components (rank) per patch if gnb>0,
+    #                     else it is set automatically
     min_corr = .8       # min peak value from correlation image
     min_pnr = 10        # min peak to noise ration from PNR image
     ssub_B = 2          # additional downsampling factor in space for background


### PR DESCRIPTION
updates code for 1p background.

No matter whether using patches or not the following documentation in the demo now actually holds
    #                         gnb= 0: Return background as b and W
    #                         gnb=-1: Return full rank background B
    #                         gnb<-1: Don't return background

Added the option to return b and W also when using patches.
If the full rank background is returned, than as sparse b and dense f, with smart computation of b that avoids to ever use a dense pixel x pixel matrix.
Updates some visualization functions to work with the ring model background.