### PR TITLE
speed up OnACID by ~15% if testing to add multiple components

### DIFF
--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -401,16 +401,16 @@ class OnACID(object):
 
         if self.params.get('online', 'batch_update_suff_stat'):
         # faster update using minibatch of frames
-            if ((t + 1 - self.params.get('online', 'init_batch')) %
-                self.params.get('online', 'update_freq') == 0):
+            min_batch = min(self.params.get('online', 'update_freq'), mbs)
+            if ((t + 1 - self.params.get('online', 'init_batch')) % min_batch == 0):
 
-                #ccf = self.estimates.C_on[:self.M, t - self.params.get('online', 'update_freq') + 1:t + 1]
-                #y = self.estimates.Yr_buf.get_last_frames(self.params.get('online', 'update_freq'))
-                ccf = self.estimates.C_on[:self.M, t - mbs + 1:t + 1]
-                y = self.estimates.Yr_buf #.get_last_frames(mbs)
+                ccf = self.estimates.C_on[:self.M, t - min_batch + 1:t + 1]
+                y = self.estimates.Yr_buf.get_last_frames(min_batch)
+                # ccf = self.estimates.C_on[:self.M, t - mbs + 1:t + 1]
+                # y = self.estimates.Yr_buf #.get_last_frames(mbs)
 
                 # much faster: exploit that we only access CY[m, ind_pixels], hence update only these
-                n0 = mbs #self.params.get('online', 'update_freq')
+                n0 = min_batch
                 t0 = 0 * self.params.get('online', 'init_batch')
                 w1 = (t - n0 + t0) * 1. / (t + t0)  # (1 - 1./t)#mbs*1. / t
                 w2 = 1. / (t + t0)  # 1.*mbs /t

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -1402,6 +1402,7 @@ def get_candidate_components(sv, dims, Yres_buf, min_num_trial=3, gSig=(5, 5),
     Cin = []
     Cin_res = []
     idx = []
+    all_indices = []
     ijsig_all = []
     cnn_pos = []
     local_maxima = []
@@ -1459,7 +1460,6 @@ def get_candidate_components(sv, dims, Yres_buf, min_num_trial=3, gSig=(5, 5),
         # indeces_ = np.ravel_multi_index(np.ix_(*[np.arange(ij[0], ij[1])
         #                 for ij in ijSig]), dims, order='C').ravel(order = 'C')
 
-        Ypx = Yres_buf.T[indeces, :]
         ain = np.maximum(mean_buff[indeces], 0)
 
         if sniper_mode:
@@ -1478,7 +1478,7 @@ def get_candidate_components(sv, dims, Yres_buf, min_num_trial=3, gSig=(5, 5),
         if na:
             ain /= sqrt(na)
             Ain.append(ain)
-            Y_patch.append(Ypx)
+            Y_patch.append(Yres_buf.T[indeces, :]) if compute_corr else all_indices.append(indeces)
             idx.append(ind)
             if sniper_mode:
                 Ain_cnn.append(ain_cnn)
@@ -1517,7 +1517,7 @@ def get_candidate_components(sv, dims, Yres_buf, min_num_trial=3, gSig=(5, 5),
         idx = list(np.array(idx)[keep_final])
     else:
         Ain = [Ain[kp] for kp in keep_cnn]
-        Y_patch = [Y_patch[kp] for kp in keep_cnn]
+        Y_patch = [Yres_buf.T[all_indices[kp]] for kp in keep_cnn]
         idx = list(np.array(idx)[keep_cnn])
         for i, (ain, Ypx) in enumerate(zip(Ain, Y_patch)):
             ain, cin, cin_res = rank1nmf(Ypx, ain)


### PR DESCRIPTION
more efficient computations in `get_candidate_components`
fix batch update of sufficient statistics to use `min(update_freq, minibatch_shape)`