### PR TITLE
Pin to earlier tifffile before upstream breakage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - scikit-learn
 - scipy
 - tensorflow
-- tifffile
+- tifffile=0.15.1
 - tk=8.6.8
 - tqdm
 - yapf


### PR DESCRIPTION
To deal with the latest releases of tifffile not supporting our sample tifffiles (and the new library you'd install currently not having a conda package so we can't just add it to the environment.yml), this pins tifffile at 0.15.1.

Upstream issue is filed against the feedstock:
https://github.com/conda-forge/tifffile-feedstock/issues/32