### PR TITLE
Add a caimanmanager command to include coverage

### DIFF
--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -72,10 +72,14 @@ def com(A: np.ndarray, d1: int, d2: int, d3: Optional[int] = None) -> np.array:
                          dtype=A.dtype)
     else:
         Coor = np.matrix([
-            np.outer(np.ones(d3), np.outer(np.ones(d2), np.arange(d1)).ravel()).ravel(),
-            np.outer(np.ones(d3), np.outer(np.arange(d2), np.ones(d1)).ravel()).ravel(),
-            np.outer(np.arange(d3), np.outer(np.ones(d2), np.ones(d1)).ravel()).ravel()],
-            dtype=A.dtype)
+            np.outer(np.ones(d3),
+                     np.outer(np.ones(d2), np.arange(d1)).ravel()).ravel(),
+            np.outer(np.ones(d3),
+                     np.outer(np.arange(d2), np.ones(d1)).ravel()).ravel(),
+            np.outer(np.arange(d3),
+                     np.outer(np.ones(d2), np.ones(d1)).ravel()).ravel()
+        ],
+                         dtype=A.dtype)
 
     cm = (Coor * A / A.sum(axis=0)).T
     return np.array(cm)

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 """
 Class representing a time series.
 
@@ -34,6 +33,7 @@ try:
     plt.ion()
 except:
     pass
+
 
 #%%
 class timeseries(np.ndarray):
@@ -96,14 +96,15 @@ class timeseries(np.ndarray):
                         frRef = inp.fr
                     else:
                         if not (frRef - inp.fr) == 0:
-                            raise ValueError('Frame rates of input vectors do not match.'
-                                             ' You cannot perform operations on time series with different frame rates.')
+                            raise ValueError(
+                                'Frame rates of input vectors do not match.'
+                                ' You cannot perform operations on time series with different frame rates.')
                     if startRef is None:
                         startRef = inp.start_time
                     else:
                         if not (startRef - inp.start_time) == 0:
-                            warnings.warn(
-                                'start_time of input vectors do not match: ignore if this is what desired.', UserWarning)
+                            warnings.warn('start_time of input vectors do not match: ignore if this is desired.',
+                                          UserWarning)
 
         # then just call the parent
         return np.ndarray.__array_prepare__(self, out_arr, context)
@@ -171,31 +172,33 @@ class timeseries(np.ndarray):
                         logging.debug(str(i) + ' frames saved')
 
                     curfr = self[i].copy()
-                    if to32 and not('float32' in str(self.dtype)):
+                    if to32 and not ('float32' in str(self.dtype)):
                         curfr = curfr.astype(np.float32)
                     tif.save(curfr, compress=compress)
         elif extension == '.npz':
-            if to32 and not('float32' in str(self.dtype)):
+            if to32 and not ('float32' in str(self.dtype)):
                 input_arr = self.astype(np.float32)
             else:
                 input_arr = np.array(self)
 
-            np.savez(file_name, input_arr=input_arr, start_time=self.start_time,
-                     fr=self.fr, meta_data=self.meta_data, file_name=self.file_name)
+            np.savez(file_name,
+                     input_arr=input_arr,
+                     start_time=self.start_time,
+                     fr=self.fr,
+                     meta_data=self.meta_data,
+                     file_name=self.file_name)
         elif extension == '.avi':
             codec = None
             try:
                 codec = cv2.FOURCC('I', 'Y', 'U', 'V')
             except AttributeError:
                 codec = cv2.VideoWriter_fourcc(*'IYUV')
-            np.clip(self, np.percentile(self, 1),
-                    np.percentile(self, 99), self)
+            np.clip(self, np.percentile(self, 1), np.percentile(self, 99), self)
             minn, maxx = np.min(self), np.max(self)
             data = 255 * (self - minn) / (maxx - minn)
             data = data.astype(np.uint8)
             y, x = data[0].shape
-            vw = cv2.VideoWriter(file_name, codec, self.fr,
-                                 (x, y), isColor=True)
+            vw = cv2.VideoWriter(file_name, codec, self.fr, (x, y), isColor=True)
             for d in data:
                 vw.write(cv2.cvtColor(d, cv2.COLOR_GRAY2BGR))
             vw.release()
@@ -206,23 +209,33 @@ class timeseries(np.ndarray):
             else:
                 f_name = ''
 
-            if to32 and not('float32' in str(self.dtype)):
+            if to32 and not ('float32' in str(self.dtype)):
                 input_arr = self.astype(np.float32)
             else:
                 input_arr = np.array(self)
 
             if self.meta_data[0] is None:
-                savemat(file_name, {'input_arr': np.rollaxis(
-                    input_arr, axis=0, start=3), 'start_time': self.start_time,
-                    'fr': self.fr, 'meta_data': [], 'file_name': f_name})
+                savemat(
+                    file_name, {
+                        'input_arr': np.rollaxis(input_arr, axis=0, start=3),
+                        'start_time': self.start_time,
+                        'fr': self.fr,
+                        'meta_data': [],
+                        'file_name': f_name
+                    })
             else:
-                savemat(file_name, {'input_arr': np.rollaxis(
-                    input_arr, axis=0, start=3), 'start_time': self.start_time,
-                    'fr': self.fr, 'meta_data': self.meta_data, 'file_name': f_name})
+                savemat(
+                    file_name, {
+                        'input_arr': np.rollaxis(input_arr, axis=0, start=3),
+                        'start_time': self.start_time,
+                        'fr': self.fr,
+                        'meta_data': self.meta_data,
+                        'file_name': f_name
+                    })
 
         elif extension in ('.hdf5', '.h5'):
             with h5py.File(file_name, "w") as f:
-                if to32 and not('float32' in str(self.dtype)):
+                if to32 and not ('float32' in str(self.dtype)):
                     input_arr = self.astype(np.float32)
                 else:
                     input_arr = np.array(self)
@@ -231,19 +244,18 @@ class timeseries(np.ndarray):
                 dset.attrs["fr"] = self.fr
                 dset.attrs["start_time"] = self.start_time
                 try:
-                    dset.attrs["file_name"] = [
-                        a.encode('utf8') for a in self.file_name]
+                    dset.attrs["file_name"] = [a.encode('utf8') for a in self.file_name]
                 except:
                     logging.warning('No file saved')
                 if self.meta_data[0] is not None:
                     logging.debug("Metadata for saved file: " + str(self.meta_data))
-                    dset.attrs["meta_data"] = cpk.dumps(self.meta_data)  
+                    dset.attrs["meta_data"] = cpk.dumps(self.meta_data)
         elif extension == '.mmap':
             base_name = name
 
             T = self.shape[0]
             dims = self.shape[1:]
-            if to32 and not('float32' in str(self.dtype)):
+            if to32 and not ('float32' in str(self.dtype)):
                 input_arr = self.astype(np.float32)
             else:
                 input_arr = np.array(self)
@@ -253,21 +265,24 @@ class timeseries(np.ndarray):
 
             fname_tot = memmap_frames_filename(base_name, dims, T, order)
             fname_tot = os.path.join(os.path.split(file_name)[0], fname_tot)
-            big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
-                                shape=(np.uint64(np.prod(dims)),
-                                       np.uint64(T)), order=order)
+            big_mov = np.memmap(fname_tot,
+                                mode='w+',
+                                dtype=np.float32,
+                                shape=(np.uint64(np.prod(dims)), np.uint64(T)),
+                                order=order)
 
             big_mov[:] = np.asarray(input_arr, dtype=np.float32)
             big_mov.flush()
             del big_mov, input_arr
             return fname_tot
         elif extension == '.nwb':
-            if to32 and not('float32' in str(self.dtype)):
+            if to32 and not ('float32' in str(self.dtype)):
                 input_arr = self.astype(np.float32)
             else:
                 input_arr = np.array(self)
             # Create NWB file
-            nwbfile = NWBFile(sess_desc, identifier,
+            nwbfile = NWBFile(sess_desc,
+                              identifier,
                               datetime.now(tzlocal()),
                               experimenter=experimenter,
                               lab=lab_name,
@@ -278,30 +293,29 @@ class timeseries(np.ndarray):
             device = Device('imaging_device')
             nwbfile.add_device(device)
             # OpticalChannel
-            optical_channel = OpticalChannel('OpticalChannel',
-                                             'main optical channel',
-                                             emission_lambda=emission_lambda)
+            optical_channel = OpticalChannel('OpticalChannel', 'main optical channel', emission_lambda=emission_lambda)
             imaging_plane = nwbfile.create_imaging_plane(name='ImagingPlane',
-                                                optical_channel=optical_channel,
-                                                description=imaging_plane_description,
-                                                device=device,
-                                                excitation_lambda=excitation_lambda,
-                                                imaging_rate=self.fr,
-                                                indicator=indicator,
-                                                location=location)
+                                                         optical_channel=optical_channel,
+                                                         description=imaging_plane_description,
+                                                         device=device,
+                                                         excitation_lambda=excitation_lambda,
+                                                         imaging_rate=self.fr,
+                                                         indicator=indicator,
+                                                         location=location)
             # Images
-            image_series = TwoPhotonSeries(name=var_name_hdf5, dimension=self.shape[1:],
+            image_series = TwoPhotonSeries(name=var_name_hdf5,
+                                           dimension=self.shape[1:],
                                            data=input_arr,
                                            imaging_plane=imaging_plane,
                                            starting_frame=[0],
                                            starting_time=starting_time,
                                            rate=self.fr)
-            
+
             nwbfile.add_acquisition(image_series)
-            
+
             with NWBHDF5IO(file_name, 'w') as io:
                 io.write(nwbfile)
-            
+
             return file_name
 
         else:
@@ -326,10 +340,8 @@ def concatenate(*args, **kwargs):
                     obj = m
                     frRef = obj.fr
                 else:
-                    obj.__dict__['file_name'].extend(
-                        [ls for ls in m.file_name])
-                    obj.__dict__['meta_data'].extend(
-                        [ls for ls in m.meta_data])
+                    obj.__dict__['file_name'].extend([ls for ls in m.file_name])
+                    obj.__dict__['meta_data'].extend([ls for ls in m.meta_data])
                     if obj.fr != m.fr:
                         raise ValueError('Frame rates of input vectors \
                             do not match. You cannot concatenate movies with \

--- a/caiman/gui/gui_pyqtgraph_layout.py
+++ b/caiman/gui/gui_pyqtgraph_layout.py
@@ -150,9 +150,11 @@ def draw_contours():
         cv2.drawContours(bkgr_contours, sum([contours[jj] for jj in idx4], []), -1, (255, 255, 0), 1)
         cv2.drawContours(bkgr_contours, sum([contours[jj] for jj in idx5], []), -1, (255, 0, 255), 1)
         cv2.drawContours(bkgr_contours, sum([contours[jj] for jj in idx6], []), -1, (0, 255, 255), 1)
-    
+
     img.setImage(bkgr_contours, autoLevels=False)
-# pg.setConfigOptions(imageAxisOrder='row-major')
+
+
+pg.setConfigOptions(imageAxisOrder='row-major')
 
 
 def draw_contours_update(cf, im):
@@ -192,7 +194,7 @@ def draw_contours_update(cf, im):
     im.setImage(curFrame, autoLevels=False)
 
 
-#%%
+# %%
 
 #  Define a top-level widget to hold everything
 w = QtGui.QWidget()
@@ -203,22 +205,21 @@ text = QtGui.QLineEdit('enter text')
 win = pg.GraphicsLayoutWidget()
 win.setMaximumWidth(300)
 win.setMinimumWidth(200)
-hist = pg.HistogramLUTItem() # Contrast/color control
+hist = pg.HistogramLUTItem()  # Contrast/color control
 win.addItem(hist)
-p1 =  pg.PlotWidget()
-p2 =  pg.PlotWidget()
-p3 =  pg.PlotWidget()
+p1 = pg.PlotWidget()
+p2 = pg.PlotWidget()
+p3 = pg.PlotWidget()
 t = ParameterTree()
 t_action = ParameterTree()
 action_layout = QtGui.QGridLayout()
 
-
-## Create a grid layout to manage the widgets size and position
+#  Create a grid layout to manage the widgets size and position
 layout = QtGui.QGridLayout()
 w.setLayout(layout)
 
 # A plot area (ViewBox + axes) for displaying the image
-#p1 = win.addPlot(title="Image here")
+# p1 = win.addPlot(title="Image here")
 # Item for displaying image data
 img = pg.ImageItem()
 p1.addItem(img)
@@ -496,7 +497,7 @@ def remove_group():
     estimates.rejected_list = np.union1d(estimates.rejected_list,estimates.idx_components)
     estimates.accepted_list = np.setdiff1d(estimates.accepted_list,estimates.idx_components)
     change(None, None)
-    
+
 pars_action.param('REMOVE GROUP').sigActivated.connect(remove_group)
 
 
@@ -504,7 +505,7 @@ def add_single():
     estimates.accepted_list = np.union1d(estimates.accepted_list,estimates.components_to_plot)
     estimates.rejected_list = np.setdiff1d(estimates.rejected_list,estimates.components_to_plot)
     change(None, None)
-    
+
 pars_action.param('ADD SINGLE').sigActivated.connect(add_single)
 
 
@@ -512,13 +513,12 @@ def remove_single():
     estimates.rejected_list = np.union1d(estimates.rejected_list,estimates.components_to_plot)
     estimates.accepted_list = np.setdiff1d(estimates.accepted_list,estimates.components_to_plot)
     change(None, None)
-    
+
 pars_action.param('REMOVE SINGLE').sigActivated.connect(remove_single)
 
 
 def save_object():
     print('Saving')
-    
     ffll = F.getSaveFileName(filter='*.hdf5')
     print(ffll[0])
     cnm_obj.estimates = estimates

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -177,7 +177,7 @@ class OnACID(object):
         self.estimates.CY, self.estimates.CC = self.estimates.CY * 1. / self.params.get('online', 'init_batch'), 1 * self.estimates.CC / self.params.get('online', 'init_batch')
 
         print('Expecting ' + str(expected_comps) + ' components')
-        self.estimates.CY.resize([expected_comps + self.params.get('init', 'nb'), self.estimates.CY.shape[-1]])
+        self.estimates.CY.resize([expected_comps + self.params.get('init', 'nb'), self.estimates.CY.shape[-1]], refcheck=False)
         if self.params.get('online', 'use_dense'):
             self.estimates.Ab_dense = np.zeros((self.estimates.CY.shape[-1], expected_comps + self.params.get('init', 'nb')),
                                      dtype=np.float32)
@@ -387,7 +387,7 @@ class OnACID(object):
                         self.estimates.Ab_dense[:, :Ab_.shape[1]] = Ab_.toarray()
                     print('Increasing number of expected components to:' +
                           str(expected_comps))
-                self.update_counter.resize(self.N)
+                self.update_counter.resize(self.N, refcheck=False)
 
                 self.estimates.noisyC[self.M - num_added:self.M, t - mbs +
                             1:t + 1] = Cf_temp[self.M - num_added:self.M]

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -104,6 +104,24 @@ def do_run_nosetests(targdir: str) -> None:
     else:
         print("Nosetests success!")
 
+def do_run_coverage_nosetests(targdir: str) -> None:
+    # Run nosetests, but invoke coverage so we get statistics on how much our tests actually exercise
+    # the code. It would probably be a mistake to do CI testing around these figures (as we often add things to
+    # the codebase before they're fully fleshed out), but we can at least make the command below easier to invoke
+    # with this frontend.
+    #
+    # This command will not function from the conda package, because there would be no reason to use it in that case.
+    # If we ever change our mind on this, it's a simple addition of the coverage package to the feedstock.
+    out, err, ret = runcmd(["nosetests", "--with-coverage", "--cover-package=caiman", "--cover-erase", "--traverse-namespace", "caiman"])
+    if ret != 0:
+        print("Nosetests failed with return code " + str(ret))
+        print("If it failed due to a message like the following, it is a known issue:")
+        print("ValueError: cannot resize an array that references or is referenced by another array in this way.")
+        print("We believe this to be harmless and caused by coverage having additional rules for code")
+        sys.exit(ret)
+    else:
+        print("Nosetests success!")
+
 
 def do_run_demotests(targdir: str) -> None:
     out, err, ret = runcmd([os.path.join(caiman_datadir(), "test_demos.sh")])
@@ -205,6 +223,8 @@ def main():
         do_check_install(cfg.userdir, cfg.inplace)
     elif cfg.command == 'test':
         do_run_nosetests(cfg.userdir)
+    elif cfg.command == 'covtest':
+        do_run_coverage_nosetests(cfg.userdir)
     elif cfg.command == 'demotest':
         if os.name == 'nt':
             do_nt_run_demotests(cfg.userdir)

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
 - python=3.7
 - tensorflow # Must list before keras to preempt default keras backend
 - bokeh
+- coverage
 - cython
 - future
 - h5py


### PR DESCRIPTION
This adds an (undocumented) subcommand to caimanmanager that runs nosetests with coverage enabled. It also adds coverage to environment.yml so source builds include it. I did not add it to the feedstock because there's no point in running this test outside of a source build.

Note as well that coverage imposes additional rules on python that restrict array resizing, causing caiman code to throw an error. We probably should look into this. The error looks like this:

```
Traceback (most recent call last):
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/caiman/tests/test_onacid.py", line 54, in test_onacid
    demo()
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/caiman/tests/test_onacid.py", line 46, in demo
    cnm.fit_online()
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/caiman/source_extraction/cnmf/online_cnmf.py", line 725, in fit_online
    self.initialize_online()
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/caiman/source_extraction/cnmf/online_cnmf.py", line 671, in initialize_online
    self._prepare_object(Yr, T1)
  File "/mnt/home/pgunn/miniconda3/envs/caiman/lib/python3.7/site-packages/caiman/source_extraction/cnmf/online_cnmf.py", line 180, in _prepare_object
    self.estimates.CY.resize([expected_comps + self.params.get('init', 'nb'), self.estimates.CY.shape[-1]])
ValueError: cannot resize an array that references or is referenced
by another array in this way.
Use the np.resize function or refcheck=False
```