### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 CaImAn
 ======
-<img src="https://github.com/flatironinstitute/CaImAn/blob/master/docs/LOGOS/Caiman_logo_FI.png" width="500" align="right">
+<img src="https://github.com/flatironinstitute/CaImAn/blob/main/docs/LOGOS/Caiman_logo_FI.png" width="500" align="right">
 
 A Python toolbox for large scale **Ca**lcium **Im**aging data **An**alysis and behavioral analysis.
 


### PR DESCRIPTION
fix broken path to logo

# Description
Absolute link was broken in readme to logo on front page. Fixed by changing master to main in path.