### PR TITLE
Allow custom basename when saving mcorr memmaps

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -2976,8 +2976,7 @@ def motion_correct_batch_pwrigid(fname, max_shifts, strides, overlaps, add_to_mo
                                                             newoverlaps=newoverlaps, newstrides=newstrides,
                                                             upsample_factor_grid=upsample_factor_grid, order='F', dview=dview, save_movie=save_movie,
                                                             base_name=base_name, num_splits=num_splits_to_process,
-                                                            shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, base_name_prefix=base_name_prefix,
-                                                            gSig_filt=gSig_filt,
+                                                            shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
                                                             use_cuda=use_cuda, border_nan=border_nan, var_name_hdf5=var_name_hdf5, is3D=is3D,
                                                             indices=indices)
 


### PR DESCRIPTION
# Description

Currently, if the same input file is put through motion correction with different parameter variants the resulting motion corrected memmap will always have the same filename. I could not find a way to set the filename of mcorrr memmaps that are saved when setting `save_movie=True` in `MotionCorrect.motion_correct()`.

I added a kwarg called `base_name_prefix` to `MotionCorrect.motion_correct()` which allows a user to append a prefix to the basename that is used when saving memmaps. By default it is set to `None`, but if a user supplies a `str` it will set that as a prefix to the `base_name` when saving the memmap.

Let me know if there's a better way to do this!

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.

# Branching
targets `dev`

# Has your PR been tested?

Tested that currently functionality isn't broken by running `test_demos.sh`, no failures. Also tested the new functionality and it does work, prefixes are set to saved memmaps.