### PR TITLE
workaround to urllib permission error

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -82,7 +82,15 @@ def download_demo(name='Sue_2x_3000_40_-46.tif', save_folder=''):
             url = file_dict[name]
             logging.info(f"downloading {name} with urllib")
             logging.info(f"GET {url} HTTP/1.1")
-            f = urlopen(url)
+            try:
+                f = urlopen(url)
+            except:
+                logging.info(f"Trying to set user agent to download demo")
+                from urllib.request import Request
+                req = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+                f = urlopen(req)
+                
+                
             data = f.read()
             with open(path_movie, "wb") as code:
                 code.write(data)


### PR DESCRIPTION
Added a workaround to the permission error. This should solve issue #457. However, we might want to find a more permanent solution storage that would not block the urlreq. I did not propagate the changes to master since I do not know if you are OK with this patch. 