### PR TITLE
proper loading of 3D .nwb files (solves #749)

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1688,11 +1688,14 @@ def load(file_name: Union[str, List[str]],
                         var_name_hdf5 = fkeys[0]
 
                     if extension == '.nwb':
-                        fgroup = f[var_name_hdf5]['data']
+                        try:
+                            fgroup = f[var_name_hdf5]['data']
+                        except:
+                            fgroup = f['acquisition'][var_name_hdf5]['data']
                     else:
                         fgroup = f[var_name_hdf5]
 
-                    if var_name_hdf5 in f:
+                    if var_name_hdf5 in f or var_name_hdf5 in f['acquisition']:
                         if subindices is None:
                             images = np.array(fgroup).squeeze()
                             #if images.ndim > 3:
@@ -2221,9 +2224,10 @@ def load_iter(file_name, subindices=None, var_name_hdf5: str = 'mov'):
 
                 return
                 #raise StopIteration
-        elif extension in ('.hdf5', '.h5', '.mat'):
+        elif extension in ('.hdf5', '.h5', '.nwb', '.mat'):
             with h5py.File(file_name, "r") as f:
-                Y = f.get(var_name_hdf5)
+                Y = f.get('acquisition/' + var_name_hdf5 + '/data'
+                           if extension == '.nwb' else var_name_hdf5)
                 if subindices is None:
                     for y in Y:
                         yield y

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -232,9 +232,18 @@ class MotionCorrect(object):
         #       from a method that is not a constructor
         if self.min_mov is None:
             if self.gSig_filt is None:
-                self.min_mov = np.array([cm.load(self.fname[0],
-                                                 var_name_hdf5=self.var_name_hdf5,
-                                                 subindices=slice(400))]).min()
+                # self.min_mov = np.array([cm.load(self.fname[0],
+                #                                  var_name_hdf5=self.var_name_hdf5,
+                #                                  subindices=slice(400))]).min()
+                iterator = cm.base.movies.load_iter(self.fname[0],
+                                                    var_name_hdf5=self.var_name_hdf5)
+                mi = np.inf
+                for _ in range(400):
+                    try:
+                        mi = min(mi, next(iterator).min()[()])
+                    except StopIteration:
+                        break
+                self.min_mov = mi
             else:
                 self.min_mov = np.array([high_pass_filter_space(m_, self.gSig_filt)
                     for m_ in cm.load(self.fname[0], var_name_hdf5=self.var_name_hdf5,

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -890,10 +890,7 @@ class CNMFParams(object):
         if self.data['fnames'] is not None:
             if isinstance(self.data['fnames'], str):
                 self.data['fnames'] = [self.data['fnames']]
-            if self.motion['is3D']:
-                T = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0][0]
-            else:
-                T = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[1]
+            T = get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[1]
             if len(self.data['fnames']) > 1:
                 T = T[0]
             num_splits = max(T//max(self.motion['num_frames_split'], 10), 1)

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -785,11 +785,12 @@ def test(Y, A_in, C, f, n_pixels_per_process, nb):
             raise Exception('Dimension of Matrix C must be neurons x time')
 
     if f is not None:
-
         f = np.atleast_2d(f)
         if f.shape[1] == 1:
             raise Exception(
                 'Dimension of Matrix f must be background comps x time ')
+    else:
+        f = np.zeros((0, Y.shape[1]), dtype=np.float32)
 
     if (A_in is None) and (C is None):
         raise Exception('Either A or C need to be determined')

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -1010,6 +1010,8 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                             siz = f[var_name_hdf5]['data'].shape
                         else:
                             siz = f[var_name_hdf5].shape
+                    elif var_name_hdf5 in f['acquisition']:
+                        siz = f['acquisition'][var_name_hdf5]['data'].shape
                     else:
                         logging.error('The file does not contain a variable' +
                                       'named {0}'.format(var_name_hdf5))


### PR DESCRIPTION
# Description

Addresses issue #749 by properly loading 3D *.nwb files and using `load_iter` instead of `load` during motion correction for memory efficiency. 

Fixes # (749)

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.

# Branching

- Pull requests with non breaking bug fixes should be made against the **master** branch.
- All other PRs should be made against the **dev** branch.

# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

```python caimanmanager.py test```

and

```python caimanmanager.py demotest```

prior to submitting your pull request. 

Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.
