### PR TITLE
Remove future imports of things now included by def in Py3

### DIFF
--- a/SLURM/demo_slurm.py
+++ b/SLURM/demo_slurm.py
@@ -1,31 +1,24 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 #%%
+import ca_source_extraction as cse
+import glob
+from ipyparallel import Client
 import matplotlib as mpl
 mpl.use('TKAgg')
 from matplotlib import pyplot as plt
-# plt.ion()
-
-import sys
-import os
 import numpy as np
-import ca_source_extraction as cse
-
-# sys.path.append('../SPGL1_python_port')
-#%
-from time import time
+import os
+import psutil
+import pylab as pl
 from scipy.sparse import coo_matrix
-import tifffile
+import shutil
 import subprocess
+import sys
+from time import time
+import tifffile
 import time as tm
 from time import time
-import pylab as pl
-import psutil
-from ipyparallel import Client
-import shutil
-import glob
 
 #%%
 slurm_script = '/mnt/xfs1/home/agiovann/SOFTWARE/Constrained_NMF/SLURM/slurmStart.sh'

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -18,10 +18,6 @@ See Also:
 # \copyright GNU General Public License v2.0
 # \date Created on Tue Jun 30 20:56:07 2015 , Updated on Fri Aug 19 17:30:11 2016
 
-
-from __future__ import division
-from __future__ import print_function
-
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -7,8 +7,6 @@ Created on Thu Oct 22 13:22:26 2015
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 #%%
 from builtins import map
 from builtins import zip

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -22,7 +22,6 @@ author: Andrea Giovannucci
 """
 
 #%%
-from __future__ import print_function
 import cv2
 import h5py
 import numpy as np

--- a/caiman/base/traces.py
+++ b/caiman/base/traces.py
@@ -6,13 +6,12 @@ Spyder Editor
 
 author: agiovann
 """
-from __future__ import division
-from __future__ import print_function
 #%%
 from builtins import zip
 from builtins import str
 from builtins import range
 from past.utils import old_div
+
 import cv2
 import logging
 import numpy as np

--- a/caiman/behavior/behavior.py
+++ b/caiman/behavior/behavior.py
@@ -9,8 +9,6 @@ Created on Wed Mar 16 16:31:55 2016
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 #%%
 from builtins import zip
 from builtins import range

--- a/caiman/cluster.py
+++ b/caiman/cluster.py
@@ -14,7 +14,6 @@ Alongside each array x we ensure the value x.dtype which stores the data type.
 # \copyright GNU General Public License v2.0
 # \date Created on Thu Oct 20 12:07:09 2016
 
-from __future__ import print_function
 from builtins import zip
 from builtins import str
 from builtins import map

--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -7,8 +7,6 @@ Created on Thu Oct 20 12:12:34 2016
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 from builtins import range
 from past.utils import old_div
 
@@ -24,6 +22,7 @@ import warnings
 
 from caiman.paths import caiman_datadir
 from .utils.stats import mode_robust, mode_robust_fast
+
 try:
     cv2.setNumThreads(0)
 except:

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -7,12 +7,10 @@ Created on Thu Oct 20 11:33:35 2016
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
-from past.builtins import basestring
 from builtins import map
 from builtins import str
 from builtins import range
+from past.builtins import basestring
 from past.utils import old_div
 
 import ipyparallel as parallel

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -39,8 +39,6 @@ Copyright (C) 2011, the scikit-image team
 
 """
 
-from __future__ import division
-from __future__ import print_function
 from past.builtins import basestring
 #%%
 from builtins import zip

--- a/caiman/paths.py
+++ b/caiman/paths.py
@@ -4,10 +4,7 @@
 
 """
 
-from __future__ import print_function
-
 import os
