### PR TITLE
Update docstrings and fix typos in `run_CNMF_patches`

### DIFF
--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -170,16 +170,16 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
         gnb: int
             number of global background components
 
-        backend: string
-            'ipyparallel' or 'single_thread' or SLURM
-
-        n_processes: int
-            nuber of cores to be used (should be less than the number of cores started with ipyparallel)
+        dview: 
+            TODO
 
         memory_fact: double
             unitless number accounting how much memory should be used.
             It represents the fration of patch processed in a single thread.
              You will need to try different values to see which one would work
+
+        border_pix: int
+            TODO
 
         low_rank_background: bool
             if True the background is approximated with gnb components. If false every patch keeps its background (overlaps are randomly assigned to one spatial component only)
@@ -189,10 +189,20 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
             I.e. neurons that are closer to the center of another patch are removed to
             avoid duplicates, cause the other patch should already account for them.
 
+        indices: List[slice]
+            TODO
+
     Returns:
+
         A_tot: matrix containing all the components from all the patches
 
         C_tot: matrix containing the calcium traces corresponding to A_tot
+        
+        YrA_tot: TODO
+
+        b: TODO
+
+        f: TODO
 
         sn_tot: per pixel noise estimate
 

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -165,7 +165,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
             dimensions of the original movie across y, x, and time
 
         params:
-            CNMFParms object containing all the parameters for the various algorithms
+            CNMFParams object containing all the parameters for the various algorithms
 
         gnb: int
             number of global background components

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -47,7 +47,7 @@ def cnmf_patches(args_in):
                 dimensions of the original movie across y, x, and time
 
             params:
-                CNMFParms object containing all the parameters for the various algorithms
+                CNMFParams object containing all the parameters for the various algorithms
 
             rf: int
                 half-size of the square patch in pixel


### PR DESCRIPTION
# Description

- Fixed a docstring typo, `CNMFParms` -> `CNMFParams`.
- Adapted the docstring of `map_reduce.run_CNMF_patches` to match the actual function signature

Note: Since I do not know the details of this function, I could not write the full docstrings myself. I opted to have a complete and up-to-date docstring, and left TODO notes for the arguments that were not documented.

# Type of change

- [x] Changes in documentation or new examples for demos and/or use cases.

# Has your PR been tested?

Not tested, as it is just a trivial change in the docs.