### PR TITLE
Support loading videos from MKV containers

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1562,7 +1562,7 @@ def load(file_name: Union[str, List[str]],
 
                 input_arr = np.squeeze(input_arr)
 
-        elif extension == '.avi':      # load avi file
+        elif extension in ('.avi', '.mkv'):      # load video file
             cap = cv2.VideoCapture(file_name)
 
             try:
@@ -2184,7 +2184,7 @@ def load_iter(file_name, subindices=None, var_name_hdf5: str = 'mov'):
                 Y = Y[subindices]
             for y in Y:
                 yield y.asarray()
-        elif extension == '.avi':
+        elif extension in ('.avi', '.mkv'):
             cap = cv2.VideoCapture(file_name)
             if subindices is None:
                 while True:

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -193,7 +193,7 @@ class timeseries(np.ndarray):
                      fr=self.fr,
                      meta_data=self.meta_data,
                      file_name=self.file_name)
-        elif extension == '.avi':
+        elif extension in ('.avi', '.mkv'):
             codec = None
             try:
                 codec = cv2.FOURCC('I', 'Y', 'U', 'V')

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -984,7 +984,7 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                 tffl = tifffile.TiffFile(file_name)
                 siz = tffl.series[0].shape
                 T, dims = siz[0], siz[1:]
-            elif extension == '.avi':
+            elif extension in ('.avi', '.mkv'):
                 cap = cv2.VideoCapture(file_name)
                 dims = [0, 0]
                 try:


### PR DESCRIPTION
# Description

In our lab we make extensive use of the more modern Matroska container (MKV) for videos, mostly containing FFV1 or VP9-encoded material. The new Miniscope v4 DAQ software as well as the PoMiDAQ Miniscope DAQ software are also either using MKV as default or supporting it in combination with FFV1 as an option.

Fortunately, making CaImAn support loading video data from MKV files natively is a very trivial change, so with this patch it can load data generated in the MKV format directly without any conversion.
All Linux distributions understand MKV natively (via GStreamer or FFmpeg) and Windows supports this format out of the box since Windows 10 as well.

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Has your PR been tested?

Yes, it doesn't break anything and works fine for our files (CaImAn loads and analyzes them)

Thanks for considering!