-import sys # for sys.prefix
 
 def caiman_datadir():
 	"""

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -23,9 +23,6 @@ See Also:
 #\copyright GNU General Public License v2.0
 #\date Created on Fri Aug 26 15:44:32 2016
 
-from __future__ import division
-from __future__ import print_function
-
 from builtins import object
 from builtins import str
 

--- a/caiman/source_extraction/cnmf/cnmf_optional_outputs.py
+++ b/caiman/source_extraction/cnmf/cnmf_optional_outputs.py
@@ -12,8 +12,6 @@ Created on Fri Aug 26 15:44:32 2016
  
 
 """
-from __future__ import division
-from __future__ import print_function
 
 from builtins import str
 from builtins import object

--- a/caiman/source_extraction/cnmf/deconvolution.py
+++ b/caiman/source_extraction/cnmf/deconvolution.py
@@ -6,8 +6,6 @@
 Created on Tue Sep  1 16:11:25 2015
 @author: Eftychios A. Pnevmatikakis, based on an implementation by T. Machado,  Andrea Giovannucci & Ben Deverett
 """
-from __future__ import division
-from __future__ import print_function
 
 from builtins import range
 from past.utils import old_div

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -14,30 +14,29 @@ different set of methods like ICA PCA, greedy roi
 #\date Created on Tue Jun 30 21:01:17 2015
 #\author: Eftychios A. Pnevmatikakis
 
-from __future__ import division
-from __future__ import print_function
 from builtins import range
-from past.utils import old_div
+import cv2
+from math import sqrt
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
 import numpy as np
-from sklearn.decomposition import NMF, FastICA
-from skimage.morphology import disk
+from past.utils import old_div
+import scipy
 import scipy.ndimage as nd
 from scipy.ndimage.measurements import center_of_mass
 from scipy.ndimage.filters import correlate
+import scipy.sparse as spr
+from skimage.morphology import disk
 from skimage.transform import downscale_local_mean
 from skimage.transform import resize as resize_sk
-import scipy.sparse as spr
-import scipy
+from sklearn.decomposition import NMF, FastICA
+from sklearn.utils.extmath import randomized_svd, squared_norm
+import sys
+
 import caiman
 from caiman.source_extraction.cnmf.deconvolution import constrained_foopsi
 from caiman.source_extraction.cnmf.pre_processing import get_noise_fft, get_noise_welch
 from caiman.source_extraction.cnmf.spatial import circular_constraint, connectivity_constraint
-import cv2
-import sys
-import matplotlib.pyplot as plt
-import matplotlib.animation as animation
-from sklearn.utils.extmath import randomized_svd, squared_norm
-from math import sqrt
 
 try:
     cv2.setNumThreads(0)

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -14,8 +14,6 @@ Function for implementing parallel scalable segmentation of two photon imaging d
 #\copyright GNU General Public License v2.0
 #\date Created on Wed Feb 17 14:58:26 2016
 
-from __future__ import division
-from __future__ import print_function
 from builtins import zip
 from builtins import str
 from builtins import map

--- a/caiman/source_extraction/cnmf/merging.py
+++ b/caiman/source_extraction/cnmf/merging.py
@@ -10,13 +10,12 @@ Created on Tue Sep  8 16:23:57 2015
 #\version   1.0
 #\copyright GNU General Public License v2.0
 
-from __future__ import division
-from __future__ import print_function
 from builtins import range
-from past.utils import old_div
-from scipy.sparse import coo_matrix, csgraph, csc_matrix, lil_matrix
-import scipy
 import numpy as np
+from past.utils import old_div
+import scipy
+from scipy.sparse import coo_matrix, csgraph, csc_matrix, lil_matrix
+
 from .spatial import update_spatial_components, threshold_components
 from .temporal import update_temporal_components
 from .deconvolution import constrained_foopsi

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -14,9 +14,6 @@ imaging data in real time. In Advances in Neural Information Processing Systems
 @url http://papers.nips.cc/paper/6832-onacid-online-analysis-of-calcium-imaging-data-in-real-time
 """
 
