### PR TITLE
Bokeh plotting 2->3 fix second (final?) round

### DIFF
--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -5,7 +5,7 @@ Created on Thu Jul 12 11:11:45 2018
 
 @author: epnevmatikakis
 """
-
+import bokeh
 import logging
 import matplotlib.pyplot as plt
 import numpy as np
@@ -249,7 +249,6 @@ class Estimates(object):
                 set of dictionary containing the various parameters
         """
         try:
-            import bokeh
             if 'csc_matrix' not in str(type(self.A)):
                 self.A = scipy.sparse.csc_matrix(self.A)
             if self.dims is None:
@@ -307,7 +306,7 @@ class Estimates(object):
                                use_cnn=params.quality['use_cnn'])
                 bokeh.plotting.show(bokeh.layouts.row(p1, p2))
         except:
-            print("Bokeh could not be loaded. Either it is not installed or you are not running within a notebook")
+            print("Error with bokeh plotter.")
             print("Using non-interactive plot as fallback")
             self.plot_contours(img=img, idx=idx, thr_method=thr_method,
                                thr=thr, params=params, cmap=cmap)

--- a/caiman/source_extraction/cnmf/estimates.py
+++ b/caiman/source_extraction/cnmf/estimates.py
@@ -497,8 +497,6 @@ class Estimates(object):
                 name of colormap (e.g. 'viridis') used to plot image_neurons
 
         """
-        logging.warning("This plotter is likely inaccurate/buggy b/c of a Bokeh update. Fix pending.")
-
         if 'csc_matrix' not in str(type(self.A)):
             self.A = scipy.sparse.csc_matrix(self.A)
         if dims is None:

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -672,7 +672,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
         source2_idx = ColumnDataSource(data=dict(idx=idx, length=length))
         source3 = ColumnDataSource(
             data=dict(image=[image_neurons[linit]], im=[image_neurons],
-                      x=[0], y=[d2], dw=[d3], dh=[d2]))
+                      x=[0], y=[0], dw=[d3], dh=[d2]))
         callback = CustomJS(args=dict(source=source, source_=source_, sourceN=sourceN,
                                       source2=source2, source2_=source2_, source2_idx=source2_idx),
                             code="""
@@ -755,7 +755,7 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
     plot1 = bpl.figure(x_range=xr, y_range=yr, width=300, height=300)
 
     if max_projection:
-        plot1.image(image=[image_neurons], x=0, y=image_neurons.shape[0],
+        plot1.image(image=[image_neurons], x=0, y=0,
                     dw=image_neurons.shape[1], dh=image_neurons.shape[0], palette=grayp)
         plot1.patch('c1x', 'c2x', alpha=0.6, color='purple',
                     line_width=2, source=source2)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -266,8 +266,8 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
                        width=int(min(1, d2/d1)*300),
                        height=int(min(1, d1/d2)*300))
 
-    plot1.image(image=[image_neurons[::-1, :]], x=0,
-                y=image_neurons.shape[0], dw=d2, dh=d1, palette=grayp)
+    plot1.image(image=[image_neurons], x=0,
+                y=0, dw=d2, dh=d1, palette=grayp)
     plot1.patch('c1', 'c2', alpha=0.6, color='purple',
                 line_width=2, source=source2)
 
@@ -796,7 +796,7 @@ def nb_imshow(image, cmap='jet'):
     yr = Range1d(start=image.shape[0], end=0)
     p = bpl.figure(x_range=xr, y_range=yr)
 
