### PR TITLE
hdf5 recursive group save: Add support for missing np.int32

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -410,8 +410,8 @@ def recursively_save_dict_contents_to_group(h5file, path, dic):
             item = np.array(item)
         if not isinstance(key, str):
             raise ValueError("dict keys must be strings to save to hdf5")
-        # save strings, numpy.int64, and numpy.float64 types
-        if isinstance(item, (np.int64, np.float64, str, np.float, float, np.float32,int)):
+        # save strings, numpy.int64, numpy.int32, and numpy.float64 types
+        if isinstance(item, (np.int64, np.int32, np.float64, str, np.float, float, np.float32,int)):
             h5file[path + key] = item
             if not h5file[path + key].value == item:
                 raise ValueError('The data representation in the HDF5 file does not match the original dict.')

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -442,7 +442,7 @@ def recursively_save_dict_contents_to_group(h5file, path, dic):
         elif type(item).__name__ in ['CNMFParams', 'Estimates']: # parameter object
             recursively_save_dict_contents_to_group(h5file, path + key + '/', item.__dict__)
         else:
-            raise ValueError('Cannot save %s type.' % type(item))
+            raise ValueError("Cannot save %s type for key '%s'." % (type(item), key))
 
 
 def recursively_load_dict_contents_from_group( h5file, path):


### PR DESCRIPTION
On trying to save the results using `cnm2.save()`, I got the following error:
```
ValueError                                Traceback (most recent call last)
<ipython-input-108-b2ac98e98e5a> in <module>
      3 if save_results:
      4     import time
----> 5     cnm2.save(fnames[0] + time.strftime("%Y_%m_%d_%H_%M") + 'analysis_results.hdf5')

h:\caiman\caiman_git\caiman\source_extraction\cnmf\cnmf.py in save(self, filename)
    603 
    604         if '.hdf5' in filename:
--> 605             save_dict_to_hdf5(self.__dict__, filename)
    606         else:
    607             raise Exception("Filename not supported")

h:\caiman\caiman_git\caiman\utils\utils.py in save_dict_to_hdf5(dic, filename)
    357 
    358     with h5py.File(filename, 'w') as h5file:
--> 359         recursively_save_dict_contents_to_group(h5file, '/', dic)
    360 
    361 def load_dict_from_hdf5(filename):

h:\caiman\caiman_git\caiman\utils\utils.py in recursively_save_dict_contents_to_group(h5file, path, dic)
    441             h5file[path + key] = np.array(item)
    442         elif type(item).__name__ in ['CNMFParams', 'Estimates']: # parameter object
--> 443             recursively_save_dict_contents_to_group(h5file, path + key + '/', item.__dict__)
    444         else:
    445             raise ValueError("Cannot save %s type for key '%s'." % (type(item), key))

h:\caiman\caiman_git\caiman\utils\utils.py in recursively_save_dict_contents_to_group(h5file, path, dic)
    427         # save dictionaries
    428         elif isinstance(item, dict):
--> 429             recursively_save_dict_contents_to_group(h5file, path + key + '/', item)
    430         elif 'sparse' in str(type(item)):
    431             logging.info(key + ' is sparse ****')

h:\caiman\caiman_git\caiman\utils\utils.py in recursively_save_dict_contents_to_group(h5file, path, dic)
    443             recursively_save_dict_contents_to_group(h5file, path + key + '/', item.__dict__)
    444         else:
--> 445             raise ValueError("Cannot save %s type for key '%s'." % (type(item), key))
    446 
    447 

ValueError: Cannot save <class 'numpy.int32'> type for key 'n_processes'.
```

It successfully saves the file with the changes made in this PR.