### PR TITLE
update to keep data as float32

### DIFF
--- a/caiman/source_extraction/cnmf/merging.py
+++ b/caiman/source_extraction/cnmf/merging.py
@@ -224,14 +224,14 @@ def merge_components(Y, A, b, C, R, f, S, sn_pix, temporal_params,
             R_merged = np.vstack([res[7] for res in merge_res])
         else:
             # we initialize the values
-            A_merged = lil_matrix((d, nbmrg))
-            C_merged = np.zeros((nbmrg, t))
-            R_merged = np.zeros((nbmrg, t))
-            S_merged = np.zeros((nbmrg, t))
-            bl_merged = np.zeros((nbmrg, 1))
-            c1_merged = np.zeros((nbmrg, 1))
-            sn_merged = np.zeros((nbmrg, 1))
-            g_merged = np.zeros((nbmrg, p))
+            A_merged = lil_matrix((d, nbmrg), dtype=np.float32)
+            C_merged = np.zeros((nbmrg, t), dtype=np.float32)
+            R_merged = np.zeros((nbmrg, t), dtype=np.float32)
+            S_merged = np.zeros((nbmrg, t), dtype=np.float32)
+            bl_merged = np.zeros((nbmrg, 1), dtype=np.float32)
+            c1_merged = np.zeros((nbmrg, 1), dtype=np.float32)
+            sn_merged = np.zeros((nbmrg, 1), dtype=np.float32)
+            g_merged = np.zeros((nbmrg, p), dtype=np.float32)
             merged_ROIs = []
             for i in range(nbmrg):
                 merged_ROI = np.where(list_conxcomp[:, ind[i]])[0]

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -203,7 +203,7 @@ def update_spatial_components(Y, C=None, f=None, A_in=None, sn=None, dims=None,
     nr = np.shape(C)[0]
     if normalize_yyt_one and C is not None:
         C = np.array(C)
-        d_ = scipy.sparse.lil_matrix((nr, nr))
+        d_ = scipy.sparse.lil_matrix((nr, nr), dtype=np.float32)
         d_.setdiag(np.sqrt(np.sum(C ** 2, 1)))
         A_in = A_in * d_
         C = C/(np.sqrt((C**2).sum(1))[:, np.newaxis] + np.finfo(np.float32).eps)
@@ -534,7 +534,7 @@ def threshold_components(A, dims, medw=None, thr_method='max', maxthr=0.1, nrgth
         indices.extend(At.indices.tolist())
         data.extend(At.data.tolist())
 
-    Ath = csc_matrix((data, indices, indptr), shape=(d, nr))
+    Ath = csc_matrix((data, indices, indptr), shape=(d, nr), dtype=np.float32)
     return Ath
 
 
@@ -610,7 +610,7 @@ def threshold_components_parallel(pars):
 
     # if we have deleted the element
     if BW.max() == 0:
-        return csr_matrix(Ath2), i
+        return csr_matrix(Ath2, dtype=np.float32), i
     #
     # we want to extract the largest connected component ( to remove small unconnected pixel )
     if extract_cc:
@@ -628,7 +628,7 @@ def threshold_components_parallel(pars):
         BW = BW.flatten()
         Ath2[BW] = Ath[BW]
 
-    return csr_matrix(Ath2), i
+    return csr_matrix(Ath2, dtype=np.float32), i
 
 def nnls_L0(X, Yp, noise):
     """


### PR DESCRIPTION
# Description
Fixes an issue which arose recently where dtype becomes float64 for the estimates (A and C). This causes an inefficient use of memory. e.g. when reconstructing the denoised movie.


# Type of change
Specified dtype=np.float32 as an argument for several numpy functions. 

- [ *] Bug fix (non-breaking change which fixes an issue)


# Has your PR been tested?
Yes, test and demotest with caimanmanager

