### PR TITLE
Change domain for datafiles hosting to a direct (non-Cloudfront) endpoint

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -65,14 +65,14 @@ def download_demo(name='Sue_2x_3000_40_-46.tif', save_folder=''):
     #\bug
     #\warning
 
-    file_dict = {'Sue_2x_3000_40_-46.tif': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/Sue_2x_3000_40_-46.tif',
-                 'demoMovieJ.tif': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/demoMovieJ.tif',
-                 'demo_behavior.h5': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/demo_behavior.h5',
-                 'Tolias_mesoscope_1.hdf5': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_1.hdf5',
-                 'Tolias_mesoscope_2.hdf5': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_2.hdf5',
-                 'Tolias_mesoscope_3.hdf5': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_3.hdf5',
-                 'data_endoscope.tif': 'https://users.flatironinstitute.org/~neuro/caiman_downloadables/data_endoscope.tif'}
-    #          ,['./example_movies/demoMovie.tif','https://users.flatironinstitute.org/~neuro/caiman_downloadables/demoMovie.tif']]
+    file_dict = {'Sue_2x_3000_40_-46.tif': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/Sue_2x_3000_40_-46.tif',
+                 'demoMovieJ.tif': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/demoMovieJ.tif',
+                 'demo_behavior.h5': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/demo_behavior.h5',
+                 'Tolias_mesoscope_1.hdf5': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_1.hdf5',
+                 'Tolias_mesoscope_2.hdf5': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_2.hdf5',
+                 'Tolias_mesoscope_3.hdf5': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/Tolias_mesoscope_3.hdf5',
+                 'data_endoscope.tif': 'https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/data_endoscope.tif'}
+    #          ,['./example_movies/demoMovie.tif','https://caiman.flatironinstitute.org/~neuro/caiman_downloadables/demoMovie.tif']]
     base_folder = os.path.join(caiman_datadir(), 'example_movies')
     if os.path.exists(base_folder):
         if not os.path.isdir(os.path.join(base_folder, save_folder)):


### PR DESCRIPTION
This is meant as a better fix for #457 . The old endpoint was pointing at a CloudFront cache which has anti-abuse features that sometimes considered API-like web requests invalid and returned 500. Dylan set up a direct DNS name for us that points right at our users service (but otherwise has identical semantics to users.flatironinstitute.org) so that won't be a concern anymore.