### PR TITLE
Add standard function to get (some muddled notion of) caiman version

### DIFF
--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import subprocess
 import numpy as np
 import scipy
 from scipy.ndimage.morphology import generate_binary_structure, iterate_structure
 
+import caiman.utils.utils
 from ...paths import caiman_datadir
 from .utilities import dict_compare, get_file_size
 
@@ -769,11 +769,7 @@ class CNMFParams(object):
         }
 
         self.change_params(params_dict)
-        try:
-            lc = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").split("\n")[0]
-            self.data['last_commit'] = lc
-        except:  #subprocess.CalledProcessError:
-            pass
+        self.data['last_commit'] = '-'.join(caiman.utils.utils.get_caiman_version())
         if self.data['dims'] is None and self.data['fnames'] is not None:
             self.data['dims'] = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0]
         if self.data['fnames'] is not None:

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -528,8 +528,8 @@ def get_caiman_version() -> Tuple[str, str]:
     # from these methods:
     # 'GITW' ) git rev-parse if caiman is built from "pip install -e ." and we are working
     #    out of the checkout directory (the user may have since updated without reinstall)
-    # 'GITI') Crumbs left from setup.py run from a git checkout (done from git rev-parse in setup.py)
-    # 'RELF') A release file left in the process to cut a release
+    # 'RELF') A release file left in the process to cut a release. Should have a single line
+    #    in it whick looks like "Version:1.4"
     # 'FILE') The date of some frequently changing files, which act as a very rough
     #    approximation when no other methods are possible
     #
@@ -547,14 +547,6 @@ def get_caiman_version() -> Tuple[str, str]:
     if rev is not None:
         return 'GITW', rev
 
-    # Attempt: 'GITI'. This is made by setup.py from the git version
-    setupfile = os.path.join(caiman_datadir(), 'GITVERSION')
-    if os.path.isfile(setupfile):
-        with open(setupfile, 'r') as sfh:
-            for line in sfh:
-                if ':' in line: # expect a line like "Version:1.3"
-                    _, version = line.rstrip().split(':')
-                    return 'GITI', version 
     # Attempt: 'RELF'
     relfile = os.path.join(caiman_datadir(), 'RELEASE')
     if os.path.isfile(relfile):


### PR DESCRIPTION
This adds a standard function in utils that tries various methods to get some notion of the version of caiman that's installed. Parsing the output is still the user's responsibility.