### PR TITLE
dev: remove some old crift, move towards better handling of temporary files

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -106,15 +106,6 @@ class movie(ts.timeseries):
         else:
             raise Exception('Input must be an ndarray, use load instead!')
 
-    def apply_shifts_online(self, xy_shifts, save_base_name=None):
-        # This function is unused.
-        # todo: todocument
-
-        if save_base_name is None:
-            return movie(apply_shift_online(self, xy_shifts, save_base_name=save_base_name), fr=self.fr)
-        else:
-            return apply_shift_online(self, xy_shifts, save_base_name=save_base_name)
-
     def calc_min(self) -> 'movie':
         # todo: todocument
 

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -677,5 +677,5 @@ def get_tempdir() -> str:
     temp_under_data = os.path.join(caiman_datadir(), "temp")
     if not os.path.isdir(temp_under_data):
         logging.warning(f"Default temporary dir {temp_under_data} does not exist, creating")
-    os.makedirs(temp_under_data)
+    	os.makedirs(temp_under_data)
     return temp_under_data

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -662,3 +662,20 @@ def get_caiman_version() -> Tuple[str, str]:
         if last_modified > newest:
             newest = last_modified
     return 'FILE', str(int(newest))
+
+def get_tempdir() -> str:
+    """ Returns where CaImAn can store temporary files, such as memmap files. Controlled mainly by environment variables """
+    # CAIMAN_TEMP is used to control where temporary files live. 
+    # If unset, uses default of a temp folder under caiman_datadir()
+    # To get the old "store it where I am" behaviour, set CAIMAN_TEMP to a single dot.
+    # If you prefer to store it somewhere different, provide a full path to that location.
+    if 'CAIMAN_TEMP' in os.environ:
+        if os.path.isdir(os.environ['CAIMAN_TEMP']):
+            return os.environ['CAIMAN_TEMP']
+        else:
+            logging.warning(f"CAIMAN_TEMP is set to nonexistent directory {os.environment['CAIMAN_TEMP']}. Ignoring")
+    temp_under_data = os.path.join(caiman_datadir(), "temp")
+    if not os.path.isdir(temp_under_data):
+        logging.warning(f"Default temporary dir {temp_under_data} does not exist, creating")
+    os.makedirs(temp_under_data)
+    return temp_under_data

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -677,5 +677,5 @@ def get_tempdir() -> str:
     temp_under_data = os.path.join(caiman_datadir(), "temp")
     if not os.path.isdir(temp_under_data):
         logging.warning(f"Default temporary dir {temp_under_data} does not exist, creating")
-    	os.makedirs(temp_under_data)
+        os.makedirs(temp_under_data)
     return temp_under_data

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -67,6 +67,7 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
             else:
                 distutils.dir_util.copy_tree(copydir, os.path.join(targdir, copydir))
         os.makedirs(os.path.join(targdir, 'example_movies'), exist_ok=True)
+        os.makedirs(os.path.join(targdir, 'temp'          ), exist_ok=True)
         for stdmovie in standard_movies:
             shutil.copy(stdmovie, os.path.join(targdir, 'example_movies'))
         for extrafile in extra_files:


### PR DESCRIPTION
This:
A) removes an unused function (there's a few more we should probably just let live in the git history)
B) Adds to utils a get_tempdir() that will eventually be used to hold all temporary files belonging to the current run. This is controllable with the CAIMAN_TEMP environment variable, and will default to caiman_data/temp/; the current behaviour (which I consider antisocial and which people have occasionally grumbled at me about; leaves cruft in cwd) can be maintained by setting it to '.'   -- note that this will also make it easier to manage (but not necessarily entirely safe, depending on threading choices) running multiple copies of Caiman at once, differentiated only by env vars. It will also be friendlier to docker and other environments where parts of the exposed filesystem are readonly.

Right now the new function isn't used for anything; subsequent diffs will start using it.

(about 3 years ago I had a similar idea with a different implementation; occasional nags from people got me to revisit the topic and I think this is a better approach because it doesn't pollute the call tree)