### PR TITLE
pyproject / PEP-517

### DIFF
--- a/_buildhelper_cython.py
+++ b/_buildhelper_cython.py
@@ -14,11 +14,11 @@
 # small as oasis). No more `pip install -e .`
 
 from Cython.Build import cythonize
-from distutils.command.build_ext import build_ext
 import numpy as np
 import os
 import sys
 from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py as _build_py
 import setuptools.extension
 
 class build_py(_build_py):
@@ -27,15 +27,15 @@ class build_py(_build_py):
         return super().run()
 
     def initialize_options(self):
-        super.initalize_options()
+        super().initialize_options()
         if sys.platform == 'darwin':
             # TODO: Verify still needed; requirement was
             #       added w/ OSX 10.9
             # See also:
             # https://github.com/pandas-dev/pandas/issues/23424
-	    extra_compiler_args = ['-stdlib=libc++']
+            extra_compiler_args = ['-stdlib=libc++']
         else:
-	    extra_compiler_args = []
+            extra_compiler_args = []
 
         if self.distribution.ext_modules is None:
             self.distribution.ext_modules = []

--- a/_buildhelper_cython.py
+++ b/_buildhelper_cython.py
@@ -7,11 +7,6 @@
 # This was ported from logic originally in the
 # old-stype setup.py, in order to comply with the
 # new PEP-517/PEP-518 build style.
-#
-# We intentionally do not support editable builds, as
-# they are confusing and usually the wrong thing for
-# projects that have a built component, even one as
-# small as oasis). No more `pip install -e .`
 
 from Cython.Build import cythonize
 import numpy as np

--- a/buildhelper_cython.py
+++ b/buildhelper_cython.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+###################
+# build helper for pyproject.toml to do the
+# cython parts of the build.
+#
+# This was ported from logic originally in the
+# old-stype setup.py, in order to comply with the
+# new PEP-517/PEP-518 build style.
+#
+# We intentionally do not support editable builds, as
+# they are confusing and usually the wrong thing for
+# projects that have a built component, even one as
+# small as oasis). No more `pip install -e .`
+
+from Cython.Build import cythonize
+from distutils.command.build_ext import build_ext
+import numpy as np
+import os
+import sys
+from setuptools import setup, find_packages
+import setuptools.extension
+
+class build_py(_build_py):
+    def run(self):
+        self.run_command("build_ext")
+        return super().run()
+
+    def initialize_options(self):
+        super.initalize_options()
+        if sys.platform == 'darwin':
+            # TODO: Verify still needed; requirement was
+            #       added w/ OSX 10.9
+            # See also:
+            # https://github.com/pandas-dev/pandas/issues/23424
+	    extra_compiler_args = ['-stdlib=libc++']
+        else:
+	    extra_compiler_args = []
+
+        if self.distribution.ext_modules is None:
+            self.distribution.ext_modules = []
+
+        self.distribution.ext_modules.append(
+            setuptools.extension.Extension(
+                "caiman.source_extraction.cnmf.oasis",
+                sources=["caiman/source_extraction/cnmf/oasis.pyx"],
+                include_dirs=[np.get_include()],
+                language="c++",
+                extra_compile_args = extra_compiler_args,
+                extra_link_args = extra_compiler_args,
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "caiman"
+description = "Library and software for ROI detection and deconvolution of Calcium Imaging datasets"
+authors = [
+	{ name = "Andrea Giovannucci"},
+	{ name = "Eftychios Pnevmatikakis"},
+	{ name = "Johannes Friedrich" },
+	{ name = "Valentina Staneva" },
+	{ name = "Ben Deverett" },
+	{ name = "Erick Cobos" },
+	{ name = "Jeremie Kalfon"}]
+readme = "README.md"
+
+[build-system]
+requires = ["cython", "distutils", "numpy", "setuptools", "wheel"]
+
+[tool.setuptools]
+py-modules = ["buildhelper_cython"]
+
+[tool.setuptools.cmdclass]
+build_py = "buildhelper_cython.build_py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ authors = [
 	{ name = "Erick Cobos" },
 	{ name = "Jeremie Kalfon"}]
 readme = "README.md"
+dynamic = ["classifiers", "keywords", "license", "scripts", "version"]
 
 [build-system]
-requires = ["cython", "distutils", "numpy", "setuptools", "wheel"]
+requires = ["cython", "numpy", "setuptools", "wheel"]
 
 [tool.setuptools]
-py-modules = ["buildhelper_cython"]
+py-modules = ["_buildhelper_cython"]
 
 [tool.setuptools.cmdclass]
-build_py = "buildhelper_cython.build_py"
+build_py = "_buildhelper_cython.build_py"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from setuptools import setup, find_packages
 import numpy as np
 import os
-from os import path
 import sys
 from Cython.Build import cythonize
 from setuptools.extension import Extension
@@ -13,7 +12,7 @@ from distutils.command.build_ext import build_ext
     Installation script for anaconda installers
 """
 
-here = path.abspath(path.dirname(__file__))
+here = os.path.abspath(os.path.dirname(__file__))
 
 with open('README.md', 'r') as rmf:
     readme = rmf.read()


### PR DESCRIPTION
This adds the needed additional files for PEP-517 compliant pip plumbing.

The practical impact of this is little:
* future-proofing our setup (in case the current tools eventually stop supporting old-style setup.py)
* For the very few people who build with environment.yml and then pip install, it is used and re-enables the `-e` flag
* It may make the (not encouraged but still sort-of-supported) pip install path used as a last resort and by colab a bit more efficient

In the longer-term we'll want to follow up on this by moving more of the fields from "dynamic" values defined in setup.py into residing just in the toml - I don't *ever* want to do that with the version value, but the other fields are good candidates for that). I'm not doing that now because I'd like to sit in the middle for awhile until all the tools and libraries are certain to look in at least both places (maybe that's already the case, I don't know and don't care to wager - moving slowly is safe).

Will need to keep an eye out for if the conda plumbing is impacted by this, although I don't expect it to be.