### PR TITLE
mmapping: explicit type promotions to avoid overflow

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -270,13 +270,14 @@ def save_portion(pars):
         del big_mov
     else:
         with open(big_mov, 'r+b') as f:
-            f.seek(idx_start * Yr_tot.dtype.itemsize * tot_frames)
+            f.seek(idx_start * np.uint64(Yr_tot.dtype.itemsize) * tot_frames)
             f.write(Yr_tot)
-            if f.tell() != idx_end * Yr_tot.dtype.itemsize * tot_frames:
-                    logging.debug(f.tell())
-                    logging.debug(idx_end * Yr_tot.dtype.itemsize * tot_frames)
+            computed_position = idx_end * np.uint64(Yr_tot.dtype.itemsize) * tot_frames
+            if f.tell() != computed_position:
+                    logging.debug(f"Error in mmap portion write: at position {f.tell()}")
+                    logging.debug(f"But should be at position {idx_end} * {Yr_tot.dtype.itemsize} * {tot_frames} = {computed_position}")
                     f.close()
-                    raise Exception('Writing at the wrong location!')
+                    raise Exception('Internal error in mmapping: Actual position does not match computed position')
 
     del Yr_tot
     logging.debug('done')

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -274,8 +274,8 @@ def save_portion(pars):
             f.write(Yr_tot)
             computed_position = idx_end * np.uint64(Yr_tot.dtype.itemsize) * tot_frames
             if f.tell() != computed_position:
-                    logging.debug(f"Error in mmap portion write: at position {f.tell()}")
-                    logging.debug(f"But should be at position {idx_end} * {Yr_tot.dtype.itemsize} * {tot_frames} = {computed_position}")
+                    logging.critical(f"Error in mmap portion write: at position {f.tell()}")
+                    logging.critical(f"But should be at position {idx_end} * {Yr_tot.dtype.itemsize} * {tot_frames} = {computed_position}")
                     f.close()
                     raise Exception('Internal error in mmapping: Actual position does not match computed position')
 

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -270,9 +270,9 @@ def save_portion(pars):
         del big_mov
     else:
         with open(big_mov, 'r+b') as f:
-            f.seek(idx_start * np.uint64(Yr_tot.dtype.itemsize) * tot_frames)
+            f.seek(idx_start * int(Yr_tot.dtype.itemsize) * tot_frames)
             f.write(Yr_tot)
-            computed_position = idx_end * np.uint64(Yr_tot.dtype.itemsize) * tot_frames
+            computed_position = idx_end * int(Yr_tot.dtype.itemsize) * tot_frames
             if f.tell() != computed_position:
                     logging.critical(f"Error in mmap portion write: at position {f.tell()}")
                     logging.critical(f"But should be at position {idx_end} * {Yr_tot.dtype.itemsize} * {tot_frames} = {computed_position}")


### PR DESCRIPTION
Hoping to fix issue #448 - believe we're going above the bounds of uint32 and numpy isn't doing type promotion for us. This sprinkles in a cast to np.uint64 and also improves logging for the code that's breaking