### PR TITLE
NWB support

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1288,7 +1288,7 @@ def load(file_name, fr=30, start_time=0, meta_data=None, subindices=None,
             with np.load(file_name) as f:
                 return movie(**f).astype(outtype)
 
-        elif extension in ('.hdf5', '.h5'):
+        elif extension in ('.hdf5', '.h5', '.nwb'):
             if is_behavior:
                 with h5py.File(file_name, "r") as f:
                     kk = list(f.keys())

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -944,7 +944,7 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                 filename = os.path.split(file_name)[-1]
                 Yr, dims, T = load_memmap(os.path.join(
                         os.path.split(file_name)[0], filename))
-            elif extension == '.h5' or extension == '.hdf5':
+            elif extension in ('.h5', '.hdf5', '.nwb'):
                 with h5py.File(file_name, "r") as f:
                     kk = list(f.keys())
                     if len(kk) == 1:


### PR DESCRIPTION
Add support for NWB files that are actually HDF5 files.

This is a stopgap while we work on a more robust backend-agnostic pynwb importer.