### PR TITLE
updated vis tools to work with new bokeh

### DIFF
--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -498,6 +498,8 @@ class Estimates(object):
                 name of colormap (e.g. 'viridis') used to plot image_neurons
 
         """
+        logging.warning("This plotter is likely inaccurate/buggy b/c of a Bokeh update. Fix pending.")
+
         if 'csc_matrix' not in str(type(self.A)):
             self.A = scipy.sparse.csc_matrix(self.A)
         if dims is None:

--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -282,8 +282,8 @@ class Estimates(object):
                                 self.dims[0], self.dims[1], coordinates=coor_g,
                                 thr_method=thr_method, thr=thr, show=False,
                                 line_color=line_color, cmap=cmap)
-                p1.plot_width = 450
-                p1.plot_height = 450 * self.dims[0] // self.dims[1]
+                p1.width = 450
+                p1.height = 450 * self.dims[0] // self.dims[1]
                 p1.title.text = "Accepted Components"
                 if params is not None:
                     p1.xaxis.axis_label = '''\
@@ -296,8 +296,8 @@ class Estimates(object):
                                 self.dims[0], self.dims[1], coordinates=coor_b,
                                 thr_method=thr_method, thr=thr, show=False,
                                 line_color=line_color, cmap=cmap)
-                p2.plot_width = 450
-                p2.plot_height = 450 * self.dims[0] // self.dims[1]
+                p2.width = 450
+                p2.height = 450 * self.dims[0] // self.dims[1]
                 p2.title.text = 'Rejected Components'
                 if params is not None:
                     p2.xaxis.axis_label = '''\
@@ -385,7 +385,7 @@ class Estimates(object):
 
         plt.ion()
         nr, T = self.C.shape
-        if self.R is None or self.R == b'NoneType':
+        if self.R is None or not isinstance(self.R, np.ndarray):
             self.R = self.YrA
         if self.R.shape != [nr, T]:
             if self.YrA is None:
@@ -437,7 +437,7 @@ class Estimates(object):
 
         plt.ion()
         nr, T = self.C.shape
-        if self.R is None or self.R == b'NoneType':
+        if self.R is None or not isinstance(self.R, np.ndarray):
             self.R = self.YrA
         if self.R.shape != (nr, T):
             if self.YrA is None:
@@ -504,7 +504,7 @@ class Estimates(object):
             dims = self.dims
         plt.ion()
         nr, T = self.C.shape
-        if self.R is None or self.R == b'NoneType':
+        if self.R is None or not isinstance(self.R, np.ndarray):
             self.R = self.YrA
         if self.R.shape != [nr, T]:
             if self.YrA is None:

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -265,7 +265,7 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
                        height=int(min(1, d1/d2)*300))
 
     plot1.image(image=[image_neurons[::-1, :]], x=0,
-                y=0, dw=d2, dh=d1, palette=grayp)
+                y=image_neurons.shape[0], dw=d2, dh=d1, palette=grayp)
     plot1.patch('c1', 'c2', alpha=0.6, color='purple',
                 line_width=2, source=source2)
 
@@ -753,7 +753,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
     plot1 = bpl.figure(x_range=xr, y_range=yr, width=300, height=300)
 
     if max_projection:
-        plot1.image(image=[image_neurons], x=0, y=0,
+        plot1.image(image=[image_neurons], x=0, y=image_neurons.shape[0],
                     dw=image_neurons.shape[1], dh=image_neurons.shape[0], palette=grayp)
         plot1.patch('c1x', 'c2x', alpha=0.6, color='purple',
                     line_width=2, source=source2)
@@ -771,7 +771,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
         callback.args['slider_layer'] = slider_layer
         callback_layer.args['slider_neuron'] = slider
         callback_layer.args['slider_layer'] = slider_layer
-        plot1.image(image='image', x='x', y=0, dw='dw', dh='dh',
+        plot1.image(image='image', x='x', y='y', dw='dw', dh='dh',
                     color_mapper=cmap, source=source3)
         plot1.patch('c1', 'c2', alpha=0.6, color='purple',
                     line_width=2, source=source2)
@@ -794,7 +794,7 @@ def nb_imshow(image, cmap='jet'):
     yr = Range1d(start=image.shape[0], end=0)
     p = bpl.figure(x_range=xr, y_range=yr)
 
-    p.image(image=[image[::-1, :]], x=0, y=0, 
+    p.image(image=[image[::-1, :]], x=0, y=image.shape[0], 
             dw=image.shape[1], dh=image.shape[0], palette=grayp)
 
     return p

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -237,8 +237,8 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
             code += """
                 mets[3] = metrics_.data['CNN'][f].toFixed(3)
             """   
-        labels = LabelSet(x=0, y='y', text='keys', source=metrics) #, render_mode='canvas')
-        labels2 = LabelSet(x=10, y='y', text='mets', source=metrics, text_align="right") #render_mode='canvas'
+        labels = LabelSet(x=0, y='y', text='keys', source=metrics) 
+        labels2 = LabelSet(x=10, y='y', text='mets', source=metrics, text_align="right") 
         plot2 = bpl.figure(width=200, height=100, toolbar_location = None)
         plot2.axis.visible = False
         plot2.grid.visible = False
@@ -551,7 +551,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
 
         image_neurons = np.nan * \
             np.ones((int(1.05 * (d1 + d2)), int(1.05 * (d1 + d3))))
-        print(f"image_neurons shape: {image_neurons.shape}")  # ET remove
+
         image_neurons[:d2, -d3:] = tmp[0][::-1]
         image_neurons[:d2, :d1] = tmp[2].T[::-1]
         image_neurons[-d1:, -d3:] = tmp[1]
@@ -740,7 +740,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
                 source2.change.emit();
             """)
 
