### PR TITLE
holoviews in env.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,3 +28,4 @@ dependencies:
 - tk=8.6.8
 - tqdm
 - yapf
+- holoviews


### PR DESCRIPTION
# Description

After the latest addition of the `holoviews` visualizations, `caimanmanager.py` fails due to missing dependency. Simply adding this line to `environment.yml` fixed the issue.

This has nothing to do with the promised changes to `demo_pipeline.py`.

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Branching

- Pull requests with non breaking bug fixes should be made against the **master** branch.
- All other PRs should be made against the **dev** branch.

# Has your PR been tested?

Yes, all tests pass. Perhaps an integration test for `caimanmanager.py` should be added. I'm not sure how to mock all of the filesystem things there, though. Maybe `pathlib` can help with a cross-platform interface?
