### PR TITLE
Fix compile on Mac OS 10.14 with Python 3.6.  See https://github.com/…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ data_files.append(['bin', binaries])
 # compile with:     python setup.py build_ext -i
 # clean up with:    python setup.py clean --all
 if sys.platform == 'darwin':
-	extra_compiler_args = ['-stdlib=libc++']
+        # see https://github.com/pandas-dev/pandas/issues/23424
+	extra_compiler_args = ['-stdlib=libc++']  # not needed #, '-mmacosx-version-min=10.9']
 else:
 	extra_compiler_args = []
 
@@ -54,7 +55,9 @@ ext_modules = [Extension("caiman.source_extraction.cnmf.oasis",
                          sources=["caiman/source_extraction/cnmf/oasis.pyx"],
                          include_dirs=[np.get_include()],
                          language="c++",
-                         extra_compile_args = extra_compiler_args)]
+                         extra_compile_args = extra_compiler_args,
+                         extra_link_args = extra_compiler_args,
+                         )]
 
 setup(
     name='caiman',


### PR DESCRIPTION
…pandas-dev/pandas/issues/23424

Caiman master doesn't compile with a fresh Anaconda Python 3.6 install, throwing this error at the link step. 

````
g++ -bundle -undefined dynamic_lookup -L/Users/histed/anaconda3/envs/caiman36/lib -arch x86_64 -L/Users/histed/anaconda3/envs/caiman36/lib -arch x86_64 -arch x86_64 build/temp.macosx-10.7-x86_64-3.6/caiman/source_extraction/cnmf/oasis.o -o build/lib.macosx-10.7-x86_64-3.6/caiman/source_extraction/cnmf/oasis.cpython-36m-darwin.so
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
ld: library not found for -lstdc++
clang: error: linker command failed with exit code 1 (use -v to see invocation)
error: command 'g++' failed with exit status 1
````

The fix is to pass the ````-stdlib=libc++ ```` to the linker as in attached pull req.

Pandas bug here: https://github.com/pandas-dev/pandas/issues/23424 suggests that ````-mmacosx-version-min=10.9```` is also required, but it didn't seem to be needed for me.  On the other hand it doesn't seem to cause problems.