-from __future__ import division
-from __future__ import print_function
-
 from builtins import map
 from builtins import range
 from builtins import str

--- a/caiman/source_extraction/cnmf/pre_processing.py
+++ b/caiman/source_extraction/cnmf/pre_processing.py
@@ -20,14 +20,11 @@ See Also:
 #\date Created on Tue Jun 30 21:01:17 2015
 
 
-from __future__ import division
-from __future__ import print_function
-
+import numpy as np
+import scipy
 import shutil
 import tempfile
 
-import numpy as np
-import scipy
 from builtins import map
 from builtins import range
 from ...mmapping import load_memmap

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -7,8 +7,6 @@ Created on Wed Aug 05 20:38:27 2015
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 # noinspection PyCompatibility
 from past.builtins import basestring
 from builtins import zip

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -5,8 +5,7 @@
 
 @author: agiovann
 """
-from __future__ import division
-from __future__ import print_function
+
 from builtins import str
 from builtins import map
 from builtins import range

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -19,9 +19,6 @@ See Also:
 # \copyright GNU General Public License v2.0
 # \date Created on Sat Sep 12 15:52:53 2015
 
-from __future__ import division
-from __future__ import print_function
-
 from builtins import str
 from builtins import range
 from past.utils import old_div

--- a/caiman/summary_images.py
+++ b/caiman/summary_images.py
@@ -19,15 +19,15 @@ See Also:
 # \date Created on Thu Oct 20 11:41:21 2016
 
 
-from __future__ import division
 from builtins import range
 
 import cv2
 import numpy as np
 from scipy.ndimage import convolve, generate_binary_structure
 from scipy.sparse import coo_matrix
-from caiman.source_extraction.cnmf.pre_processing import get_noise_fft
+
 import caiman as cm
+from caiman.source_extraction.cnmf.pre_processing import get_noise_fft
 
 #try:
 #    cv2.setNumThreads(0)

--- a/caiman/tests/comparison/create_gt.py
+++ b/caiman/tests/comparison/create_gt.py
@@ -17,8 +17,6 @@ caiman/tests/comparison/comparison.py
 # \author: Jeremie KALFON
 
 
-from __future__ import division
-from __future__ import print_function
 from builtins import str
 from builtins import range
 

--- a/caiman/tests/test_general.py
+++ b/caiman/tests/test_general.py
@@ -18,8 +18,6 @@ caiman/tests/comparison/comparison.py
 #\author: Jremie KALFON
 
 
-from __future__ import division
-from __future__ import print_function
 from builtins import str
 from builtins import range
 

--- a/caiman/utils/image_preprocessing_keras.py
+++ b/caiman/utils/image_preprocessing_keras.py
@@ -8,19 +8,17 @@ Can easily be extended to include new transformations,
 new preprocessing methods, etc...
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-
+from functools import partial
+import multiprocessing.pool
 import numpy as np
+import os
 import re
 from scipy import linalg
 import scipy.ndimage as ndi
 from six.moves import range
-import os
 import threading
 import warnings
-import multiprocessing.pool
-from functools import partial
+
 try:
     from keras import backend as K
 except:

--- a/caiman/utils/stats.py
+++ b/caiman/utils/stats.py
@@ -7,8 +7,6 @@ Created on Thu Oct 20 13:49:57 2016
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 from builtins import range
 from past.utils import old_div
 try:

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -8,27 +8,30 @@
 #\copyright GNU General Public License v2.0
 #\date Created on Tue Jun 30 21:01:17 2016
 #\author: andrea giovannucci
-from __future__ import division
-from __future__ import print_function
+
 from builtins import str
 from builtins import range
 from past.utils import old_div
+
 import base64
 import cv2
+from IPython.display import HTML
+from math import sqrt, ceil
+import matplotlib as mpl
+import matplotlib.cm as cm
+from matplotlib.widgets import Slider
 import numpy as np
 import pylab as pl
-from tempfile import NamedTemporaryFile
-from IPython.display import HTML
-import sys
-from warnings import warn
-from scipy.sparse import issparse, spdiags, coo_matrix, csc_matrix
-from matplotlib.widgets import Slider
-from ..base.rois import com
 from scipy.ndimage.measurements import center_of_mass
 from scipy.ndimage.filters import median_filter
-import matplotlib.cm as cm
-import matplotlib as mpl
-from math import sqrt, ceil
+from scipy.sparse import issparse, spdiags, coo_matrix, csc_matrix
+from skimage.measure import find_contours
+import sys
+from tempfile import NamedTemporaryFile
+from warnings import warn
+
+from ..base.rois import com
+from ..summary_images import local_correlations
 
 try:
     cv2.setNumThreads(0)
@@ -41,9 +44,6 @@ try:
     from bokeh.models import CustomJS, ColumnDataSource, Range1d
 except:
     print("Bokeh could not be loaded. Either it is not installed or you are not running within a notebook")
-
-from ..summary_images import local_correlations
-from skimage.measure import find_contours
 
 
 #%%

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import argparse
 import distutils.dir_util
 import filecmp

--- a/demos/general/demo_behavior.py
+++ b/demos/general/demo_behavior.py
@@ -7,8 +7,6 @@ Created on Sun Aug  6 11:43:39 2017
 @author: agiovann
 """
 
