### PR TITLE
cnmf/online_cnmf.py:OnACID.initialize_online(): Fix call to np.percentile()

### DIFF
--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -1037,7 +1037,7 @@ class OnACID(object):
         T1 = np.array(Ts).sum()*self.params.get('online', 'epochs') if T is None else T
         self._prepare_object(Yr, T1)
         if opts['show_movie']:
-            self.bnd_AC = np.percentile(self.estimates.A.dot(self.estimates.C),
+            self.bnd_AC = np.percentile(np.ravel(self.estimates.A.dot(self.estimates.C)),
                                         (0.001, 100-0.005))
             #self.bnd_BG = np.percentile(self.estimates.b.dot(self.estimates.f),
             #                            (0.001, 100-0.001))


### PR DESCRIPTION
numpy 1.22 (over a year ago) completely reworked np.percentile(), causing our old way of calling it to no longer be valid (that way may have never been intended).

Here I flatten the input array down with np.ravel() before passing it in, which seems to give the same result that 1.21 did on the non-flattened array.

I am very unsure about this fix (and we may need to visit other uses of np.percentile() to see if they need adjustment too).