### PR TITLE
dockerfile copy repository from local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM continuumio/anaconda3
 RUN conda config --set always_yes yes
 RUN conda update --yes conda
 RUN apt-get update && apt-get install -y gcc g++ libgl1
-RUN mkdir src && cd src && git clone -b dev https://github.com/flatironinstitute/CaImAn.git && cd CaImAn && conda env create -n caiman -f environment.yml && conda install --override-channels -c conda-forge -n caiman pip
+COPY . src/CaImAn
+RUN cd src/CaImAn && conda env create -n caiman -f environment.yml && conda install --override-channels -c conda-forge -n caiman pip
 RUN /bin/bash -c "cd src/CaImAn && source activate caiman && /opt/conda/envs/caiman/bin/pip install ."
 RUN /bin/bash -c "source activate caiman && caimanmanager.py install"
 


### PR DESCRIPTION
# Description

The current implementation of the dockerfile clones the repository directly from github, from flatironinstitute's repository.
However, whenever someone forks the repository (or works on a specific branch) the resulted image will contain a different code than intended.

Relevant documentation for creation of a docker image in a project:
https://docs.docker.com/language/python/build-images/

The new solution copies the repository's files directly from the currrent folder.

# Has your PR been tested?

Ran
```python caimanmanager.py test```
successfully.