### PR TITLE
Fix cropping method and add ability to save compressed .avi files with the FFV1 codec

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -549,19 +549,15 @@ class movie(ts.timeseries):
 
     def crop(self, crop_top=0, crop_bottom=0, crop_left=0, crop_right=0, crop_begin=0, crop_end=0) -> None:
         """
-        Crop movie
+        Crop movie (inline)
 
         Args:
             crop_top/crop_bottom/crop_left,crop_right: (undocumented)
 
             crop_begin/crop_end: (undocumented)
-            
-        Return:
-            cropped movie
         """
         t, h, w = self.shape
-        cropped_movie = self[crop_begin:t - crop_end, crop_top:h - crop_bottom, crop_left:w - crop_right]
-        return cropped_movie
+        self[:, :, :] = self[crop_begin:t - crop_end, crop_top:h - crop_bottom, crop_left:w - crop_right]
     
     def removeBL(self, windowSize:int=100, quantilMin:int=8, in_place:bool=False, returnBL:bool=False):                   
         """

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -549,15 +549,19 @@ class movie(ts.timeseries):
 
     def crop(self, crop_top=0, crop_bottom=0, crop_left=0, crop_right=0, crop_begin=0, crop_end=0) -> None:
         """
-        Crop movie (inline)
+        Crop movie
 
         Args:
             crop_top/crop_bottom/crop_left,crop_right: (undocumented)
 
             crop_begin/crop_end: (undocumented)
+            
+        Return:
+            cropped movie
         """
         t, h, w = self.shape
-        self[:, :, :] = self[crop_begin:t - crop_end, crop_top:h - crop_bottom, crop_left:w - crop_right]
+        cropped_movie = self[crop_begin:t - crop_end, crop_top:h - crop_bottom, crop_left:w - crop_right]
+        return cropped_movie
     
     def removeBL(self, windowSize:int=100, quantilMin:int=8, in_place:bool=False, returnBL:bool=False):                   
         """

--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -160,6 +160,10 @@ class timeseries(np.ndarray):
             q_max, q_min: float in [0, 100]
                 percentile for maximum/minimum clipping value if saving as avi
                 (If set to None, no automatic scaling to the dynamic range [0, 255] is performed)
+                
+            compress: int
+                if saving as .tif, specifies the compression level
+                if saving as .avi or .mkv, compress=0 uses the IYUV codec, otherwise the FFV1 codec is used
 
         Raises:
             Exception 'Extension Unknown'
@@ -207,10 +211,16 @@ class timeseries(np.ndarray):
                      file_name=self.file_name)
         elif extension in ('.avi', '.mkv'):
             codec = None
-            try:
-                codec = cv2.FOURCC('I', 'Y', 'U', 'V')
-            except AttributeError:
-                codec = cv2.VideoWriter_fourcc(*'IYUV')
+            if compress == 0:
+                try:
+                    codec = cv2.FOURCC('I', 'Y', 'U', 'V')
+                except AttributeError:
+                    codec = cv2.VideoWriter_fourcc(*'IYUV')
+            else:
+                try:
+                    codec = cv2.FOURCC('F', 'F', 'V', '1')
+                except AttributeError:
+                    codec = cv2.VideoWriter_fourcc(*'FFV1')
             if q_max is None or q_min is None:
                 data = self.astype(np.uint8)
             else:


### PR DESCRIPTION
# Description

This pull request fixes the cropping method in the movie class, which gives a ValueError when run (e.g., "ValueError: could not broadcast input array from shape (1000,340,348) into shape (1000,390,388)"). The changes make it so the cropped movie is returned and not cropped inline.

A second edit also allows timeseries.save to save .avi files using the FFV1 codec, which a lossless codec, resulting in a much smaller file size.

# Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Has your PR been tested?

It had one error running python caimanmanager.py test: the parallel test. I'm not sure what the issue is, since my edits are minor and shouldn't affect the parallel processing. I've recently been getting parallel errors with my computer (prior to any edits of the code), though, so that's likely the issue.

The demotest ran successfully.