### PR TITLE
volpy: keras is now an install optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ We recently added VolPy, an analysis pipeline for voltage imaging data. The anal
 * `volparams`: An object for setting parameters of voltage imaging. It can be set and changed easily and is passed into the algorithms.
 * `VOLPY`: An object for running the spike detection algorithm and saving results.
 
+In order to use VolPy, you must install Keras into your conda environment. You can do this by activating your environment, and then issuing the command "conda install -c conda-forge keras".
+
 To see examples of how these methods are used, please consult the `demo_pipeline_voltage_imaging.py` script in the `demos/general` folder. For more information about the approach check the [preprint](https://www.biorxiv.org/content/10.1101/2020.01.02.892323v1).
 
 ## New: Installation through conda-forge (August 2019)

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -150,6 +150,8 @@ def do_nt_run_demotests(targdir: str) -> None:
         print("Testing " + str(demo))
         if "demo_behavior.py" in demo:
             print("  Skipping tests on " + demo + ": This is interactive")
+        elif "demo_pipeline_voltage_imaging.py" in demo:
+            print("  Skipping tests on " + demo + ": This needs Keras, an optional dependency")
         else:
             out, err, ret = runcmd(["python", demo], ignore_error=False)
             if ret != 0:

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,6 @@ dependencies:
 - ipython
 - ipyparallel
 - jupyter
-- keras
 - matplotlib
 - mypy
 - nose

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -40,6 +40,8 @@ cd `dirname ${BASH_SOURCE[0]}`
 for demo in demos/general/*; do
 	if [ $demo == "demos/general/demo_behavior.py" ]; then
 		echo "	Skipping tests on $demo: This is interactive"
+	elif [ $demo == "demos/general/demo_pipeline_voltage_imaging.py" ]; then
+		echo "	Skipping tests on $demo: This uses Keras, an optional install"
 	elif [ -d $demo ]; then
 		true
 	else


### PR DESCRIPTION
This diff:
* Notes that VolPy requires an optional install of Keras to function
* Removes keras from environment.yml
* Adds the volpy demo to things that the test commands in caimanmanager will never run

It should be followed up with a diff to the feedstock to take keras back out from the binary builds.