### PR TITLE
sklearn deprecation, remove `normalize` from LassoLars

### DIFF
--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -410,7 +410,7 @@ def regression_ipyparallel(pars):
                 model = make_pipeline(
                     StandardScaler(with_mean=False),
                     linear_model.LassoLars(alpha=lambda_lasso, positive=True,
-                                                 fit_intercept=True, normalize=False)
+                                                 fit_intercept=True)
                     )
                 a = model.fit(np.array(c.T), np.ravel(y))['lassolars'].coef_
 


### PR DESCRIPTION
# Description

minor change, the latest sklearn v1.2 that just released deprecated the `normalize` kwarg for `LassoLars`, it just produces a massive stream of warnings during CNMF (they can be disabled but it'll be removed by v1.4 so might as well fix it?)

```python3
/home/kushalk/python-venvs/mescore/lib/python3.10/site-packages/sklearn/linear_model/_base.py:117: FutureWarning: 'normalize' was deprecated in version 1.2 and will be removed in 1.4. Please leave the normalize parameter to its default value to silence this warning. The default behavior of this estimator is to not do any normalization. If normalization is needed please use sklearn.preprocessing.StandardScaler instead.
  warnings.warn(
```

not exactly sure which tests should be used, I ran `nose2` in the root dir with both `nose` and `nose2` installed and the tests pass, see #1021 