### PR TITLE
CNMFParams repr

### DIFF
--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -8,6 +8,8 @@ from scipy.ndimage.morphology import generate_binary_structure, iterate_structur
 from ...paths import caiman_datadir
 from .utilities import dict_compare, get_file_size
 
+from pprint import pformat
+
 class CNMFParams(object):
 
     def __init__(self, fnames=None, dims=None, dxy=(1, 1),
@@ -700,7 +702,7 @@ class CNMFParams(object):
             'use_dense': use_dense,            # flag for representation and storing of A and b
             'use_peak_max': use_peak_max,      # flag for finding candidate centroids
         }
-        
+
         self.motion = {
             'border_nan': 'copy',                 # flag for allowing NaN in the boundaries
             'gSig_filt': None,                  # size of kernel for high pass spatial filtering in 1p data
@@ -721,7 +723,7 @@ class CNMFParams(object):
             'upsample_factor_grid': 4,          # motion field upsampling factor during FFT shifts
             'use_cuda': False                   # flag for using a GPU
         }
-        
+
         self.change_params(params_dict)
         if self.data['dims'] is None and self.data['fnames'] is not None:
             self.data['dims'] = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0]
@@ -755,7 +757,7 @@ class CNMFParams(object):
                             "in group spatial automatically to False.")
             self.set('spatial', {'update_background_components': False})
         if method_init=='corr_pnr' and ring_size_factor is not None:
-            logging.warning("using CNMF-E's ringmodel for background hence setting key " + 
+            logging.warning("using CNMF-E's ringmodel for background hence setting key " +
                             "normalize_init in group init automatically to False.")
             self.set('init', {'normalize_init': False})
 
@@ -841,6 +843,15 @@ class CNMFParams(object):
                 'patch_params': self.patch, 'online': self.online, 'quality': self.quality,
                 'merging': self.merging, 'motion': self.motion
                 }
+
+    def __repr__(self):
+
+        formatted_outputs = [
+            '{}:\n\n{}'.format(group_name, pformat(group_dict))
+            for group_name, group_dict in self.to_dict().items()
+        ]
+
+        return 'CNMFParams:\n\n' + '\n\n'.join(formatted_outputs)
 
     def change_params(self, params_dict, verbose=False):
         for gr in list(self.__dict__.keys()):


### PR DESCRIPTION
A draft addressing #526 

@epnev current iteration looks like:

```python
from caiman.source_extraction.cnmf.params import CNMFParams

print(CNMFParams())
```

