### PR TITLE
Add a max_merge_area parameter for preventing the merging of components if the merged component's area is too large

### DIFF
--- a/caiman/source_extraction/cnmf/merging.py
+++ b/caiman/source_extraction/cnmf/merging.py
@@ -191,14 +191,10 @@ def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, 
             Acsc = A.tocsc()[:, merged_ROI]
             Ctmp = np.array(C)[merged_ROI, :]
 
-            print(np.sum(Acsc > 0))
-
             # don't merge if the size of the merged ROI exceeds max_merge_area
             if max_merge_area is not None and np.sum(Acsc > 0) > max_merge_area:
-                print("Skipping merge of {}...".format(merged_ROI))
                 continue
             
-            print('Merging components {}'.format(merged_ROI))
             logging.info('Merging components {}'.format(merged_ROI))
             merged_ROIs.append(merged_ROI)
 

--- a/caiman/source_extraction/cnmf/merging.py
+++ b/caiman/source_extraction/cnmf/merging.py
@@ -24,7 +24,7 @@ from .utilities import update_order_greedy
 
 
 
-def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, dview=None, thr=0.85, fast_merge=True, mx=1000, bl=None, c1=None, sn=None, g=None):
+def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, dview=None, thr=0.85, fast_merge=True, mx=1000, bl=None, c1=None, sn=None, g=None, max_merge_area=None):
     """ Merging of spatially overlapping components that have highly correlated temporal activity
 
     The correlation threshold for merging overlapping components is user specified in thr
@@ -77,6 +77,9 @@ def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, 
              discrete time constant for each row in C
         sn:
              noise level for each row in C
+
+        max_merge_area: int
+            maximum area (in pixels) of merged components, used to determine whether to merge
 
     Returns:
         A:     sparse matrix
@@ -184,12 +187,20 @@ def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, 
 
         for i in range(nbmrg):
             merged_ROI = np.where(list_conxcomp[:, ind[i]])[0]
-            logging.info('Merging components {}'.format(merged_ROI))
-            merged_ROIs.append(merged_ROI)
 
             Acsc = A.tocsc()[:, merged_ROI]
             Ctmp = np.array(C)[merged_ROI, :]
 
+            print(np.sum(Acsc > 0))
+
+            # don't merge if the size of the merged ROI exceeds max_merge_area
+            if max_merge_area is not None and np.sum(Acsc > 0) > max_merge_area:
+                print("Skipping merge of {}...".format(merged_ROI))
+                continue
+            
+            print('Merging components {}'.format(merged_ROI))
+            logging.info('Merging components {}'.format(merged_ROI))
+            merged_ROIs.append(merged_ROI)
 
             # # we l2 the traces to have normalization values
             # C_to_norm = np.sqrt([computedC.dot(computedC)
@@ -226,23 +237,24 @@ def merge_components(Y, A, b, C, f, S, sn_pix, temporal_params, spatial_params, 
             sn_merged = sn_merged[~empty]
             g_merged = g_merged[~empty]
 
-        # we want to remove merged neuron from the initial part and replace them with merged ones
-        neur_id = np.unique(np.hstack(merged_ROIs))
-        good_neurons = np.setdiff1d(list(range(nr)), neur_id)
-        A = scipy.sparse.hstack((A.tocsc()[:, good_neurons], A_merged.tocsc()))
-        C = np.vstack((C[good_neurons, :], C_merged))
-        # we continue for the variables
-        if S is not None:
-            S = np.vstack((S[good_neurons, :], S_merged))
-        if bl is not None:
-            bl = np.hstack((bl[good_neurons], np.array(bl_merged).flatten()))
-        if c1 is not None:
-            c1 = np.hstack((c1[good_neurons], np.array(c1_merged).flatten()))
-        if sn is not None:
-            sn = np.hstack((sn[good_neurons], np.array(sn_merged).flatten()))
-        if g is not None:
-            g = np.vstack((np.vstack(g)[good_neurons], g_merged))
-        nr = nr - len(neur_id) + len(C_merged)
+        if len(merged_ROIs) > 0:
+            # we want to remove merged neuron from the initial part and replace them with merged ones
+            neur_id = np.unique(np.hstack(merged_ROIs))
+            good_neurons = np.setdiff1d(list(range(nr)), neur_id)
+            A = scipy.sparse.hstack((A.tocsc()[:, good_neurons], A_merged.tocsc()))
+            C = np.vstack((C[good_neurons, :], C_merged))
+            # we continue for the variables
+            if S is not None:
+                S = np.vstack((S[good_neurons, :], S_merged))
+            if bl is not None:
+                bl = np.hstack((bl[good_neurons], np.array(bl_merged).flatten()))
+            if c1 is not None:
+                c1 = np.hstack((c1[good_neurons], np.array(c1_merged).flatten()))
+            if sn is not None:
+                sn = np.hstack((sn[good_neurons], np.array(sn_merged).flatten()))
+            if g is not None:
+                g = np.vstack((np.vstack(g)[good_neurons], g_merged))
+            nr = nr - len(neur_id) + len(C_merged)
 
     else:
         logging.info('No more components merged!')

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1,6 +1,6 @@
 import logging
 import os
-
+import subprocess
 import numpy as np
 import scipy
 from scipy.ndimage.morphology import generate_binary_structure, iterate_structure
@@ -307,6 +307,9 @@ class CNMFParams(object):
             lags: int, default: 5
                 number of autocovariance lags to be considered for time constant estimation
 
+            optimize_g: bool, default: False
+                flag for optimizing time constants
+
             fudge_factor: float (close but smaller than 1) default: .96
                 bias correction factor for discrete time constants
 
@@ -532,7 +535,9 @@ class CNMFParams(object):
             'fr': fr,
             'decay_time': decay_time,
             'dxy': dxy,
-            'var_name_hdf5': var_name_hdf5
+            'var_name_hdf5': var_name_hdf5,
+            'caiman_version': 1.5,
+            'last_commit': None,
         }
 
         self.patch = {
@@ -634,6 +639,7 @@ class CNMFParams(object):
             'fudge_factor': .96,
             # number of autocovariance lags to be considered for time constant estimation
             'lags': 5,
+            'optimize_g': False,         # flag for optimizing time constants
             'memory_efficient': False,
             # method for solving the constrained deconvolution problem ('oasis','cvx' or 'cvxpy')
             # if method cvxpy, primary and secondary (if problem unfeasible for approx
@@ -729,6 +735,11 @@ class CNMFParams(object):
         }
 
         self.change_params(params_dict)
+        try:
+            lc = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").split("\n")[0]
+            self.data['last_commit'] = lc
+        except subprocess.CalledProcessError:
+            pass
         if self.data['dims'] is None and self.data['fnames'] is not None:
             self.data['dims'] = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0]
         if self.data['fnames'] is not None:


### PR DESCRIPTION
Currently, when performing CNMF, during the refinement stage overlapping components are merged if their correlation is above a certain threshold. This leads to situations like below, where two adjacent neurons whose activity is highly correlated can start off as two components but become merged into one component:

<img width="392" alt="Screen Shot 2019-07-16 at 1 27 10 pm" src="https://user-images.githubusercontent.com/6885986/61317014-1e9aac00-a7d0-11e9-88fc-2e8cfeed114d.png">

In this case, splitting this single component back into two after-the-fact is a difficult problem. If the expected area of a neuron is known, this can be avoided by preventing components from being merged if the resulting merged component would have an area that's too large, even if the original components are highly correlated. This pull requests adds an optional `max_merge_area` parameter to do this. In the situation shown above, this allows us to have two components representing the two neurons, even when their activity is highly correlated:

<img width="391" alt="Screen Shot 2019-07-16 at 1 28 26 pm" src="https://user-images.githubusercontent.com/6885986/61317455-ff504e80-a7d0-11e9-80eb-38cf6ad07463.png">

I think this is a useful addition as it allows more control over the automatic merging process during the refinement phase, especially when many tightly-packed neurons are active at the same time, which can otherwise lead to a single component spanning multiple neurons.