### PR TITLE
Fix 'shape mismatch in assignment' error in manual_merge function

### DIFF
--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -1100,7 +1100,7 @@ class Estimates(object):
             sm, ss, yra = merge_iteration(Acsc, C_to_norm, Ctmp, fast_merge,
                                           None, g_idx, indx, params.temporal)
 
-            A_merged[:, i] = computedA
+            A_merged[:, i] = computedA[:, np.newaxis]
             C_merged[i, :] = computedC
             R_merged[i, :] = yra
             S_merged[i, :] = ss[:T]


### PR DESCRIPTION
# Description

Using the `manual_merge` function leads to the following error in Python 3.7.3 due to `computedA` missing a  second dimension:

```
ValueError: shape mismatch in assignment
```

This is fixed by adding the missing dimension.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)