```
CNMFParams:

data:

{'decay_time': 0.4,
 'dims': None,
 'dxy': (1, 1),
 'fnames': None,
 'fr': 30,
 'var_name_hdf5': 'mov'}

spatial_params:

{'block_size_spat': 5000,
 'dist': 3,
 'expandCore': array([[0, 0, 1, 0, 0],
       [0, 1, 1, 1, 0],
       [1, 1, 1, 1, 1],
       [0, 1, 1, 1, 0],
       [0, 0, 1, 0, 0]]),
 'extract_cc': True,
 'maxthr': 0.1,
 'medw': None,
 'method_exp': 'dilate',
 'method_ls': 'lasso_lars',
 'n_pixels_per_process': None,
 'nb': 1,
 'normalize_yyt_one': True,
 'nrgthr': 0.9999,
 'num_blocks_per_run_spat': 20,
 'se': None,
 'ss': None,
 'thr_method': 'nrg',
 'update_background_components': True}

temporal_params:

{'ITER': 2,
 'bas_nonneg': False,
 'block_size_temp': 5000,
 'fudge_factor': 0.96,
 'lags': 5,
 'memory_efficient': False,
 'method_deconvolution': 'oasis',
 'nb': 1,
 'noise_method': 'mean',
 'noise_range': [0.25, 0.5],
 'num_blocks_per_run_temp': 20,
 'p': 2,
 's_min': None,
 'solvers': ['ECOS', 'SCS'],
 'verbosity': False}

init_params:

{'K': 30,
 'alpha_snmf': 1000.0,
 'center_psf': False,
 'gSig': [5, 5],
 'gSiz': [11, 11],
 'init_iter': 2,
 'kernel': None,
 'maxIter': 5,
 'max_iter_snmf': 500,
 'method_init': 'greedy_roi',
 'min_corr': 0.85,
 'min_pnr': 20,
 'nIter': 5,
 'nb': 1,
 'normalize_init': True,
 'options_local_NMF': None,
 'perc_baseline_snmf': 20,
 'ring_size_factor': 1.5,
 'rolling_length': 100,
 'rolling_sum': True,
 'sigma_smooth_snmf': (0.5, 0.5, 0.5),
 'ssub': 2,
 'ssub_B': 2,
 'tsub': 2}

preprocess_params:

{'check_nan': True,
 'compute_g': False,
 'include_noise': False,
 'lags': 5,
 'max_num_samples_fft': 3072,
 'n_pixels_per_process': None,
 'noise_method': 'mean',
 'noise_range': [0.25, 0.5],
 'p': 2,
 'pixels': None,
 'sn': None}

patch_params:

{'border_pix': 0,
 'del_duplicates': False,
 'in_memory': True,
 'low_rank_background': True,
 'memory_fact': 1,
 'n_processes': 1,
 'nb_patch': 1,
 'only_init': True,
 'p_ssub': 2,
 'p_tsub': 2,
 'remove_very_bad_comps': False,
 'rf': None,
 'skip_refinement': False,
 'stride': None}

online:

{'N_samples_exceptionality': 12,
 'batch_update_suff_stat': False,
 'dist_shape_update': False,
 'ds_factor': 1,
 'epochs': 1,
 'expected_comps': 500,
 'init_batch': 200,
 'init_method': 'bare',
 'iters_shape': 5,
 'max_comp_update_shape': inf,
 'max_num_added': 5,
 'max_shifts_online': 10,
 'min_SNR': 2.5,
 'min_num_trial': 5,
 'minibatch_shape': 100,
 'minibatch_suff_stat': 5,
 'motion_correct': True,
 'movie_name_online': 'online_movie.avi',
 'n_refit': 0,
 'normalize': False,
 'num_times_comp_updated': inf,
 'path_to_model': '/home/barryza1/caiman_data/model/cnn_model_online.h5',
 'rval_thr': 0.8,
 'save_online_movie': False,
 'show_movie': False,
 'simultaneously': False,
 'sniper_mode': False,
 'test_both': False,
 'thresh_CNN_noisy': 0.5,
 'thresh_fitness_delta': -50,
 'thresh_fitness_raw': -60.97977932734429,
 'thresh_overlap': 0.5,
 'update_freq': 200,
 'update_num_comps': True,
 'use_dense': True,
 'use_peak_max': True}

quality:

{'SNR_lowest': 0.5,
 'cnn_lowest': 0.1,
 'gSig_range': None,
 'min_SNR': 2.5,
 'min_cnn_thr': 0.9,
 'rval_lowest': -1,
 'rval_thr': 0.8,
 'use_cnn': True}

merging:

{'do_merge': True, 'merge_thr': 0.8}

motion:

{'border_nan': 'copy',
 'gSig_filt': None,
 'max_deviation_rigid': 3,
 'max_shifts': (6, 6),
 'min_mov': None,
 'niter_rig': 1,
 'nonneg_movie': True,
 'num_frames_split': 80,
 'num_splits_to_process_els': [7, None],
 'num_splits_to_process_rig': None,
 'overlaps': (32, 32),
 'pw_rigid': False,
 'shifts_opencv': True,
 'splits_els': 14,
 'splits_rig': 14,
 'strides': (96, 96),
 'upsample_factor_grid': 4,
 'use_cuda': False}
```