### PR TITLE
storagedir

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,31 @@
+Please check this file after new releases; it will cover (only) major changes or changes that will impact how CaImAn runs, and will not generally cover new features or minor changes (see the version history on Github for that). Most recent changes are at the top.
+
+1.9.0
+-----
+This implements a storage layer that, if enabled, will try not to write files
+to the working directory, instead by default saving them to
+
+~/caiman_data/temp/
+
+You can enable it by setting the CAIMAN_NEW_TEMPFILE environment variable, and
+control it further by looking at the docs in caiman/paths.py. In the future this will be the default behaviour.
+
+This serves three purposes:
+1) Some users ran CaImAn from directories with very little free space, but had other directories with plenty of space
+2) Some users wanted to run more than one instance of CaImAn at the same time and didn't want the tempfiles to stomp each other
+3) Leaving things in the current working directory is untidy
+
+In the future, this will likely evolve into a storage manager.
+
+1.8.9
+-----
+Python 3.7-3.9 are supported versions of CaImAn. 3.6 is no longer supported.
+Tensorflow 2.2+ is the supported version of tensorflow for CaImAn.
+
+1.8.3
+-----
+Compatibility with Tensorflow 2.x and Bokeh2
+
+1.6
+---
+First Anaconda packages, available on conda-forge. This is now the recommended install method for Windows and is reasonable on other platforms.

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1749,7 +1749,7 @@ def load(file_name: Union[str, List[str]],
             raise Exception('Unknown file type')
     else:
         logging.error(f"File request:[{file_name}] not found!")
-        raise Exception('File not found!')
+        raise Exception(f'File {file_name} not found!')
 
     return movie(input_arr.astype(outtype),
                  fr=fr,

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -1,28 +1,26 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+
 """
 Class representing a time series.
-
-author: Andrea Giovannucci
 """
 
-#%%
 import cv2
+from datetime import datetime
+from dateutil.tz import tzlocal
 import h5py
 import logging
 import numpy as np
 import os
 import pylab as plt
+from pynwb import NWBHDF5IO, NWBFile
+from pynwb.ophys import TwoPhotonSeries, OpticalChannel
+from pynwb.device import Device
 import pickle as cpk
 from scipy.io import savemat
 import tifffile
 import warnings
-from datetime import datetime
-from dateutil.tz import tzlocal
-from pynwb import NWBHDF5IO, NWBFile
-from pynwb.ophys import TwoPhotonSeries, OpticalChannel
-from pynwb.device import Device
-from caiman.paths import memmap_frames_filename
+
+import caiman.paths
 
 try:
     cv2.setNumThreads(0)
@@ -35,7 +33,6 @@ except:
     pass
 
 
-#%%
 class timeseries(np.ndarray):
     """
     Class representing a time series.
@@ -167,7 +164,8 @@ class timeseries(np.ndarray):
             Exception 'Extension Unknown'
 
         """
-        name, extension = os.path.splitext(file_name)[:2]
+        file_name = caiman.paths.fn_relocated(file_name)
+        name, extension = os.path.splitext(file_name)[:2] # name is only used by the memmap saver
         extension = extension.lower()
         logging.debug("Parsing extension " + str(extension))
 
@@ -289,7 +287,7 @@ class timeseries(np.ndarray):
             input_arr = np.transpose(input_arr, list(range(1, len(dims) + 1)) + [0])
             input_arr = np.reshape(input_arr, (np.prod(dims), T), order='F')
 
-            fname_tot = memmap_frames_filename(base_name, dims, T, order)
+            fname_tot = caiman.paths.memmap_frames_filename(base_name, dims, T, order)
             fname_tot = os.path.join(os.path.split(file_name)[0], fname_tot)
             big_mov = np.memmap(fname_tot,
                                 mode='w+',
@@ -377,3 +375,4 @@ def concatenate(*args, **kwargs):
     except:
         logging.debug('no meta information passed')
         return obj.__class__(np.concatenate(*args, **kwargs))
+

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -63,7 +63,7 @@ from skimage.transform import warp as warp_sk
 import caiman as cm
 import caiman.base.movies
 import caiman.motion_correction
-from caiman.paths import memmap_frames_filename
+import caiman.paths
 from .mmapping import prepare_shape
 
 try:
@@ -492,7 +492,7 @@ class MotionCorrect(object):
         m_reg = np.stack(m_reg, axis=0)
         if save_memmap:
             dims = m_reg.shape
-            fname_tot = memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
+            fname_tot = caiman.paths.memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
             big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
                         shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
             big_mov[:] = np.reshape(m_reg.transpose(1, 2, 0), (np.prod(dims[1:]), dims[0]), order='F')
@@ -582,7 +582,8 @@ def apply_shift_online(movie_iterable, xy_shifts, save_base_name=None, order='F'
     dims = (len(movie_iterable),) + movie_iterable[0].shape  # TODO: Refactor so length is either tracked separately or is last part of tuple
 
     if save_base_name is not None:
-        fname_tot = memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
+        fname_tot = caiman.paths.memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
+        fname_tot = caiman.paths.fn_relocated(fname_tot)
         big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
                             shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
 
@@ -819,7 +820,7 @@ def motion_correct_online(movie_iterable, add_to_movie, max_shift_w=25, max_shif
                 dims = (dims[0], dims[1] + min_h -
                         max_h, dims[2] + min_w - max_w)
 
-            fname_tot:Optional[str] = memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
+            fname_tot:Optional[str] = caiman.paths.memmap_frames_filename(save_base_name, dims[1:], dims[0], order)
             big_mov = np.memmap(fname_tot, mode='w+', dtype=np.float32,
                                 shape=prepare_shape((np.prod(dims[1:]), dims[0])), order=order)
 
@@ -3124,7 +3125,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
     if save_movie:
         if base_name is None:
             base_name = os.path.split(fname)[1][:-4]
-        fname_tot:Optional[str] = memmap_frames_filename(base_name, dims, T, order)
+        fname_tot:Optional[str] = caiman.paths.memmap_frames_filename(base_name, dims, T, order)
         if isinstance(fname,tuple):
             fname_tot = os.path.join(os.path.split(fname[0])[0], fname_tot)
         else:

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -180,7 +180,7 @@ class MotionCorrect(object):
         """
         if 'ndarray' in str(type(fname)):
             logging.info('Creating file for motion correction "tmp_mov_mot_corr.hdf5"')
-            cm.movie(fname).save('./tmp_mov_mot_corr.hdf5') # FIXME don't write to the current directory!
+            cm.movie(fname).save('tmp_mov_mot_corr.hdf5')
             fname = ['./tmp_mov_mot_corr.hdf5']
 
         if type(fname) is not list:

--- a/caiman/paths.py
+++ b/caiman/paths.py
@@ -54,6 +54,8 @@ def fn_relocated(fn:str) -> str:
         but if all they think about is filenames, they go under CaImAn's notion of its temporary dir. This is under the
         principle of "sensible defaults, but users can override them".
     """
+    if not 'CAIMAN_NEW_TEMPFILE' in os.environ: # XXX We will ungate this in a future version of caiman
+        return fn
     if str(os.path.basename(fn)) == str(fn): # No path stuff
         return os.path.join(get_tempdir(), fn)
     else:

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -50,6 +50,7 @@ from ...motion_correction import MotionCorrect
 from ...utils.utils import save_dict_to_hdf5, load_dict_from_hdf5
 from caiman import summary_images
 from caiman import cluster
+import caiman.paths
 
 try:
     cv2.setNumThreads(0)
@@ -655,7 +656,7 @@ class CNMF(object):
         return self
 
 
-    def save(self,filename):
+    def save(self, filename):
         '''save object in hdf5 file format
 
         Args:
@@ -664,9 +665,10 @@ class CNMF(object):
         '''
 
         if '.hdf5' in filename:
+            filename = caiman.paths.fn_relocated(filename)
             save_dict_to_hdf5(self.__dict__, filename)
         else:
-            raise Exception("Filename not supported")
+            raise Exception("File extension not supported for cnmf.save")
 
     def remove_components(self, ind_rm):
         """
@@ -1005,6 +1007,7 @@ def load_CNMF(filename, n_processes=1, dview=None):
     '''
     new_obj = CNMF(n_processes)
     if os.path.splitext(filename)[1].lower() in ('.hdf5', '.h5'):
+        filename = caiman.paths.fn_relocated(filename)
         for key, val in load_dict_from_hdf5(filename).items():
             if key == 'params':
                 prms = CNMFParams()

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -36,6 +36,7 @@ from time import time
 from typing import List, Tuple
 
 import caiman
+import caiman.paths
 from .cnmf import CNMF
 from .estimates import Estimates
 from .initialization import imblur, initialize_components, hals, downscale
@@ -1013,7 +1014,7 @@ class OnACID(object):
                 self.estimates = cnm.estimates
 
             else:
-                Y.save('init_file.hdf5')
+                Y.save(caiman.paths.fn_relocated('init_file.hdf5'))
                 f_new = mmapping.save_memmap(['init_file.hdf5'], base_name='Yr', order='C',
                                              slices=[slice(0, opts['init_batch']), None, None])
 
@@ -1062,7 +1063,7 @@ class OnACID(object):
 
         if '.hdf5' in filename:
             # keys_types = [(k, type(v)) for k, v in self.__dict__.items()]
-            save_dict_to_hdf5(self.__dict__, filename)
+            save_dict_to_hdf5(self.__dict__, caiman.paths.fn_relocated(filename))
         else:
             raise Exception("Unsupported file extension")
 
@@ -2486,7 +2487,7 @@ def initialize_movie_online(Y, K, gSig, rf, stride, base_name,
     # merging threshold, max correlation allowed
     # order of the autoregressive system
     base_name = base_name + '.mmap'
-    fname_new = Y.save(base_name, order='C')
+    fname_new = Y.save(caiman.paths.fn_relocated(base_name), order='C')
     Yr, dims, T = caiman.load_memmap(fname_new)
     d1, d2 = dims
     images = np.reshape(Yr.T, [T] + list(dims), order='F')
@@ -2592,7 +2593,8 @@ def load_OnlineCNMF(filename, dview = None):
             useful to set up parllelization in the objects
     """
 
-    for key,val in load_dict_from_hdf5(filename).items():
+    filename = caiman.paths.fn_relocated(filename)
+    for key, val in load_dict_from_hdf5(filename).items():
         if key == 'params':
             prms = CNMFParams()
             for subdict in val.keys():

--- a/caiman/tests/test_demo.py
+++ b/caiman/tests/test_demo.py
@@ -4,8 +4,8 @@ import numpy.testing as npt
 import numpy as np
 import os
 import caiman as cm
+import caiman.paths
 from caiman.source_extraction import cnmf
-from caiman.paths import caiman_datadir
 
 
 def demo(parallel=False):
@@ -17,7 +17,7 @@ def demo(parallel=False):
         n_processes, dview = 2, None
 
     # LOAD MOVIE AND MEMORYMAP
-    fname_new = cm.save_memmap([os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')],
+    fname_new = cm.save_memmap([os.path.join(caiman.paths.caiman_datadir(), 'example_movies', 'demoMovie.tif')],
                                base_name='Yr',
                                order='C')
     Yr, dims, T = cm.load_memmap(fname_new)

--- a/caimanmanager.py
+++ b/caimanmanager.py
@@ -60,6 +60,7 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
             shutil.copytree(sourcedir_base, targdir)
         else:
             distutils.dir_util.copy_tree(sourcedir_base, targdir)
+        os.makedirs(os.path.join(targdir, 'temp'          ), exist_ok=True)
     else:          # here we recreate the other logical path here. Maintenance concern: Keep these reasonably in sync with what's in setup.py
         for copydir in extra_dirs:
             if not force:


### PR DESCRIPTION
This:
1) Adds a CHANGELOG.txt
2) Reimplements, on user request, the ability to have CaImAn not leave files in the current working directory for its scripts. This is not enabled by default right now, but it passes tests when it is both enabled and when the tests are run from a readonly directory.

I hope to eventually switch this to being enabled by default, but not in 1.9.0.

Longer-term I hope to make a storage manager module that handles everything relating to filenames; it might also pull a lot of other file handling logic out of the rest of the codebase into a central place.

This PR is primarily intended to document the change, but any commentary on it before it lands in dev is welcome.