### PR TITLE
Use tifffile for .btf files

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1510,6 +1510,7 @@ def load(file_name: Union[str, List[str]],
 
     if os.path.exists(file_name):
         _, extension = os.path.splitext(file_name)[:2]
+
         extension = extension.lower()
         if extension == '.mat':
             logging.warning('Loading a *.mat file. x- and y- dimensions ' +
@@ -1519,7 +1520,7 @@ def load(file_name: Union[str, List[str]],
             if mjv == 2:
                 extension = '.h5'
 
-        if extension == '.tif' or extension == '.tiff':        # load avi file
+        if extension in ['.tif', '.tiff', '.btf']:  # load avi file
             with tifffile.TiffFile(file_name) as tffl:
                 multi_page = True if tffl.series[0].shape[0] > 1 else False
                 if len(tffl.pages) == 1:
@@ -2159,7 +2160,7 @@ def load_iter(file_name, subindices=None, var_name_hdf5: str = 'mov'):
     """
     if os.path.exists(file_name):
         extension = os.path.splitext(file_name)[1].lower()
-        if extension in ('.tif', '.tiff'):
+        if extension in ('.tif', '.tiff', '.btf'):
             Y = tifffile.TiffFile(file_name).pages
             if subindices is not None:
                 if type(subindices) is range:
@@ -2224,4 +2225,3 @@ def load_iter(file_name, subindices=None, var_name_hdf5: str = 'mov'):
     else:
         logging.error(f"File request:[{file_name}] not found!")
         raise Exception('File not found!')
-

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -171,7 +171,7 @@ class timeseries(np.ndarray):
         extension = extension.lower()
         logging.debug("Parsing extension " + str(extension))
 
-        if extension == '.tif':
+        if extension in ['.tif', '.tiff', '.btf']:
             with tifffile.TiffWriter(file_name, bigtiff=bigtiff, imagej=imagej) as tif:
                 for i in range(self.shape[0]):
                     if i % 200 == 0:

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -980,7 +980,7 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                 mjv, mnv = scipy.io.matlab.mio.get_matfile_version(byte_stream)
                 if mjv == 2:
                     extension = '.h5'
-            if extension == '.tif' or extension == '.tiff':
+            if extension in ['.tif', '.tiff', '.btf']:
                 tffl = tifffile.TiffFile(file_name)
                 siz = tffl.series[0].shape
                 T, dims = siz[0], siz[1:]
@@ -1195,4 +1195,3 @@ def fast_graph_Laplacian_pixel(pars):
         ind = np.where(w>0)[0]
 
     return indeces[ind].tolist(), w[ind].tolist()
-    


### PR DESCRIPTION
# Description

According to [OME-TIFF spec](https://docs.openmicroscopy.org/ome-model/6.0.1/ome-tiff/specification.html) `.ome.btf` is valid, and, in my experience, common. Since [tifffile](https://pypi.org/project/tifffile/) supports OME-TIFF, I've modified logic so CaImAn supports `.btf` files.

I've tested the motion correction pipeline on a very small `.btf` file and it seems to work properly. Unfortunately, most of my files are 70GB+ of `uint16` bigtiffs, so reading in as float32 means my computer ran out of memory. I plan on trying my hand at removing `asarray` & doing stream processing, but if someone at flatiron is already doing this please let me know so I don't duplicate effort! Thanks

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.
