### PR TITLE
Switch from the z5py library to the zarr library

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1532,9 +1532,9 @@ def load(file_name: Union[str, list[str]],
 
         elif extension in ('.hdf5', '.h5', '.nwb', 'n5', 'zarr'):
             if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
-                f = zarr.open(file_name, "r"):
+                f = zarr.open(file_name, "r")
             else:
-                f = h5py.File(file_name, "r"):
+                f = h5py.File(file_name, "r")
             ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with get_file_size() !!
             fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
             if len(fkeys) == 1 and 'Dataset' in str(type(f[fkeys[0]])): # If the file we're parsing has only one dataset inside it,
@@ -2181,9 +2181,9 @@ def load_iter(file_name: Union[str, list[str]], subindices=None, var_name_hdf5: 
                 
             elif extension in ('.hdf5', '.h5', '.nwb', '.mat', 'n5', 'zarr'):
                 if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
-                    f = zarr.open(file_name, "r"):
+                    f = zarr.open(file_name, "r")
                 else:
-                    f = h5py.File(file_name, "r"):
+                    f = h5py.File(file_name, "r")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed.
                 fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(fkeys) == 1 and 'Dataset' in str(type(f[fkeys[0]])): # If the hdf5 file we're parsing has only one dataset inside it,
@@ -2272,9 +2272,9 @@ def get_file_size(file_name, var_name_hdf5='mov') -> tuple[tuple, Union[int, tup
             elif extension in ('.h5', '.hdf5', '.nwb', 'n5', 'zarr'):
                 # FIXME this doesn't match the logic in load()
                 if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
-                    f = zarr.open(file_name, "r"):
+                    f = zarr.open(file_name, "r")
                 else:
-                    f = h5py.File(file_name, "r"):
+                    f = h5py.File(file_name, "r")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with movies.my:load() !!
                 kk = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(kk) == 1 and 'Dataset' in str(type(f[kk[0]])): # TODO: Consider recursing into a group to find a dataset

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -27,8 +27,7 @@ import tifffile
 from tqdm import tqdm
 from typing import Any, Optional, Union
 import warnings
-# Flip to normal import if this is ever resolved: https://github.com/constantinpape/z5/issues/146
-# import z5py
+import zarr
 from zipfile import ZipFile
 
 import caiman as cm
@@ -1565,11 +1564,7 @@ def load(file_name: Union[str, list[str]],
                     raise Exception('Key not found in hdf5 file')
 
         elif extension in ('.n5', '.zarr'):
-           try:
-               import z5py
-           except ImportError:
-               raise Exception("z5py library not available; if you need this functionality use the conda package")
-           with z5py.File(file_name, "r") as f:
+           with zarr.open(file_name, "r") as f:
                 fkeys = list(f.keys())
                 if len(fkeys) == 1: # If the n5/zarr file we're parsing has only one dataset inside it, ignore the arg and pick that dataset
                     var_name_hdf5 = fkeys[0]
@@ -2313,12 +2308,7 @@ def get_file_size(file_name, var_name_hdf5='mov') -> tuple[tuple, Union[int, tup
             elif extension in ('.n5', '.zarr'): # TODO: After #1168, if where things land leaves us with compatible APIs between h5 and zarr/n5,
                                                 # replace this and above with a dispatch to common code that takes an open handle and has the interiour of
                                                 # both these blocks (they're nearly identical)
-                try:
-                    import z5py
-                except:
-                    raise Exception("z5py not available; if you need this use the conda-based setup")
-
-                with z5py.File(file_name, "r") as f:
+                with zarr.open(file_name, "r") as f:
                     kk = list(f.keys())
                     if len(kk) == 1:
                         siz = f[kk[0]].shape

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1537,9 +1537,9 @@ def load(file_name: Union[str, list[str]],
                 f = h5py.File(file_name, "r")
             ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with get_file_size() !!
             fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
-            if len(fkeys) == 1 and 'Dataset' in str(type(f[fkeys[0]])): # If the file we're parsing has only one dataset inside it,
-                                                                        # ignore the arg and pick that dataset
-                                                                        # TODO: Consider recursing into a group to find a dataset
+            if len(fkeys) == 1: # If the file we're parsing has only one dataset inside it,
+                                # ignore the arg and pick that dataset
+                                # TODO: Consider recursing into a group to find a dataset
                 var_name_hdf5 = fkeys[0]
             if extension == '.nwb': # Apparently nwb files are specially-formatted hdf5 files
                 try:
@@ -2186,8 +2186,8 @@ def load_iter(file_name: Union[str, list[str]], subindices=None, var_name_hdf5: 
                     f = h5py.File(file_name, "r")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed.
                 fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
-                if len(fkeys) == 1 and 'Dataset' in str(type(f[fkeys[0]])): # If the hdf5 file we're parsing has only one dataset inside it,
-                                                                            # ignore the arg and pick that dataset
+                if len(fkeys) == 1: # If the hdf5 file we're parsing has only one dataset inside it,
+                                    # ignore the arg and pick that dataset
                     var_name_hdf5 = fkeys[0]
                 Y = f.get('acquisition/' + var_name_hdf5 + '/data'
                         if extension == '.nwb' else var_name_hdf5)
@@ -2277,7 +2277,7 @@ def get_file_size(file_name, var_name_hdf5='mov') -> tuple[tuple, Union[int, tup
                     f = h5py.File(file_name, "r")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with movies.my:load() !!
                 kk = list(filter(lambda x: x not in ignore_keys, f.keys()))
-                if len(kk) == 1 and 'Dataset' in str(type(f[kk[0]])): # TODO: Consider recursing into a group to find a dataset
+                if len(kk) == 1: # TODO: Consider recursing into a group to find a dataset
                     siz = f[kk[0]].shape
                 elif var_name_hdf5 in f:
                     if extension == '.nwb':

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -22,4 +22,4 @@ dependencies:
 - tensorflow >=2.4.0
 - tifffile
 - tqdm
-- z5py >=2.0.15
+- zarr

--- a/environment.yml
+++ b/environment.yml
@@ -34,4 +34,4 @@ dependencies:
 - tk
 - tqdm
 - yapf
-- z5py >= 2.0.15
+- zarr

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tifffile
 tk
 tqdm
 yapf
+zarr

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -26,3 +26,4 @@ tifffile
 tk
 tqdm
 yapf
+zarr


### PR DESCRIPTION
This removes z5py as a dependency, swapping in zarr (which is also available in pypi, so it also replaces the conditional imports with a static import)