### PR TITLE
play movies w/o loading them into memory

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1240,164 +1240,8 @@ class movie(ts.timeseries):
         Raises:
             Exception 'Unknown backend!'
         """
-        # todo: todocument
-        if backend == 'pylab':
-            logging.warning('*** WARNING *** SPEED MIGHT BE LOW. USE opencv backend if available')
-
-        gain *= 1.     # convert to float in case we were passed an int
-        if q_max < 100:
-            maxmov = np.nanpercentile(self[0:10], q_max)
-        else:
-            maxmov = np.nanmax(self)
-
-        if q_min > 0:
-            minmov = np.nanpercentile(self[0:10], q_min)
-        else:
-            minmov = np.nanmin(self)
-
-        def process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text):
-            if bord_px is not None and np.sum(bord_px) > 0:
-                frame = frame[bord_px:-bord_px, bord_px:-bord_px]
-            if magnification != 1:
-                frame = cv2.resize(frame, None, fx=magnification, fy=magnification, interpolation=interpolation)
-            frame = (offset + frame - minmov) * gain / (maxmov - minmov)
-
-            if plot_text == True:
-                text_width, text_height = cv2.getTextSize('Frame = ' + str(iddxx),
-                                                            fontFace=5,
-                                                            fontScale=0.8,
-                                                            thickness=1)[0]
-                cv2.putText(frame,
-                            'Frame = ' + str(iddxx),
-                            ((frame.shape[1] - text_width) // 2, frame.shape[0] - (text_height + 5)),
-                            fontFace=5,
-                            fontScale=0.8,
-                            color=(255, 255, 255),
-                            thickness=1)
-            return frame
-
-        if backend == 'pylab':
-            pl.ion()
-            fig = pl.figure(1)
-            ax = fig.add_subplot(111)
-            ax.set_title("Play Movie")
-            im = ax.imshow((offset + self[0] - minmov) * gain / (maxmov - minmov + offset),
-                           cmap=pl.cm.gray,
-                           vmin=0,
-                           vmax=1,
-                           interpolation='none')                                            # Blank starting image
-            fig.show()
-            im.axes.figure.canvas.draw()
-            pl.pause(1)
-
-        elif backend == 'notebook':
-            # First set up the figure, the axis, and the plot element we want to animate
-            fig = pl.figure()
-            im = pl.imshow(self[0], interpolation='None', cmap=pl.cm.gray)
-            pl.axis('off')
-
-            def animate(i):
-                im.set_data(self[i])
-                return im,
-
-            # call the animator.  blit=True means only re-draw the parts that have changed.
-            anim = animation.FuncAnimation(fig, animate, frames=self.shape[0], interval=1, blit=True)
-
-            # call our new function to display the animation
-            return visualization.display_animation(anim, fps=fr)
-
-        elif backend == 'embed_opencv':
-            stopButton = widgets.ToggleButton(
-                value=False,
-                description='Stop',
-                disabled=False,
-                button_style='danger', # 'success', 'info', 'warning', 'danger' or ''
-                tooltip='Description',
-                icon='square' # (FontAwesome names without the `fa-` prefix)
-            )
-            def view(button):
-                display_handle=display(None, display_id=True)
-                for iddxx, frame in enumerate(self):
-                    frame = process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text)
-                    display_handle.update(Image(data=cv2.imencode(
-                            '.jpg', np.minimum((frame * 255.), 255).astype('u1'))[1].tobytes()))
-                    pl.pause(1. / fr)
-                    if stopButton.value==True:
-                        break
-            display(stopButton)
-            thread = threading.Thread(target=view, args=(stopButton,))
-            thread.start()
-
-        if fr is None:
-            fr = self.fr
-
-        looping = True
-        terminated = False
-        if save_movie:
-            fourcc = cv2.VideoWriter_fourcc(*opencv_codec)
-            frame_in = self[0]
-            if bord_px is not None and np.sum(bord_px) > 0:
-                frame_in = frame_in[bord_px:-bord_px, bord_px:-bord_px]
-            out = cv2.VideoWriter(movie_name, fourcc, 30.,
-                                  tuple([int(magnification * s) for s in frame_in.shape[1::-1]]))
-        while looping:
-
-            for iddxx, frame in enumerate(self):
-                if bord_px is not None and np.sum(bord_px) > 0:
-                    frame = frame[bord_px:-bord_px, bord_px:-bord_px]
-
-                if backend == 'opencv' or (backend == 'embed_opencv' and save_movie):
-                    frame = process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text)
-                    if backend == 'opencv':
-                        cv2.imshow('frame', frame)
-                    if save_movie:
-                        if frame.ndim < 3:
-                            frame = np.repeat(frame[:, :, None], 3, axis=-1)
-                        frame = np.minimum((frame * 255.), 255).astype('u1')
-                        out.write(frame)
-                    if backend == 'opencv' and (cv2.waitKey(int(1. / fr * 1000)) & 0xFF == ord('q')):
-                        looping = False
-                        terminated = True
-                        break
-
-                elif backend == 'embed_opencv' and not save_movie:
-                    break
-
-                elif backend == 'pylab':
-                    im.set_data((offset + frame) * gain / maxmov)
-                    ax.set_title(str(iddxx))
-                    pl.axis('off')
-                    fig.canvas.draw()
-                    pl.pause(1. / fr * .5)
-                    ev = pl.waitforbuttonpress(1. / fr * .5)
-                    if ev is not None:
-                        pl.close()
-                        break
-
-                elif backend == 'notebook':
-                    logging.debug('Animated via MP4')
-                    break
-
-                else:
-                    raise Exception('Unknown backend!')
-
-            if terminated:
-                break
-
-            if save_movie:
-                out.release()
-                save_movie = False
-
-            if do_loop:
-                looping = True
-            else:
-                looping = False
-
-        if backend == 'opencv':
-            cv2.waitKey(100)
-            cv2.destroyAllWindows()
-            for i in range(10):
-                cv2.waitKey(100)
+        play(self, gain, fr, magnification, offset, interpolation, backend, do_loop, bord_px,
+             q_max, q_min, plot_text, save_movie, opencv_codec, movie_name)
 
 
 def load(file_name: Union[str, List[str]],
@@ -2321,6 +2165,11 @@ def load_iter(file_name: Union[str, List[str]], subindices=None, var_name_hdf5: 
                     #raise StopIteration
             elif extension in ('.hdf5', '.h5', '.nwb', '.mat'):
                 with h5py.File(file_name, "r") as f:
+                    ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed.
+                    fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
+                    if len(fkeys) == 1 and 'Dataset' in str(type(f[fkeys[0]])): # If the hdf5 file we're parsing has only one dataset inside it,
+                                                                                # ignore the arg and pick that dataset
+                        var_name_hdf5 = fkeys[0]
                     Y = f.get('acquisition/' + var_name_hdf5 + '/data'
                             if extension == '.nwb' else var_name_hdf5)
                     if subindices is None:
@@ -2340,3 +2189,251 @@ def load_iter(file_name: Union[str, List[str]], subindices=None, var_name_hdf5: 
         else:
             logging.error(f"File request:[{file_name}] not found!")
             raise Exception('File not found!')
+
+
+def play(movie,
+         gain: float = 1,
+         fr=None,
+         magnification: float = 1,
+         offset: float = 0,
+         interpolation=cv2.INTER_LINEAR,
+         backend: str = 'opencv',
+         do_loop: bool = False,
+         bord_px=None,
+         q_max: float = 99.75,
+         q_min: float = 1,
+         plot_text: bool = False,
+         save_movie: bool = False,
+         opencv_codec: str = 'H264',
+         movie_name: str = 'movie.avi',
+         var_name_hdf5: str = 'mov') -> None:
+    """
+    Play the movie using opencv
+
+    Args:
+        movie: movie object, or filename or list of filenames
+
+        gain: adjust movie brightness
+
+        fr: framerate, playing speed if different from original (inter frame interval in seconds)
+
+        magnification: float
+            magnification factor
+
+        offset: (undocumented)
+
+        interpolation:
+            interpolation method for 'opencv' and 'embed_opencv' backends
+
+        backend: 'pylab', 'notebook', 'opencv' or 'embed_opencv'; the latter 2 are much faster
+
+        do_loop: Whether to loop the video
+
+        bord_px: int
+            truncate pixels from the borders
+
+        q_max, q_min: float in [0, 100]
+             percentile for maximum/minimum plotting value
+
+        plot_text: bool
+            show some text
+
+        save_movie: bool
+            flag to save an avi file of the movie
+
+        opencv_codec: str
+            FourCC video codec for saving movie. Check http://www.fourcc.org/codecs.php
+
+        movie_name: str
+            name of saved file
+
+        var_name_hdf5: str
+            if loading from hdf5/n5 name of the dataset inside the file to load (ignored if the file only has one dataset)
+
+    Raises:
+        Exception 'Unknown backend!'
+    """
+    # todo: todocument
+    it = True if (isinstance(movie, list) or isinstance(movie, tuple) or isinstance(movie, str)) else False
+    if backend == 'pylab':
+        logging.warning('*** WARNING *** SPEED MIGHT BE LOW. USE opencv backend if available')
+
+    gain *= 1.     # convert to float in case we were passed an int
+    if q_max < 100:
+        maxmov = np.nanpercentile(load(movie, subindices=slice(0,10), var_name_hdf5=var_name_hdf5) if it else movie[0:10], q_max)
+    else:
+        if it:
+            maxmov = -np.inf
+            for frame in load_iter(movie, var_name_hdf5=var_name_hdf5):
+                maxmov = max(maxmov, np.nanmax(frame))
+        else:
+            maxmov = np.nanmax(movie)
+
+    if q_min > 0:
+        minmov = np.nanpercentile(load(movie, subindices=slice(0,10), var_name_hdf5=var_name_hdf5) if it else movie[0:10], q_min)
+    else:
+        if it:
+            minmov = np.inf
+            for frame in load_iter(movie, var_name_hdf5=var_name_hdf5):
+                minmov = min(minmov, np.nanmin(frame))
+        else:
+            minmov = np.nanmin(movie)
+
+    def process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text):
+        if bord_px is not None and np.sum(bord_px) > 0:
+            frame = frame[bord_px:-bord_px, bord_px:-bord_px]
+        if magnification != 1:
+            frame = cv2.resize(frame, None, fx=magnification, fy=magnification, interpolation=interpolation)
+        frame = (offset + frame - minmov) * gain / (maxmov - minmov)
+
+        if plot_text == True:
+            text_width, text_height = cv2.getTextSize('Frame = ' + str(iddxx),
+                                                        fontFace=5,
+                                                        fontScale=0.8,
+                                                        thickness=1)[0]
+            cv2.putText(frame,
+                        'Frame = ' + str(iddxx),
+                        ((frame.shape[1] - text_width) // 2, frame.shape[0] - (text_height + 5)),
+                        fontFace=5,
+                        fontScale=0.8,
+                        color=(255, 255, 255),
+                        thickness=1)
+        return frame
+
+    if backend == 'pylab':
+        pl.ion()
+        fig = pl.figure(1)
+        ax = fig.add_subplot(111)
+        ax.set_title("Play Movie")
+        im = ax.imshow((offset + (load(movie, subindices=slice(0,2), var_name_hdf5=var_name_hdf5) if it else movie)[0] - minmov) * gain / (maxmov - minmov + offset),
+                       cmap=pl.cm.gray,
+                       vmin=0,
+                       vmax=1,
+                       interpolation='none')                                            # Blank starting image
+        fig.show()
+        im.axes.figure.canvas.draw()
+        pl.pause(1)
+
+    elif backend == 'notebook':
+        # First set up the figure, the axis, and the plot element we want to animate
+        fig = pl.figure()
+        im = pl.imshow(next(load_iter(movie, subindices=slice(0,1), var_name_hdf5=var_name_hdf5))\
+                    if it else movie[0], interpolation='None', cmap=pl.cm.gray)
+        pl.axis('off')
+
+        if it:
+            m_iter = load_iter(movie, var_name_hdf5=var_name_hdf5)
+            def animate(i):
+                try:
+                    im.set_data(next(m_iter))
+                except StopIteration:
+                    pass
+                return im,
+        else:
+            def animate(i):
+                im.set_data(movie[i])
+                return im,
+
+        # call the animator.  blit=True means only re-draw the parts that have changed.
+        frames = cm.source_extraction.cnmf.utilities.get_file_size(movie)[-1] if it else movie.shape[0]
+        anim = animation.FuncAnimation(fig, animate, frames=frames, interval=1, blit=True)
+
+        # call our new function to display the animation
+        return visualization.display_animation(anim, fps=fr)
+
+    elif backend == 'embed_opencv':
+        stopButton = widgets.ToggleButton(
+            value=False,
+            description='Stop',
+            disabled=False,
+            button_style='danger', # 'success', 'info', 'warning', 'danger' or ''
+            tooltip='Description',
+            icon='square' # (FontAwesome names without the `fa-` prefix)
+        )
+        def view(button):
+            display_handle=display(None, display_id=True)
+            for iddxx, frame in enumerate(load_iter(movie, var_name_hdf5=var_name_hdf5) if it else movie):
+                frame = process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text)
+                display_handle.update(Image(data=cv2.imencode(
+                        '.jpg', np.clip((frame * 255.), 0, 255).astype('u1'))[1].tobytes()))
+                pl.pause(1. / fr)
+                if stopButton.value==True:
+                    break
+        display(stopButton)
+        thread = threading.Thread(target=view, args=(stopButton,))
+        thread.start()
+
+    if fr is None:
+        try:
+            fr = movie.fr
+        except AttributeError:
+            raise Exception('Argument fr is None. You must provide the framerate for playing the movie.')
+
+    looping = True
+    terminated = False
+    if save_movie:
+        fourcc = cv2.VideoWriter_fourcc(*opencv_codec)
+        frame_in = next(load_iter(movie, subindices=slice(0,1), var_name_hdf5=var_name_hdf5))\
+                    if it else movie[0]
+        if bord_px is not None and np.sum(bord_px) > 0:
+            frame_in = frame_in[bord_px:-bord_px, bord_px:-bord_px]
+        out = cv2.VideoWriter(movie_name, fourcc, 30.,
+                              tuple([int(magnification * s) for s in frame_in.shape[1::-1]]))
+    while looping:
+
+        for iddxx, frame in enumerate(load_iter(movie, var_name_hdf5=var_name_hdf5) if it else movie):
+            if bord_px is not None and np.sum(bord_px) > 0:
+                frame = frame[bord_px:-bord_px, bord_px:-bord_px]
+
+            if backend == 'opencv' or (backend == 'embed_opencv' and save_movie):
+                frame = process_frame(iddxx, frame, bord_px, magnification, interpolation, minmov, maxmov, gain, offset, plot_text)
+                if backend == 'opencv':
+                    cv2.imshow('frame', frame)
+                if save_movie:
+                    if frame.ndim < 3:
+                        frame = np.repeat(frame[:, :, None], 3, axis=-1)
+                    frame = np.minimum((frame * 255.), 255).astype('u1')
+                    out.write(frame)
+                if backend == 'opencv' and (cv2.waitKey(int(1. / fr * 1000)) & 0xFF == ord('q')):
+                    looping = False
+                    terminated = True
+                    break
+
+            elif backend == 'embed_opencv' and not save_movie:
+                break
+
+            elif backend == 'pylab':
+                im.set_data((offset + frame) * gain / maxmov)
+                ax.set_title(str(iddxx))
+                pl.axis('off')
+                fig.canvas.draw()
+                pl.pause(1. / fr * .5)
+                ev = pl.waitforbuttonpress(1. / fr * .5)
+                if ev is not None:
+                    pl.close()
+                    break
+
+            elif backend == 'notebook':
+                logging.debug('Animated via MP4')
+                break
+
+            else:
+                raise Exception('Unknown backend!')
+
+        if terminated:
+            break
+
+        if save_movie:
+            out.release()
+            save_movie = False
+
+        if do_loop:
+            looping = True
+        else:
+            looping = False
+
+    if backend == 'opencv':
+        cv2.waitKey(100)
+        cv2.destroyAllWindows()
+        for i in range(10):
+            cv2.waitKey(100)

--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -15,8 +15,7 @@ import numpy as np
 import os
 
 import scipy
-from scipy.ndimage.filters import gaussian_filter
-from scipy.ndimage import label, center_of_mass
+from scipy.ndimage import label, gaussian_filter
 from scipy.optimize import linear_sum_assignment
 
 import shutil


### PR DESCRIPTION
# Description

To play a movie means iterating over its frames and displaying them. If only there was such a thing as a python iterator ;), which there is!

This moves the code of the `movies` `play()` method into a function and adds the option to provide a (list of) filename(s) instead of a `movie` object, which avoids loading the movie in memory by using `load_iter()` instead of `load()`. 


# Type of change

- [x] New feature (non-breaking change which adds functionality)