### PR TITLE
R check none byte

### DIFF
--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -381,7 +381,7 @@ class Estimates(object):
 
         plt.ion()
         nr, T = self.C.shape
-        if self.R is None:
+        if self.R is None or self.R == b'NoneType':
             self.R = self.YrA
         if self.R.shape != [nr, T]:
             if self.YrA is None:
@@ -433,7 +433,7 @@ class Estimates(object):
 
         plt.ion()
         nr, T = self.C.shape
-        if self.R is None:
+        if self.R is None or self.R == b'NoneType':
             self.R = self.YrA
         if self.R.shape != [nr, T]:
             if self.YrA is None:


### PR DESCRIPTION
# Description
Changes it so on initial use after reconstruction of cnmf object from memory, component viewers will work, as discussed here:

https://github.com/flatironinstitute/CaImAn/issues/967)

Fixes #967

# Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.

# Has your PR been tested?
I made sure that the viewers worked in a demo notebook that initiated a fresh cnmf instance from memory. 

I ran test/demotest which both succeeded.