### PR TITLE
Multi ci

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Multi-OS and Python Version Test
+name: Python Version Test on Ubuntu
 
 on:
   pull_request:
@@ -10,13 +10,12 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  build-ubuntu-python:
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Linux Conda test
+name: Multi-OS and Python Version Test
 
 on:
   pull_request:
@@ -10,10 +10,14 @@ on:
       - main
 
 jobs:
-  build-linux-conda:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11']
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +26,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           environment-file: environment.yml
           activate-environment: caiman
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: false
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Python Version Test on Ubuntu
+name: Linux Conda test
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  build-ubuntu-python:
+  build-linux-conda:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5


### PR DESCRIPTION
# Description

Expands upon CI to test Python 3.9 through 3.11.