### PR TITLE
mmapping: Explicit cast to np.uint64 to handle platforms where int is not already 64-bit (overflow)

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -270,9 +270,9 @@ def save_portion(pars):
         del big_mov
     else:
         with open(big_mov, 'r+b') as f:
-            f.seek(idx_start * int(Yr_tot.dtype.itemsize) * tot_frames)
+            f.seek(idx_start * np.uint64(Yr_tot.dtype.itemsize) * tot_frames)
             f.write(Yr_tot)
-            computed_position = idx_end * int(Yr_tot.dtype.itemsize) * tot_frames
+            computed_position = idx_end * np.uint64(Yr_tot.dtype.itemsize) * tot_frames
             if f.tell() != computed_position:
                     logging.critical(f"Error in mmap portion write: at position {f.tell()}")
                     logging.critical(f"But should be at position {idx_end} * {Yr_tot.dtype.itemsize} * {tot_frames} = {computed_position}")


### PR DESCRIPTION
Not 100% sure this isn't just signed-versus-unsigned, but I suspect that's not it.

If this ever proves insufficient, could use np.ulong instead, but that's less predictable and I'm reasonably sure long is 64-bit on most 64-bit architectures we'll encounter. Could even do np.ulonglong but again, that's not well defined.