### PR TITLE
Fix cnmf utils get file size for tiff files created in append mode

### DIFF
--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -993,7 +993,12 @@ def get_file_size(file_name, var_name_hdf5='mov'):
             if extension in ['.tif', '.tiff', '.btf']:
                 tffl = tifffile.TiffFile(file_name)
                 siz = tffl.series[0].shape
-                T, dims = siz[0], siz[1:]
+                # tiff files written in append mode
+                if len(siz) < 3:
+                    dims = siz
+                    T = len(tffl.pages)
+                else:
+                    T, dims = siz[0], siz[1:]
             elif extension in ('.avi', '.mkv'):
                 cap = cv2.VideoCapture(file_name)
                 dims = [0, 0]


### PR DESCRIPTION
# Description

Tiff files created in append mode raise an IndexError when saving the memmaped motion correction movie. This is due to `cnmf.utilities.get_file_size()` returning the wrong dims.

Example: 

```python
# tiff file written in append mode
cm.source_extraction.cnmf.utilities.get_file_size("/home/kushal/tiff_mcorr_issues/ap1_1_pt_5a.tif")
>>> ((216,), 270)

# non-append mode but still multi-page tiff
cm.source_extraction.cnmf.utilities.get_file_size("/home/kushal/tiff_mcorr_issues/ap1_1_pt_5a_single.tif")
>>> ((270, 216), 27090)
```

Tiff files created in append mode are created like this:

```python
tif_writer = tifffile.TiffWriter(output_path, bigtiff=True, append=True)

for frame_ix in range(n_frames):
    # do stuff to generate my output frame
    tif_writer.write(frame)
```

Tests passing on my end.

Stack trace without the fix:
```python
IndexError                                Traceback (most recent call last)
Input In [9], in <cell line: 2>()
      1 # correct for rigid motion correction and save the file (in memory mapped form)
----> 2 mc.motion_correct(save_movie=True)

File ~/repos/CaImAn/caiman/motion_correction.py:267, in MotionCorrect.motion_correct(self, template, save_movie)
    264         b0 = np.ceil(np.maximum(np.max(np.abs(self.x_shifts_els)),
    265                             np.max(np.abs(self.y_shifts_els))))
    266 else:
--> 267     self.motion_correct_rigid(template=template, save_movie=save_movie)
    268     b0 = np.ceil(np.max(np.abs(self.shifts_rig)))
    269 self.border_to_0 = b0.astype(np.int)

File ~/repos/CaImAn/caiman/motion_correction.py:301, in MotionCorrect.motion_correct_rigid(self, template, save_movie)
    298 self.shifts_rig:List = []
    300 for fname_cur in self.fname:
--> 301     _fname_tot_rig, _total_template_rig, _templates_rig, _shifts_rig = motion_correct_batch_rigid(
    302         fname_cur,
    303         self.max_shifts,
    304         dview=self.dview,
    305         splits=self.splits_rig,
    306         num_splits_to_process=self.num_splits_to_process_rig,
    307         num_iter=self.niter_rig,
    308         template=self.total_template_rig,
    309         shifts_opencv=self.shifts_opencv,
    310         save_movie_rigid=save_movie,
    311         add_to_movie=-self.min_mov,
    312         nonneg_movie=self.nonneg_movie,
    313         gSig_filt=self.gSig_filt,
    314         use_cuda=self.use_cuda,
    315         border_nan=self.border_nan,
    316         var_name_hdf5=self.var_name_hdf5,
    317         is3D=self.is3D,
    318         indices=self.indices)
    319     if template is None:
    320         self.total_template_rig = _total_template_rig

File ~/repos/CaImAn/caiman/motion_correction.py:2834, in motion_correct_batch_rigid(fname, max_shifts, dview, splits, num_splits_to_process, num_iter, template, shifts_opencv, save_movie_rigid, add_to_movie, nonneg_movie, gSig_filt, subidx, use_cuda, border_nan, var_name_hdf5, is3D, indices)
   2831 else:
   2832     base_name=os.path.splitext(os.path.split(fname)[-1])[0] + '_rig_'
-> 2834 fname_tot_rig, res_rig = motion_correction_piecewise(fname, splits, strides=None, overlaps=None,
   2835                                                      add_to_movie=add_to_movie, template=old_templ, max_shifts=max_shifts, max_deviation_rigid=0,
   2836                                                      dview=dview, save_movie=save_movie, base_name=base_name, subidx = subidx,
   2837                                                      num_splits=num_splits_to_process, shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
   2838                                                      use_cuda=use_cuda, border_nan=border_nan, var_name_hdf5=var_name_hdf5, is3D=is3D,
   2839                                                      indices=indices)
   2840 if is3D:
   2841     new_templ = np.nanmedian(np.stack([r[-1] for r in res_rig]), 0)           

File ~/repos/CaImAn/caiman/motion_correction.py:3099, in motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie, template, max_shifts, max_deviation_rigid, newoverlaps, newstrides, upsample_factor_grid, order, dview, save_movie, base_name, subidx, num_splits, shifts_opencv, nonneg_movie, gSig_filt, use_cuda, border_nan, var_name_hdf5, is3D, indices)
   3097 dims, T = cm.source_extraction.cnmf.utilities.get_file_size(fname, var_name_hdf5=var_name_hdf5)
   3098 z = np.zeros(dims)
-> 3099 dims = z[indices].shape
   3100 logging.debug(f'Number of Splits: {splits}')
   3101 if isinstance(splits, int):

IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