-from __future__ import division
-from __future__ import print_function
 from builtins import zip
 from builtins import str
 from builtins import map

--- a/demos/general/demo_caiman_basic.py
+++ b/demos/general/demo_caiman_basic.py
@@ -15,7 +15,6 @@ are tailored for that environment.
 
 """
 
-from __future__ import print_function
 from builtins import range
 
 import cv2

--- a/demos/general/demo_pipeline.py
+++ b/demos/general/demo_pipeline.py
@@ -14,9 +14,6 @@ copyright GNU General Public License v2.0
 authors: @agiovann and @epnev
 """
 
-from __future__ import division
-from __future__ import print_function
-
 import cv2
 import glob
 import logging

--- a/demos/general/demo_pipeline_cnmfE.py
+++ b/demos/general/demo_pipeline_cnmfE.py
@@ -7,9 +7,6 @@ of one photon microendoscopic calcium imaging data using the CaImAn package.
 Demo is also available as a jupyter notebook (see demo_pipeline_cnmfE.ipynb)
 """
 
-from __future__ import division
-from __future__ import print_function
-
 import logging
 import matplotlib.pyplot as plt
 import numpy as np

--- a/demos/notebooks/demo_motion_correction.ipynb
+++ b/demos/notebooks/demo_motion_correction.ipynb
@@ -21,8 +21,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
-    "from __future__ import print_function\n",
     "from builtins import zip\n",
     "from builtins import str\n",
     "from builtins import map\n",

--- a/demos/notebooks/demo_pipeline.ipynb
+++ b/demos/notebooks/demo_pipeline.ipynb
@@ -17,8 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
-    "from __future__ import print_function\n",
     "\n",
     "import bokeh.plotting as bpl\n",
     "import cv2\n",

--- a/demos/notebooks/demo_pipeline_cnmfE.ipynb
+++ b/demos/notebooks/demo_pipeline_cnmfE.ipynb
@@ -21,8 +21,6 @@
    "outputs": [],
    "source": [
     "#!/usr/bin/env python\n",
-    "from __future__ import division\n",
-    "from __future__ import print_function\n",
     "\n",
     "try:\n",
     "    get_ipython().magic(u'load_ext autoreload')\n",

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
 - tensorflow=1.4.0 # Must list before keras to preempt default keras backend
 - bokeh
 - cython
-- future
 - h5py
 - ipython
 - ipyparallel


### PR DESCRIPTION
In python3, our existing future imports are no longer necessary as they suggest Python3 style that is present by default in Python3. Now that we're not supporting Python2, this is all just cruft, so let's burn it.