-    p.image(image=[image[::-1, :]], x=0, y=image.shape[0], 
+    p.image(image=[image], x=0, y=0, 
             dw=image.shape[1], dh=image.shape[0], palette=grayp)
 
     return p

--- a/demos/notebooks/demo_caiman_cnmf_3D.ipynb
+++ b/demos/notebooks/demo_caiman_cnmf_3D.ipynb
@@ -345,13 +345,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -418,20 +411,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -450,7 +429,8 @@
     "K = 10  # number of neurons expected per patch\n",
     "gSig = [4, 4, 2]  # expected half size of neurons\n",
     "merge_thresh = 0.8  # merging threshold, max correlation allowed\n",
-    "p = 2  # order of the autoregressive system"
+    "p = 2  # order of the autoregressive system\n",
+    "print('set')"
    ]
   },
   {
@@ -466,14 +446,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
-    "#%% RUN ALGORITHM ON PATCHES\n",
-    "\n",
-    "cnm = cnmf.CNMF(n_processes, k=K, gSig=gSig, merge_thresh=merge_thresh, p=p, dview=dview,\n",
-    "                rf=rf, stride=stride, only_init_patch=True)\n",
+    "%%time\n",
+    "cnm = cnmf.CNMF(n_processes, \n",
+    "                k=K, \n",
+    "                gSig=gSig, \n",
+    "                merge_thresh=merge_thresh, \n",
+    "                p=p, \n",
+    "                dview=dview,\n",
+    "                rf=rf, \n",
+    "                stride=stride, \n",
+    "                only_init_patch=True)\n",
     "cnm.params.set('spatial', {'se': np.ones((3,3,1), dtype=np.uint8)})\n",
     "cnm = cnm.fit(images)\n",
-    "\n",
     "print(('Number of components:' + str(cnm.estimates.A.shape[-1])))"
    ]
   },
@@ -533,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
+    "%%time\n",
     "cnm.params.set('temporal', {'p': p})\n",
     "cnm2 = cnm.refit(images)"
    ]
@@ -543,7 +527,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "For a change we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace"
+    "Unlike the above layered view, we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace."
    ]
   },
   {
@@ -552,7 +536,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cnm2.estimates.nb_view_components_3d(image_type='corr', dims=dims, Yr=Yr, denoised_color='red', max_projection=True);"
+    "cnm2.estimates.nb_view_components_3d(image_type='corr', \n",
+    "                                     dims=dims, \n",
+    "                                     Yr=Yr, \n",
+    "                                     denoised_color='red', \n",
+    "                                     max_projection=True,\n",
+    "                                     axis=2);"
    ]
   },
   {
@@ -564,20 +553,6 @@
     "# STOP CLUSTER\n",
     "cm.stop_server(dview=dview)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/demos/notebooks/demo_caiman_cnmf_3D.ipynb
+++ b/demos/notebooks/demo_caiman_cnmf_3D.ipynb
@@ -405,10 +405,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane\n",
-    "\n",
-    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
-    "If you know Bokeh and would like to help, please let us know!**"
+    "View components per plane"
    ]
   },
   {
@@ -546,10 +543,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "For a change we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace\n",
-    "\n",
-    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
-    "If you know Bokeh and would like to help, please let us know!**"
+    "For a change we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace"
    ]
   },
   {

--- a/demos/notebooks/demo_caiman_cnmf_3D.ipynb
+++ b/demos/notebooks/demo_caiman_cnmf_3D.ipynb
@@ -527,7 +527,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "Unlike the above layered view, we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we additionaly show the denoised trace."
+    "Unlike the above layered view, here we view the components as max-projections (frontal in the XY direction, sagittal in YZ direction and transverse in XZ), and we also show the denoised trace."
    ]
   },
   {

--- a/demos/notebooks/demo_online_3D.ipynb
+++ b/demos/notebooks/demo_online_3D.ipynb
@@ -282,10 +282,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane\n",
-    "\n",
-    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
-    "If you know Bokeh and would like to help, please let us know!**"
+    "View components per plane"
    ]
   },
   {
@@ -441,10 +438,7 @@
    "metadata": {},
    "source": [
     "### View the results\n",
-    "View components per plane\n",
-    "\n",
-    "**Note `nb_view_components_3d()` is buggy since a new Bokeh release, and we will work on a fix soon.     \n",
-    "If you know Bokeh and would like to help, please let us know!**"
+    "View components per plane"
    ]
   },
   {


### PR DESCRIPTION
# Description

As far as I can tell, fixes the residual issues brought up in #1127 and previous PR #1129 . The problem was that images were inverted in ways I didn't notice, and this was percolating into almost every visualization function. I think it is now fixed in all tools (2d and 3d). 

# Type of change
[X] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?
Yes against test and demotest, and I also tested with the following pipelines:

    demo_pipeline
    demo_pipeline_CNMFE
    demo_caiman_cnmf_3D
    demo_online_cnmfE
    demo_online_3d

These all seemed to work well!

@j-friedrich it would be helpful if you tested that this is indeed reasonable (esp in `demo_caiman_cnmf_3D.ipynb` which is where thigns broke before: I think `axis=2` is working well now too for the 3d component viewer with max projection, which is really nice, as that is the more intuitive projection). 