### PR TITLE
Python 3.8

### DIFF
--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -358,7 +358,7 @@ class CNMF(object):
                 # sub-optimal behavior. See
                 # https://github.com/flatironinstitute/CaImAn/pull/618#discussion_r313960370
                 # for further details.
-                # b0 = 0 if self.params.get('motion', 'border_nan') is 'copy' else 0
+                # b0 = 0 if self.params.get('motion', 'border_nan') == 'copy' else 0
                 b0 = 0
                 fname_new = mmapping.save_memmap(fname_mc, base_name=base_name, order='C',
                                                  border_to_0=b0)

--- a/demos/general/demo_pipeline.py
+++ b/demos/general/demo_pipeline.py
@@ -136,7 +136,7 @@ def main():
         moviehandle.play(fr=60, q_max=99.5, magnification=2)  # press q to exit
 
 # %% MEMORY MAPPING
-    border_to_0 = 0 if mc.border_nan is 'copy' else mc.border_to_0
+    border_to_0 = 0 if mc.border_nan == 'copy' else mc.border_to_0
     # you can include the boundaries of the FOV if you used the 'copy' option
     # during motion correction, although be careful about the components near
     # the boundaries

--- a/demos/general/demo_pipeline_cnmfE.py
+++ b/demos/general/demo_pipeline_cnmfE.py
@@ -114,7 +114,7 @@ def main():
             plt.xlabel('frames')
             plt.ylabel('pixels')
 
-        bord_px = 0 if border_nan is 'copy' else bord_px
+        bord_px = 0 if border_nan == 'copy' else bord_px
         fname_new = cm.save_memmap(fname_mc, base_name='memmap_', order='C',
                                    border_to_0=bord_px)
     else:  # if no motion correction just memory map the file

--- a/demos/notebooks/demo_dendritic.ipynb
+++ b/demos/notebooks/demo_dendritic.ipynb
@@ -198,7 +198,7 @@
     "#%% Run piecewise-rigid motion correction using NoRMCorre\n",
     "mc.motion_correct(save_movie=True)\n",
     "m_els = cm.load(mc.fname_tot_els)\n",
-    "border_to_0 = 0 if mc.border_nan is 'copy' else mc.border_to_0 \n",
+    "border_to_0 = 0 if mc.border_nan == 'copy' else mc.border_to_0 \n",
     "    # maximum shift to be used for trimming against NaNs"
    ]
   },

--- a/demos/notebooks/demo_pipeline.ipynb
+++ b/demos/notebooks/demo_pipeline.ipynb
@@ -254,7 +254,7 @@
     "#%% Run piecewise-rigid motion correction using NoRMCorre\n",
     "mc.motion_correct(save_movie=True)\n",
     "m_els = cm.load(mc.fname_tot_els)\n",
-    "border_to_0 = 0 if mc.border_nan is 'copy' else mc.border_to_0 \n",
+    "border_to_0 = 0 if mc.border_nan == 'copy' else mc.border_to_0 \n",
     "    # maximum shift to be used for trimming against NaNs"
    ]
   },

--- a/demos/notebooks/demo_pipeline_cnmfE.ipynb
+++ b/demos/notebooks/demo_pipeline_cnmfE.ipynb
@@ -174,7 +174,7 @@
     "        plt.xlabel('frames')\n",
     "        plt.ylabel('pixels')\n",
     "\n",
-    "    bord_px = 0 if border_nan is 'copy' else bord_px\n",
+    "    bord_px = 0 if border_nan == 'copy' else bord_px\n",
     "    fname_new = cm.save_memmap(fname_mc, base_name='memmap_', order='C',\n",
     "                               border_to_0=bord_px)\n",
     "else:  # if no motion correction just memory map the file\n",

--- a/demos/obsolete/1_1/demo_pipeline_1_1.py
+++ b/demos/obsolete/1_1/demo_pipeline_1_1.py
@@ -137,7 +137,7 @@ def main():
 #%% MEMORY MAPPING
     # memory map the file in order 'C'
     border_to_0 = bord_px_els  # exclude borders due to motion correction
-#    border_to_0 = 0 if mc.border_nan is 'copy' else bord_px_els   
+#    border_to_0 = 0 if mc.border_nan == 'copy' else bord_px_els   
         # you can include boundaries if you used the 'copy' option in the motion
         # correction, although be careful abou the components near the boundaries
     fname_new = cm.save_memmap(fnames, base_name='memmap_', order='C',

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- python=3.7
+- python=3.8
 - cython
 - future
 - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -1,14 +1,14 @@
 channels:
 - conda-forge
 dependencies:
-- python=3.7
+- python=3.8
 - bokeh
 - coverage
 - cython
 - future
 - h5py
 - holoviews
-- ipykernel=4.10
+- ipykernel
 - ipython
 - ipyparallel
 - jupyter
@@ -27,7 +27,7 @@ dependencies:
 - scikit-learn
 - scipy
 - tensorflow
-- tifffile=0.15.1
-- tk=8.6.8
+- tifffile
+- tk
 - tqdm
 - yapf

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -37,7 +37,7 @@ export MPLCONFIG=ps
 
 cd `dirname ${BASH_SOURCE[0]}`
 
-for demo in demos/general/*; do
+for demo in demos/general/*.py; do
 	if [ $demo == "demos/general/demo_behavior.py" ]; then
 		echo "	Skipping tests on $demo: This is interactive"
 	elif [ $demo == "demos/general/demo_pipeline_voltage_imaging.py" ]; then

--- a/use_cases/NWB/demo_pipeline_NWB.py
+++ b/use_cases/NWB/demo_pipeline_NWB.py
@@ -146,7 +146,7 @@ def main():
         moviehandle.play(fr=60, q_max=99.5, magnification=2)  # press q to exit
 
 # %% MEMORY MAPPING
-    border_to_0 = 0 if mc.border_nan is 'copy' else mc.border_to_0
+    border_to_0 = 0 if mc.border_nan == 'copy' else mc.border_to_0
     # you can include the boundaries of the FOV if you used the 'copy' option
     # during motion correction, although be careful about the components near
     # the boundaries


### PR DESCRIPTION
This makes necessary adjustments to the codebase to make py38 the normal path for people who build an environment with everything-but-caiman using conda, and who then use pip to compile conda. This is the "dev" workflow.

It passes nosetests and demotests.

This implements half of #711 (the other half will be changing the feedstock).