-    plot = bpl.figure(plot_width=600, plot_height=300)
+    plot = bpl.figure(width=600, height=300)
     plot.line('x', 'y', source=source, line_width=1, line_alpha=0.6)
     if denoised_color is not None:
         plot.line('x', 'y2', source=source, line_width=1,
@@ -750,7 +750,8 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
     slider.js_on_change('value', callback)
     xr = Range1d(start=0, end=image_neurons.shape[1] if max_projection else d3)
     yr = Range1d(start=image_neurons.shape[0] if max_projection else d2, end=0)
-    plot1 = bpl.figure(x_range=xr, y_range=yr, plot_width=300, plot_height=300)
+
+    plot1 = bpl.figure(x_range=xr, y_range=yr, width=300, height=300)
 
     if max_projection:
         plot1.image(image=[image_neurons[::-1, :]], x=0, y=image_neurons.shape[0],
@@ -771,7 +772,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
         callback.args['slider_layer'] = slider_layer
         callback_layer.args['slider_neuron'] = slider
         callback_layer.args['slider_layer'] = slider_layer
-        plot1.image(image='image', x='x', y='y', dw='dw', dh='dh',
+        plot1.image(image='image', x='x', y='y', dw='dw', dh='dh', 
                     color_mapper=cmap, source=source3)
         plot1.patch('c1', 'c2', alpha=0.6, color='purple',
                     line_width=2, source=source2)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -237,9 +237,9 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
             code += """
                 mets[3] = metrics_.data['CNN'][f].toFixed(3)
             """   
-        labels = LabelSet(x=0, y='y', text='keys', source=metrics, render_mode='canvas')
-        labels2 = LabelSet(x=10, y='y', text='mets', source=metrics, render_mode='canvas', text_align="right")
-        plot2 = bpl.figure(plot_width=200, plot_height=100, toolbar_location = None)
+        labels = LabelSet(x=0, y='y', text='keys', source=metrics) #, render_mode='canvas')
+        labels2 = LabelSet(x=10, y='y', text='mets', source=metrics, text_align="right") #render_mode='canvas'
+        plot2 = bpl.figure(width=200, height=100, toolbar_location = None)
         plot2.axis.visible = False
         plot2.grid.visible = False
         plot2.tools.visible = False
@@ -252,7 +252,7 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
     callback = CustomJS(args=dict(source=source, source_=source_, source2=source2,
                                   source2_=source2_, metrics=metrics, metrics_=metrics_), code=code)
 
-    plot = bpl.figure(plot_width=600, plot_height=300)
+    plot = bpl.figure(width=600, height=300)
     plot.line('x', 'y', source=source, line_width=1, line_alpha=0.6)
     if denoised_color is not None:
         plot.line('x', 'y2', source=source, line_width=1,
@@ -261,11 +261,11 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
     xr = Range1d(start=0, end=image_neurons.shape[1])
     yr = Range1d(start=image_neurons.shape[0], end=0)
     plot1 = bpl.figure(x_range=xr, y_range=yr,
-                       plot_width=int(min(1, d2/d1)*300),
-                       plot_height=int(min(1, d1/d2)*300))
+                       width=int(min(1, d2/d1)*300),
+                       height=int(min(1, d1/d2)*300))
 
     plot1.image(image=[image_neurons[::-1, :]], x=0,
-                y=image_neurons.shape[0], dw=d2, dh=d1, palette=grayp)
+                y=0, dw=d2, dh=d1, palette=grayp)
     plot1.patch('c1', 'c2', alpha=0.6, color='purple',
                 line_width=2, source=source2)
 
@@ -551,6 +551,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
 
         image_neurons = np.nan * \
             np.ones((int(1.05 * (d1 + d2)), int(1.05 * (d1 + d3))))
+        print(f"image_neurons shape: {image_neurons.shape}")  # ET remove
         image_neurons[:d2, -d3:] = tmp[0][::-1]
         image_neurons[:d2, :d1] = tmp[2].T[::-1]
         image_neurons[-d1:, -d3:] = tmp[1]
@@ -793,7 +794,7 @@ def nb_imshow(image, cmap='jet'):
     yr = Range1d(start=image.shape[0], end=0)
     p = bpl.figure(x_range=xr, y_range=yr)
 
-    p.image(image=[image[::-1, :]], x=0, y=image.shape[0],
+    p.image(image=[image[::-1, :]], x=0, y=0, 
             dw=image.shape[1], dh=image.shape[0], palette=grayp)
 
     return p
@@ -840,8 +841,8 @@ def nb_plot_contour(image, A, d1, d2, thr=None, thr_method='max', maxthr=0.2, nr
     """
 
     p = nb_imshow(image, cmap=cmap)
-    p.plot_width = 600
-    p.plot_height = 600 * d1 // d2
+    p.width = 600
+    p.height = 600 * d1 // d2
     center = com(A, d1, d2)
     p.circle(center[:, 1], center[:, 0], size=10, color="black",
              fill_color=None, line_width=2, alpha=1)

--- a/demos/notebooks/demo_caiman_cnmf_3D.ipynb
+++ b/demos/notebooks/demo_caiman_cnmf_3D.ipynb
@@ -392,9 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%capture\n",
@@ -407,7 +405,10 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane"
+    "View components per plane\n",
+    "\n",
+    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
+    "If you know Bokeh and would like to help, please let us know!**"
    ]
   },
   {
@@ -514,9 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(('Keeping ' + str(len(cnm.estimates.idx_components)) +\n",
@@ -547,8 +546,10 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "For a change we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ),\n",
-    "and we additionaly show the denoised trace"
+    "For a change we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace\n",
+    "\n",
+    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
+    "If you know Bokeh and would like to help, please let us know!**"
    ]
   },
   {
@@ -588,7 +589,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/demos/notebooks/demo_online_3D.ipynb
+++ b/demos/notebooks/demo_online_3D.ipynb
@@ -282,7 +282,10 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane"
+    "View components per plane\n",
+    "\n",
+    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
+    "If you know Bokeh and would like to help, please let us know!**"
    ]
   },
   {
@@ -336,9 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def plot_C(cnm):\n",
@@ -426,9 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %% fit with online object\n",
@@ -442,7 +441,10 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane"
+    "View components per plane\n",
+    "\n",
+    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
+    "If you know Bokeh and would like to help, please let us know!**"
    ]
   },
   {


### PR DESCRIPTION
# Description

Updating visualization tools to handle updated bokeh as discussed in issue #1127. Basically two problems: the way it handled y origin was changed, and `plot_height` was deprecated. Also, I fixed an unrelated check for `None` that was throwing an error. 

Fixes #1127 

This is not yet finished, as discussed at the issue `nb_view_patches3d()` is still acting weird and I'm not sure how to put in the simple fix. It is probably something really simple I'm missing :smile: 

# Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)

