### PR TITLE
Updates load in movies.py

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1544,7 +1544,7 @@ def load(file_name: Union[str, List[str]],
                                                                       np.arange(shape[1]))
                                                          ).reshape((len(ts),) + shape[1:])
                         else:
-                            input_arr = tffl.asarray()
+                            input_arr = tffl.asarray(out='memmap')
                             input_arr = input_arr[subindices]
 
                 else:


### PR DESCRIPTION
Updates the load function so it uses memory more efficiently when loading a large tiff file stored as a single pagefile.

# Description

When loading a large tiff stored as a single pagefile movies.load() will load the entire tiff file into each active processor. This tends to use up all the available memory. 

Fixes # (issue)

In tffl.asarray() set out = 'memmap'    This uses memory more efficiently but is still slow. 

Please delete options that are not relevant.

- [* ] Bug fix (non-breaking change which fixes an issue)


# Has your PR been tested?
Yes, test and demotest


