### PR TITLE
Dev load pims fallback

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1425,7 +1425,7 @@ def load(file_name: Union[str, List[str]],
             height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
             dims = [length, height, width]                     # type: ignore # a list in one block and a tuple in another
-            if length == 0 or width == 0 or height == 0:       #CV failed to load
+            if length <= 0 or width <= 0 or height <= 0:       #CV failed to load
                 cv_failed = True
             else:
                 cv_failed = False
@@ -2129,7 +2129,7 @@ def load_iter(file_name: Union[str, List[str]], subindices=None, var_name_hdf5: 
                 length = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
                 width  = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
                 height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-                if length == 0 or width == 0 or height == 0: # Not a perfect way to do this, but it's a start. Could also do a try/except block?
+                if length <= 0 or width <= 0 or height <= 0: # Not a perfect way to do this, but it's a start. Could also do a try/except block?
                     do_opencv = False
                     # Close up shop, and get ready for the alternative
                     cap.release()

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1427,10 +1427,12 @@ def load(file_name: Union[str, List[str]],
             dims = [length, height, width]                     # type: ignore # a list in one block and a tuple in another
             if length <= 0 or width <= 0 or height <= 0:       #CV failed to load
                 cv_failed = True
+                logging.debug("OpenCV load failure, falling back to pims")
             else:
                 cv_failed = False
 
             if subindices is not None:
+                logging.debug("Eric note: this will likely lead to problems -- dims is used here but it is broken if cv_failed")
                 if not isinstance(subindices, list):
                     subindices = [subindices]
                 for ind, sb in enumerate(subindices):

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -1162,7 +1162,7 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                 cap = cv2.VideoCapture(file_name)
                 dims = [int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)), int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))]
                 T = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                if dims[0] == 0 or dims[1] == 0 or T == 0:
+                if dims[0] <= 0 or dims[1] <= 0 or T <= 0:
                     # fallback to pims, like load() and load_iter() do
                     pims_movie = pims.Video(file_name)
                     T = len(pims_movie)

--- a/demos/notebooks/demo_online_cnmfE.ipynb
+++ b/demos/notebooks/demo_online_cnmfE.ipynb
@@ -11,15 +11,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "IndentationError",
+     "evalue": "unindent does not match any outer indentation level (movies.py, line 2166)",
+     "output_type": "error",
+     "traceback": [
+      "Traceback \u001b[1;36m(most recent call last)\u001b[0m:\n",
+      "\u001b[0m  File \u001b[0;32m~\\miniconda3\\envs\\caiman_dev\\lib\\site-packages\\IPython\\core\\interactiveshell.py:3508\u001b[0m in \u001b[0;35mrun_code\u001b[0m\n    exec(code_obj, self.user_global_ns, self.user_ns)\u001b[0m\n",
+      "\u001b[0m  Cell \u001b[0;32mIn[3], line 15\u001b[0m\n    import caiman as cm\u001b[0m\n",
+      "\u001b[1;36m  File \u001b[1;32mc:\\users\\eric\\development\\dev_packages\\caiman\\caiman\\__init__.py:4\u001b[1;36m\n\u001b[1;33m    from .base.movies import movie, load, load_movie_chain, _load_behavior, play_movie\u001b[1;36m\n",
+      "\u001b[1;36m  File \u001b[1;32mc:\\users\\eric\\development\\dev_packages\\caiman\\caiman\\base\\movies.py:2166\u001b[1;36m\u001b[0m\n\u001b[1;33m    else: # Try pims fallback\u001b[0m\n\u001b[1;37m                             ^\u001b[0m\n\u001b[1;31mIndentationError\u001b[0m\u001b[1;31m:\u001b[0m unindent does not match any outer indentation level\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
     "    if __IPYTHON__:\n",
     "        # this is used for debugging purposes only. allows to reload classes when changed\n",
-    "        get_ipython().magic('load_ext autoreload')\n",
-    "        get_ipython().magic('autoreload 2')\n",
+    "        ipython().magic('load_ext autoreload')\n",
+    "        ipython().magic('autoreload 2')\n",
     "except NameError:\n",
     "    pass\n",
     "\n",
@@ -588,7 +601,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -602,7 +615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A few minor tweaks to the branch.
- Some spacing issues in movies.py (there were tabs!). Also, some indendentations weren't lining up properly the logic was awry -- please check to be sure I got it right. 
- Added movie viewer in the cnmfe_online demo notebook to be sure `load()` works, and added a logger message and set logger to debug temporarily while we work on this -- in particular added log message in movies.py near concern with use  `dims` when it could be broken (before offloading to pims).
- Changed criterion for offloading to pim from `==0` to `<=0` in the three places `VideoCapture()` is used, because opencv returns `-1` as a dimension when it is broken sometimes, so this covers all our bases. 