### PR TITLE
WIP: CNMFParams overhaul

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -131,9 +131,8 @@ class MotionCorrect(object):
            splits_els':list
                for parallelization split the movies in  num_splits chunks across time
 
-           num_splits_to_process_els: list,
-               if none all the splits are processed and the movie is saved  otherwise at each iteration
-                num_splits_to_process_els are considered
+           num_splits_to_process_els: UNUSED
+               Legacy parameter, does not do anything
 
            upsample_factor_grid:int,
                upsample factor of shifts per patches to avoid smearing when merging patches
@@ -192,7 +191,6 @@ class MotionCorrect(object):
         self.strides = strides
         self.overlaps = overlaps
         self.splits_els = splits_els
-        self.num_splits_to_process_els = num_splits_to_process_els
         self.upsample_factor_grid = upsample_factor_grid
         self.max_deviation_rigid = max_deviation_rigid
         self.shifts_opencv = bool(shifts_opencv)

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1033,11 +1033,19 @@ class CNMFParams(object):
     def to_dict(self) -> dict:
         """Returns the params class as a dictionary with subdictionaries for each
         category."""
-        return {'data': self.data, 'spatial_params': self.spatial, 'temporal_params': self.temporal,
-                'init_params': self.init, 'preprocess_params': self.preprocess,
-                'patch_params': self.patch, 'online': self.online, 'quality': self.quality,
-                'merging': self.merging, 'motion': self.motion, 'ring_CNN': self.ring_CNN
-                }
+        return {
+               'data': self.data,
+               'init': self.init,
+               'merging': self.merging,
+               'motion': self.motion,
+               'online': self.online,
+               'patch': self.patch,
+               'preprocess': self.preprocess,
+               'ring_CNN': self.ring_CNN,
+               'quality': self.quality,
+               'spatial': self.spatial,
+               'temporal': self.temporal
+               }
 
     def to_json(self) -> str:
         """ Reversibly serialise CNMFParams to json """

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -666,8 +666,8 @@ class CNMFParams(object):
                 Flag for reusing an already trained model (saved in path to model)
         """
 
-        if int(decay_time) == 0:
-            raise Exception("A decay time of 0 is not permitted")
+        if float(decay_time) == float(0.0):
+            raise Exception("A decay time of zero is not permitted")
 
         self.data = {
             'fnames': fnames,

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -594,7 +594,6 @@ class CNMFParams(object):
             num_frames_split: int, default: 80
                 split movie every x frames for parallel processing
 
-            num_splits_to_process_els, default: [7, None]
             num_splits_to_process_rig, default: None
                 (Undocumented, changing this likely to break the code - FIXME why is this a parameter then?)
 
@@ -608,10 +607,10 @@ class CNMFParams(object):
                 flag for applying shifts using cubic interpolation (otherwise FFT)
 
             splits_els: int, default: 14
-                number of splits across time for pw-rigid registration
+                number of splits across time for pw-rigid registration.
 
             splits_rig: int, default: 14
-                number of splits across time for rigid registration
+                number of splits across time for rigid registration.
 
             strides: (int, int), default: (96, 96)
                 how often to start a new patch in pw-rigid registration. Size of each patch will be strides + overlaps
@@ -667,7 +666,7 @@ class CNMFParams(object):
                 Flag for reusing an already trained model (saved in path to model)
         """
 
-        if decay_time == 0 or decay_time == 0.0:
+        if int(decay_time) == 0:
             raise Exception("A decay time of 0 is not permitted")
 
         self.data = {
@@ -886,7 +885,7 @@ class CNMFParams(object):
             'niter_rig': 1,                     # number of iterations rigid motion correction
             'nonneg_movie': True,               # flag for producing a non-negative movie
             'num_frames_split': 80,             # split across time every x frames
-            'num_splits_to_process_els': None,  # DO NOT MODIFY
+            'num_splits_to_process_els': None,  # Unused, will be removed in a future version of Caiman
             'num_splits_to_process_rig': None,  # DO NOT MODIFY
             'overlaps': (32, 32),               # overlap between patches in pw-rigid motion correction
             'pw_rigid': False,                  # flag for performing pw-rigid motion correction

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -317,9 +317,6 @@ class CNMFParams(object):
             n_pixels_per_process: int, default: 1000
                 number of pixels to be processed by each worker
 
-            nb: int, default: 1
-                number of global background components
-
             normalize_yyt_one: bool, default: True
                 Whether to normalize the C and A matrices so that diag(C*C.T) = 1 during update spatial
 
@@ -367,9 +364,6 @@ class CNMFParams(object):
             method_deconvolution: 'oasis'|'cvxpy'|'oasis', default: 'oasis'
                 method for solving the constrained deconvolution problem ('oasis','cvx' or 'cvxpy')
                 if method cvxpy, primary and secondary (if problem unfeasible for approx solution)
-
-            nb: int, default: 1
-                number of global background components
 
             noise_method: 'mean'|'median'|'logmexp', default: 'mean'
                 PSD averaging method for computing the noise std

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -8,6 +8,7 @@ import pkg_resources
 from pprint import pformat
 import scipy
 from scipy.ndimage import generate_binary_structure, iterate_structure
+from typing import Optional
 
 import caiman.utils.utils
 import caiman.base.movies

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1091,3 +1091,14 @@ class CNMFParams(object):
                     logging.warning(f"No subobject {gr} in parameter dict")
         self.check_consistency()
 
+    def change_params_from_json(self, jsonstring:str, verbose:bool=False) -> None:
+        """ Same as change_params, except it takes json as input """
+        to_load = json.loads(jsonstring)
+        self.change_params(to_load, verbose=verbose)
+
+    def change_params_from_jsonfile(self, json_fn:str, verbose:bool=False) -> None:
+        """ Same as change_params, except it takes a json file as input; pass the filename """
+        with open(json_fn, 'r') as json_fh:
+            to_load = json.load(json_fh)
+        self.change_params(to_load, verbose=verbose)
+

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -42,21 +42,37 @@ class CNMFParams(object):
                  thresh_fitness_delta=-50, thresh_fitness_raw=None, thresh_overlap=0.5,
                  update_freq=200, update_num_comps=True, use_dense=True, use_peak_max=True,
                  only_init_patch=True, var_name_hdf5='mov', max_merge_area=None, 
-                 use_corr_img=False, params_dict={},
+                 use_corr_img=False,
+                 params_from_file:Optional[str]=None,
+                 params_dict={},
                  ):
         """Class for setting the processing parameters. All parameters for CNMF, online-CNMF, quality testing,
         and motion correction can be set here and then used in the various processing pipeline steps.
-        The preferred way to set parameters is by using the set function, where a subclass is determined and a
-        dictionary is passed. The whole dictionary can also be initialized at once by passing a dictionary params_dict
-        when initializing the CNMFParams object. Direct setting of the positional arguments in CNMFParams is only
-        present for backwards compatibility reasons and should not be used if possible.
+
+        Params have default values; users can override the defaults in two intended ways:
+            A) During initialisation of the object, people can pass a nested dictionary through the
+               params_dict parameter, or the name of a jsonfile containing the same nested dictionary
+               through the params_from_file parameter
+            B) If the CNMFParams object already exists, they can call its change_params() method to pass in
+               a dict or change_params_from_jsonfile() to pass in a filename
+        With both of these, people only need to name and override values they wish to change; all others keep
+        their defaults.
+
+        All other means of changing parameters are deprecated (including other constructor arguments)
+        and will be removed in some future version of Caiman (whether they give a deprecation warning or not). 
 
         Args:
-            Any parameter that is not set get a default value specified
-            by the dictionary default options
-        DATA PARAMETERS (CNMFParams.data) #####
+            params_from_file
+                name of a json file used to initialise the object
+            params_dict
+                a dictionary used to initialise the object
 
-            fnames: list[str]
+            Any parameter that is not set uses a default value
+            All other arguments are deprecated and should not be used.
+
+        Object Structure:
+          CNMFParams.data (these represent features of the data and other misc settings):
+            fnames
                 list of complete paths to files that need to be processed
 
             dims: (int, int), default: computed from fnames
@@ -75,10 +91,10 @@ class CNMFParams(object):
                 if loading from hdf5 name of the variable to load
 
             caiman_version: str
-                version of CaImAn being used
+                version of CaImAn being used. Please do not override this
 
             last_commit: str
-                hash of last commit in the caiman repo
+                hash of last commit in the caiman repo. Pleaes do not override this.
 
             mmap_F: list[str]
                 paths to F-order memory mapped files after motion correction
@@ -86,47 +102,21 @@ class CNMFParams(object):
             mmap_C: str
                 path to C-order memory mapped file after motion correction
 
-        PATCH PARAMS (CNMFParams.patch)######
-
-            rf: int or list or None, default: None
-                Half-size of patch in pixels. If None, no patches are constructed and the whole FOV is processed jointly.
-                If list, it should be a list of two elements corresponding to the height and width of patches
-
-            stride: int or None, default: None
-                Overlap between neighboring patches in pixels.
-
-            nb_patch: int, default: 1
-                Number of (local) background components per patch
-
+          CNMFParams.patch (these control how the data is divided into patches):
             border_pix: int, default: 0
                 Number of pixels to exclude around each border.
-
-            low_rank_background: bool, default: True
-                Whether to update the background using a low rank approximation.
-                If False all the nonzero elements of the background components are updated using hals
-                (to be used with one background per patch)
 
             del_duplicates: bool, default: False
                 Delete duplicate components in the overlapping regions between neighboring patches. If False,
                 then merging is used.
 
-            only_init: bool, default: True
-                whether to run only the initialization
+            in_memory: bool, default: True
+                Whether to load patches in memory
 
-            p_patch: int, default: 0
-                order of AR dynamics when processing within a patch
-
-            skip_refinement: bool, default: False
-                Whether to skip refinement of components (deprecated?)
-
-            remove_very_bad_comps: bool, default: True
-                Whether to remove (very) bad quality components during patch processing
-
-            p_ssub: float, default: 2
-                Spatial downsampling factor
-
-            p_tsub: float, default: 2
-                Temporal downsampling factor
+            low_rank_background: bool, default: True
+                Whether to update the background using a low rank approximation.
+                If False all the nonzero elements of the background components are updated using hals
+                (to be used with one background per patch)
 
             memory_fact: float, default: 1
                 unitless number for increasing the amount of available memory
@@ -134,19 +124,46 @@ class CNMFParams(object):
             n_processes: int
                 Number of processes used for processing patches in parallel
 
-            in_memory: bool, default: True
-                Whether to load patches in memory
+            nb_patch: int, default: 1
+                Number of (local) background components per patch
 
-        PRE-PROCESS PARAMS (CNMFParams.preprocess) #############
+            only_init: bool, default: True
+                whether to run only the initialization
 
-            sn: np.array or None, default: None
-                noise level for each pixel
+            p_patch: int, default: 0
+                order of AR dynamics when processing within a patch
 
-            noise_range: [float, float], default: [.25, .5]
-                range of normalized frequencies over which to compute the PSD for noise determination
+            remove_very_bad_comps: bool, default: True
+                Whether to remove (very) bad quality components during patch processing
 
-            noise_method: 'mean'|'median'|'logmexp', default: 'mean'
-                PSD averaging method for computing the noise std
+            rf: int or list or None, default: None
+                Half-size of patch in pixels. If None, no patches are constructed and the whole FOV is processed jointly.
+                If list, it should be a list of two elements corresponding to the height and width of patches
+
+            skip_refinement: bool, default: False
+                Whether to skip refinement of components (deprecated?)
+
+            p_ssub: float, default: 2
+                Spatial downsampling factor
+
+            stride: int or None, default: None
+                Overlap between neighboring patches in pixels.
+
+            p_tsub: float, default: 2
+                Temporal downsampling factor
+
+          CNMFParams.preprocess (these control preprocessing steps for the data):
+            check_nan: bool, default: True
+                whether to check for NaNs
+
+            compute_g': bool, default: False
+                whether to estimate global time constant
+
+            include_noise: bool, default: False
+                    flag for using noise values when estimating g
+
+            lags: int, default: 5
+                number of lags to be considered for time constant estimation
 
             max_num_samples_fft: int, default: 3*1024
                 Chunk size for computing the PSD of the data (for memory considerations)
@@ -154,26 +171,22 @@ class CNMFParams(object):
             n_pixels_per_process: int, default: 1000
                 Number of pixels to be allocated to each process
 
-            compute_g': bool, default: False
-                whether to estimate global time constant
+            noise_method: 'mean'|'median'|'logmexp', default: 'mean'
+                PSD averaging method for computing the noise std
+
+            noise_range: [float, float], default: [.25, .5]
+                range of normalized frequencies over which to compute the PSD for noise determination
 
             p: int, default: 2
                  order of AR indicator dynamics
 
-            lags: int, default: 5
-                number of lags to be considered for time constant estimation
-
-            include_noise: bool, default: False
-                    flag for using noise values when estimating g
-
             pixels: list, default: None
                  pixels to be excluded due to saturation
 
-            check_nan: bool, default: True
-                whether to check for NaNs
+            sn: np.array or None, default: None
+                noise level for each pixel
 
-        INIT PARAMS (CNMFParams.init)###############
-
+          CNMFParams.init (these control how CNMF should be initialised):
             K: int, default: 30
                 number of components to be found (per patch or whole FOV depending on whether rf=None)
 
@@ -195,29 +208,32 @@ class CNMFParams(object):
             SC_nnn: int, default: 20
                 number of nearest neighbors to use
 
+            alpha_snmf: float, default: 0.5
+                sparse NMF sparsity regularization weight
+
+            center_psf: bool, default: False
+                whether to use 1p data processing mode. Set to true for 1p
+
             gSig: [int, int], default: [5, 5]
                 radius of average neurons (in pixels)
 
             gSiz: [int, int], default: [int(round((x * 2) + 1)) for x in gSig],
                 half-size of bounding box for each neuron
 
-            center_psf: bool, default: False
-                whether to use 1p data processing mode. Set to true for 1p
+            init_iter: int, default: 2
+                number of iterations during corr_pnr (1p) initialization
 
-            ssub: float, default: 2
-                spatial downsampling factor
-
-            tsub: float, default: 2
-                temporal downsampling factor
-
-            nb: int, default: 1
-                number of background components
+            kernel: np.array or None, default: None
+                user specified template for greedyROI
 
             lambda_gnmf: float, default: 1.
                 regularization weight for graph NMF
 
             maxIter: int, default: 5
                 number of HALS iterations during initialization
+
+            max_iter_snmf : int, default: 500
+                maximum number of iterations for sparse NMF initialization
 
             method_init: 'greedy_roi'|'corr_pnr'|'sparse_NMF'|'local_NMF' default: 'greedy_roi'
                 initialization method. use 'corr_pnr' for 1p processing and 'sparse_NMF' for dendritic processing.
@@ -228,44 +244,11 @@ class CNMFParams(object):
             min_pnr: float, default: 20
                 minimum value of psnr image for determining a candidate component during corr_pnr
 
-            seed_method: str {'auto', 'manual', 'semi'}
-                methods for choosing seed pixels during greedy_roi or corr_pnr initialization
-                'semi' detects nr components automatically and allows to add more manually
-                if running as notebook 'semi' and 'manual' require a backend that does not
-                inline figures, e.g. %matplotlib tk
-
-            ring_size_factor: float, default: 1.5
-                radius of ring (*gSig) for computing background during corr_pnr
-
-            ssub_B: float, default: 2
-                downsampling factor for background during corr_pnr
-
-            init_iter: int, default: 2
-                number of iterations during corr_pnr (1p) initialization
-
             nIter: int, default: 5
                 number of rank-1 refinement iterations during greedy_roi initialization
 
-            rolling_sum: bool, default: True
-                use rolling sum (as opposed to full sum) for determining candidate centroids during greedy_roi
-
-            rolling_length: int, default: 100
-                width of rolling window for rolling sum option
-
-            kernel: np.array or None, default: None
-                user specified template for greedyROI
-
-            max_iter_snmf : int, default: 500
-                maximum number of iterations for sparse NMF initialization
-
-            alpha_snmf: float, default: 0.5
-                sparse NMF sparsity regularization weight
-
-            sigma_smooth_snmf : (float, float, float), default: (.5,.5,.5)
-                std of Gaussian kernel for smoothing data in sparse_NMF
-
-            perc_baseline_snmf: float, default: 20
-                percentile to be removed from the data in sparse_NMF prior to decomposition
+            nb: int, default: 1
+                number of background components
 
             normalize_init: bool, default: True
                 whether to equalize the movies during initialization
@@ -273,10 +256,39 @@ class CNMFParams(object):
             options_local_NMF: dict
                 dictionary with parameters to pass to local_NMF initializer
 
-        SPATIAL PARAMS (CNMFParams.spatial) ##########
+            perc_baseline_snmf: float, default: 20
+                percentile to be removed from the data in sparse_NMF prior to decomposition
 
-            method_exp: 'dilate'|'ellipse', default: 'dilate'
-                method for expanding footprint of spatial components
+            ring_size_factor: float, default: 1.5
+                radius of ring (*gSig) for computing background during corr_pnr
+
+            rolling_length: int, default: 100
+                width of rolling window for rolling sum option
+
+            rolling_sum: bool, default: True
+                use rolling sum (as opposed to full sum) for determining candidate centroids during greedy_roi
+
+            seed_method: str {'auto', 'manual', 'semi'}
+                methods for choosing seed pixels during greedy_roi or corr_pnr initialization
+                'semi' detects nr components automatically and allows to add more manually
+                if running as notebook 'semi' and 'manual' require a backend that does not
+                inline figures, e.g. %matplotlib tk
+
+            sigma_smooth_snmf : (float, float, float), default: (.5,.5,.5)
+                std of Gaussian kernel for smoothing data in sparse_NMF
+
+            ssub: float, default: 2
+                spatial downsampling factor
+
+            ssub_B: float, default: 2
+                downsampling factor for background during corr_pnr
+
+            tsub: float, default: 2
+                temporal downsampling factor
+
+          CNMFParams.spatial (these control how the algorithms handle spatial components):
+            block_size_spat : int, default: 5000
+                Number of pixels to process at the same time for dot product. Reduce if you face memory problems
 
             dist: float, default: 3
                 expansion factor of ellipse
@@ -284,27 +296,37 @@ class CNMFParams(object):
             expandCore: morphological element, default: None(?)
                 morphological element for expanding footprints under dilate
 
-            nb: int, default: 1
-                number of global background components
-
-            n_pixels_per_process: int, default: 1000
-                number of pixels to be processed by each worker
-
-            thr_method: 'nrg'|'max', default: 'nrg'
-                thresholding method
-
-            maxthr: float, default: 0.1
-                Max threshold
-
-            nrgthr: float, default: 0.9999
-                Energy threshold
-
             extract_cc: bool, default: True
                 whether to extract connected components during thresholding
                 (might want to turn to False for dendritic imaging)
 
+            maxthr: float, default: 0.1
+                Max threshold
+
             medw: (int, int) default: None
                 window of median filter (set to (3,)*len(dims) in cnmf.fit)
+
+            method_exp: 'dilate'|'ellipse', default: 'dilate'
+                method for expanding footprint of spatial components
+
+            method_ls: 'lasso_lars'|'nnls_L0', default: 'lasso_lars'
+                'nnls_L0'. Nonnegative least square with L0 penalty
+                'lasso_lars' lasso lars function from scikit learn
+
+            n_pixels_per_process: int, default: 1000
+                number of pixels to be processed by each worker
+
+            nb: int, default: 1
+                number of global background components
+
+            normalize_yyt_one: bool, default: True
+                Whether to normalize the C and A matrices so that diag(C*C.T) = 1 during update spatial
+
+            nrgthr: float, default: 0.9999
+                Energy threshold
+
+            num_blocks_per_run_spat: int, default: 20
+                Parallelization of A'*Y operation
 
             se: np.array or None, default: None
                  Morphological closing structuring element (set to np.ones((3,)*len(dims), dtype=np.uint8) in cnmf.fit)
@@ -312,47 +334,25 @@ class CNMFParams(object):
             ss: np.array or None, default: None
                 Binary element for determining connectivity (set to np.ones((3,)*len(dims), dtype=np.uint8) in cnmf.fit)
 
+            thr_method: 'nrg'|'max', default: 'nrg'
+                thresholding method
+
             update_background_components: bool, default: True
                 whether to update the spatial background components
 
-            method_ls: 'lasso_lars'|'nnls_L0', default: 'lasso_lars'
-                'nnls_L0'. Nonnegative least square with L0 penalty
-                'lasso_lars' lasso lars function from scikit learn
 
-            block_size : int, default: 5000
-                Number of pixels to process at the same time for dot product. Reduce if you face memory problems
-
-            num_blocks_per_run: int, default: 20
-                Parallelization of A'*Y operation
-
-            normalize_yyt_one: bool, default: True
-                Whether to normalize the C and A matrices so that diag(C*C.T) = 1 during update spatial
-
-        TEMPORAL PARAMS (CNMFParams.temporal)###########
-
+          CNMFParams.temporal (these control how the algorithms handle temporal components):
             ITER: int, default: 2
                 block coordinate descent iterations
-
-            method_deconvolution: 'oasis'|'cvxpy'|'oasis', default: 'oasis'
-                method for solving the constrained deconvolution problem ('oasis','cvx' or 'cvxpy')
-                if method cvxpy, primary and secondary (if problem unfeasible for approx solution)
-
-            solvers: 'ECOS'|'SCS', default: ['ECOS', 'SCS']
-                 solvers to be used with cvxpy, can be 'ECOS','SCS' or 'CVXOPT'
-
-            p: 0|1|2, default: 2
-                order of AR indicator dynamics
-
-            memory_efficient: False
 
             bas_nonneg: bool, default: True
                 whether to set a non-negative baseline (otherwise b >= min(y))
 
-            noise_range: [float, float], default: [.25, .5]
-                range of normalized frequencies over which to compute the PSD for noise determination
+            block_size_temp : int, default: 5000
+                Number of pixels to process at the same time for dot product. Reduce if you face memory problems
 
-            noise_method: 'mean'|'median'|'logmexp', default: 'mean'
-                PSD averaging method for computing the noise std
+            fudge_factor: float (close but smaller than 1) default: .96
+                bias correction factor for discrete time constants
 
             lags: int, default: 5
                 number of autocovariance lags to be considered for time constant estimation
@@ -360,29 +360,42 @@ class CNMFParams(object):
             optimize_g: bool, default: False
                 flag for optimizing time constants
 
-            fudge_factor: float (close but smaller than 1) default: .96
-                bias correction factor for discrete time constants
+            memory_efficient:
+                (undocumented)
+
+            method_deconvolution: 'oasis'|'cvxpy'|'oasis', default: 'oasis'
+                method for solving the constrained deconvolution problem ('oasis','cvx' or 'cvxpy')
+                if method cvxpy, primary and secondary (if problem unfeasible for approx solution)
 
             nb: int, default: 1
                 number of global background components
 
-            verbosity: bool, default: False
-                whether to be verbose
+            noise_method: 'mean'|'median'|'logmexp', default: 'mean'
+                PSD averaging method for computing the noise std
 
-            block_size : int, default: 5000
-                Number of pixels to process at the same time for dot product. Reduce if you face memory problems
+            noise_range: [float, float], default: [.25, .5]
+                range of normalized frequencies over which to compute the PSD for noise determination
 
-            num_blocks_per_run: int, default: 20
+            num_blocks_per_run_temp: int, default: 20
                 Parallelization of A'*Y operation
+
+            p: 0|1|2, default: 2
+                order of AR indicator dynamics
 
             s_min: float or None, default: None
                 Minimum spike threshold amplitude (computed in the code if used).
 
-        MERGE PARAMS (CNMFParams.merge)#####
+            solvers: 'ECOS'|'SCS', default: ['ECOS', 'SCS']
+                 solvers to be used with cvxpy, can be 'ECOS','SCS' or 'CVXOPT'
+
+            verbosity: bool, default: False
+                whether to be verbose
+
+          CNMFParams.merging (these control how components are merged):
             do_merge: bool, default: True
                 Whether or not to merge
 
-            thr: float, default: 0.8
+            merge_thr: float, default: 0.8
                 Trace correlation threshold for merging two components.
 
             merge_parallel: bool, default: False
@@ -391,25 +404,9 @@ class CNMFParams(object):
             max_merge_area: int or None, default: None
                 maximum area (in pixels) of merged components, used to determine whether to merge components during fitting process
 
-        QUALITY EVALUATION PARAMETERS (CNMFParams.quality)###########
-
-            min_SNR: float, default: 2.5
-                trace SNR threshold. Traces with SNR above this will get accepted
-
+          CNMFParams.quality (these control how quality of traces are evaluated):
             SNR_lowest: float, default: 0.5
                 minimum required trace SNR. Traces with SNR below this will get rejected
-
-            rval_thr: float, default: 0.8
-                space correlation threshold. Components with correlation higher than this will get accepted
-
-            rval_lowest: float, default: -1
-                minimum required space correlation. Components with correlation below this will get rejected
-
-            use_cnn: bool, default: True
-                flag for using the CNN classifier.
-
-            min_cnn_thr: float, default: 0.9
-                CNN classifier threshold. Components with score higher than this will get accepted
 
             cnn_lowest: float, default: 0.1
                 minimum required CNN threshold. Components with score lower than this will get rejected.
@@ -417,19 +414,39 @@ class CNMFParams(object):
             gSig_range: list or integers, default: None
                 gSig scale values for CNN classifier. In not None, multiple values are tested in the CNN classifier.
 
-        ONLINE CNMF (ONACID) PARAMETERS (CNMFParams.online)#####
+            min_SNR: float, default: 2.5
+                trace SNR threshold. Traces with SNR above this will get accepted
 
+            min_cnn_thr: float, default: 0.9
+                CNN classifier threshold. Components with score higher than this will get accepted
+
+            rval_lowest: float, default: -1
+                minimum required space correlation. Components with correlation below this will get rejected
+
+            rval_thr: float, default: 0.8
+                space correlation threshold. Components with correlation higher than this will get accepted
+
+            use_cnn: bool, default: True
+                flag for using the CNN classifier.
+
+            use_ecc:
+                (undocumented)
+
+            max_ecc:
+                (undocumented)
+
+          CNMFParams.online (these control the Online/OnACID mode):
             N_samples_exceptionality: int, default: np.ceil(decay_time*fr),
                 Number of frames over which trace SNR is computed (usually length of a typical transient)
 
             batch_update_suff_stat: bool, default: False
                 Whether to update sufficient statistics in batch mode
 
-            ds_factor: int, default: 1,
-                spatial downsampling factor for faster processing (if > 1)
-
             dist_shape_update: bool, default: False,
                 update shapes in a distributed fashion
+
+            ds_factor: int, default: 1,
+                spatial downsampling factor for faster processing (if > 1)
 
             epochs: int, default: 1,
                 number of times to go over data
@@ -484,12 +501,16 @@ class CNMFParams(object):
                 Number of additional iterations for computing traces
 
             num_times_comp_updated: int, default: np.inf
+                (undocumented)
 
             opencv_codec: str, default: 'H264'
                 FourCC video codec for saving movie. Check http://www.fourcc.org/codecs.php
 
             path_to_model: str, default: os.path.join(caiman_datadir(), 'model', 'cnn_model_online.h5')
                 Path to online CNN classifier
+
+            ring_CNN:
+                Whether to use a ring CNN model (XXX due to bugs, this flag may not work and may never have worked)
 
             rval_thr: float, default: 0.8
                 space correlation threshold for accepting a new component
@@ -506,6 +527,9 @@ class CNMFParams(object):
             sniper_mode: bool, default: False
                 Whether to use the online CNN classifier for screening candidate components (otherwise space
                 correlation is used)
+
+            stop_detection:
+                Stop detecting neurons at the last epoch (XXX what does this mean?)
 
             test_both: bool, default: False
                 Whether to use both the CNN and space correlation for screening new components
@@ -528,14 +552,19 @@ class CNMFParams(object):
             update_num_comps: bool, default: True
                 Whether to search for new components
 
+            use_corr_img:
+                Use correlation image to detect new components
+
             use_dense: bool, default: True
                 Whether to store and represent A and b as a dense matrix
 
             use_peak_max: bool, default: True
                 Whether to find candidate centroids using skimage's find local peaks function
 
-        MOTION CORRECTION PARAMETERS (CNMFParams.motion)####
+            W_update_factor:
+                Update W less often than shapes by a given factor (XXX does this work?)
 
+          CNMFParams.motion (these control motion-correction):
             border_nan: bool or str, default: 'copy'
                 flag for allowing NaN in the boundaries. True allows NaN, whereas 'copy' copies the value of the
                 nearest data point.
@@ -566,6 +595,7 @@ class CNMFParams(object):
 
             num_splits_to_process_els, default: [7, None]
             num_splits_to_process_rig, default: None
+                (Undocumented, changing this likely to break the code - FIXME why is this a parameter then?)
 
             overlaps: (int, int), default: (24, 24)
                 overlap between patches in pixels in pw-rigid motion correction.
@@ -594,8 +624,7 @@ class CNMFParams(object):
             indices: tuple(slice), default: (slice(None), slice(None))
                 Use that to apply motion correction only on a part of the FOV
 
-        RING CNN PARAMETERS (CNMFParams.ring_CNN)
-
+          CNMFParams.ring_CNN (these control the ring neural networks):
             n_channels: int, default: 2
                 Number of "ring" kernels
 
@@ -885,6 +914,8 @@ class CNMFParams(object):
             'reuse_model': False                # reuse an already trained model
         }
 
+        if params_from_file is not None:
+            self.change_params_from_jsonfile(params_from_file)
         self.change_params(params_dict)
 
 

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1140,11 +1140,10 @@ class CNMFParams(object):
                         cat_handle[paramkey] = params_dict[paramkey] # Do the update
                 if legacy_used:
                     logging.warning(f"In setting CNMFParams, non-pathed parameters were used; this is deprecated. allow_legacy will default to False, and then will be removed in future versions of Caiman")
-                
         # END
         if warn_unused:
             for toplevel_k in params_dict:
-                if toplevel_k not in consumed:
+                if toplevel_k not in consumed and toplevel_k not in list(self.__dict__.keys()):
                     logging.warning(f"In setting CNMFParams, provided toplevel key {toplevel_k} was unused. This is a bug!")
         self.check_consistency()
 

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -1076,24 +1076,18 @@ class CNMFParams(object):
 
         return 'CNMFParams:\n\n' + '\n\n'.join(formatted_outputs)
 
-    def change_params(self, params_dict, verbose=False):
+    def change_params(self, params_dict, verbose=False) -> None:
         """ Method for updating the params object by providing a single dictionary.
-        For each key in the provided dictionary the method will search in all
-        subdictionaries and will update the value if it finds a match.
 
         Args:
-            params_dict: dictionary with parameters to be changed and new values
-            verbose: bool (False). Print message for all keys
+            params_dict: dictionary with parameters to be changed
+            verbose: bool (False). If true, will complain if the params dictionary is not complete
         """
         for gr in list(self.__dict__.keys()):
-            self.set(gr, params_dict, verbose=verbose)
-        for k, v in params_dict.items():
-            flag = True
-            for gr in list(self.__dict__.keys()):
-                d = getattr(self, gr)
-                if k in d:
-                    flag = False
-            if flag and verbose:
-                logging.warning(f'No parameter {k} found!')
+            if gr in params_dict:
+                self.set(gr, params_dict[gr], verbose=verbose)
+            else:
+                if verbose:
+                    logging.warning(f"No subobject {gr} in parameter dict")
         self.check_consistency()
-        return self
+

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -770,7 +770,6 @@ class CNMFParams(object):
             'method_ls': 'lasso_lars',
             # number of pixels to be processed by each worker
             'n_pixels_per_process': n_pixels_per_process,
-            'nb': gnb,                        # number of background components
             'normalize_yyt_one': True,
             'nrgthr': 0.9999,                # Energy threshold
             'num_blocks_per_run_spat': num_blocks_per_run_spat, # number of process to parallelize residual computation ** DECREASE IF MEMORY ISSUES
@@ -798,7 +797,6 @@ class CNMFParams(object):
             # if method cvxpy, primary and secondary (if problem unfeasible for approx
             # solution) solvers to be used with cvxpy, can be 'ECOS','SCS' or 'CVXOPT'
             'method_deconvolution': method_deconvolution,  # 'cvxpy', # 'oasis'
-            'nb': gnb,                   # number of background components
             'noise_method': 'mean',     # averaging method ('mean','median','logmexp')
             'noise_range': [.25, .5],   # range of normalized frequencies over which to average
             'num_blocks_per_run_temp': num_blocks_per_run_temp, # number of process to parallelize residual computation ** DECREASE IF MEMORY ISSUES

--- a/caiman/tests/comparison_humans.py
+++ b/caiman/tests/comparison_humans.py
@@ -313,33 +313,53 @@ for params_movie in np.array(params_movies)[ID]:
     c, dview, n_processes = setup_cluster(
         backend=backend_patch, n_processes=n_processes, single_thread=False)
     # %%
-    params_dict = {'fnames': [fname_new],
-                   'fr': params_movie['fr'],
-                   'decay_time': params_movie['decay_time'],
-                   'rf': params_movie['rf'],
-                   'stride': params_movie['stride_cnmf'],
-                   'K': params_movie['K'],
-                   'gSig': params_movie['gSig'],
-                   'merge_thr': params_movie['merge_thresh'],
-                   'p': global_params['p'],
-                   'nb': global_params['gnb'],
-                   'only_init': global_params['only_init_patch'],
-                   'dview': dview,
-                   'method_deconvolution': 'oasis',
-                   'border_pix': params_movie['crop_pix'],
-                   'low_rank_background': global_params['low_rank_background'],
-                   'rolling_sum': True,
-                   'nb_patch': 1,
-                   'check_nan': check_nan,
-                   'block_size_temp': block_size,
-                   'block_size_spat': block_size,
-                   'num_blocks_per_run_spat': num_blocks_per_run,
-                   'num_blocks_per_run_temp': num_blocks_per_run,
-                   'merge_parallel': True,
-                   'n_pixels_per_process': n_pixels_per_process,
-                   'ssub': global_params['ssub'],
-                   'tsub': global_params['tsub'],
-                   'thr_method': 'nrg'
+    params_dict = {
+                  'data': {
+                          'decay_time': params_movie['decay_time'],
+                          'fnames': [fname_new],
+                          'fr': params_movie['fr'],
+                          },
+                  'init': {
+                          'gSig': params_movie['gSig'],
+                          'K': params_movie['K'],
+                          'nb': global_params['gnb'],
+                          'rolling_sum': True,
+                          'ssub': global_params['ssub'],
+                          'tsub': global_params['tsub'],
+
+                          },
+                  'merging': {
+                             'merge_parallel': True,
+                             'merge_thr': params_movie['merge_thresh'],
+                             },
+                  'patch': {
+                           'border_pix': params_movie['crop_pix'],
+                           'low_rank_background': global_params['low_rank_background'],
+                           'nb_patch': 1,
+                           'only_init': global_params['only_init_patch'],
+                           'rf': params_movie['rf'],
+                           'stride': params_movie['stride_cnmf'],
+
+                           },
+                  'preprocess': {
+                                'check_nan': check_nan,
+                                'n_pixels_per_process': n_pixels_per_process,
+                                'p': global_params['p'],
+                                },
+                  'spatial':   {
+                               'block_size_spat': block_size,
+                               'nb': global_params['gnb'],
+                               'num_blocks_per_run_spat': num_blocks_per_run,
+                               'n_pixels_per_process': n_pixels_per_process,
+                               'thr_method': 'nrg'
+                               },
+                  'temporal':   {
+                                'block_size_temp': block_size,
+                                'method_deconvolution': 'oasis',
+                                'nb': global_params['gnb'],
+                                'num_blocks_per_run_temp': num_blocks_per_run,
+                                'p': global_params['p'],
+                                },
                    }
 
     init_method = global_params['init_method']
@@ -415,7 +435,7 @@ for params_movie in np.array(params_movies)[ID]:
                                 f=ld['f_gt'], R=ld['YrA_gt'], dims=(ld['d1'], ld['d2']))
 
     min_size_neuro = 3 * 2 * np.pi
-    max_size_neuro = (2 * params_dict['gSig'][0]) ** 2 * np.pi
+    max_size_neuro = (2 * params_dict['init']['gSig'][0]) ** 2 * np.pi
     gt_estimate.threshold_spatial_components(maxthr=0.2, dview=dview)
     nrn_size = gt_estimate.remove_small_large_neurons(min_size_neuro, max_size_neuro)
     nrn_dup = gt_estimate.remove_duplicates(predictions=None, r_values=None, dist_thr=0.1, min_dist=10,

--- a/caiman/tests/comparison_humans_online.py
+++ b/caiman/tests/comparison_humans_online.py
@@ -185,30 +185,49 @@ for ind_dataset in ID:
 
     # %%
     params_dict = {
-        'fnames': fls,
-        'fr': fr,
-        'decay_time': decay_time,
-        'gSig': gSig,
-        'p': global_params['p'],
-        'min_SNR': global_params['min_SNR'],
-        'rval_thr': global_params['rval_thr'],
-        'ds_factor': ds_factor,
-        'nb': gnb,
-        'motion_correct': global_params['mot_corr'],
-        'init_batch': init_batch,
-        'init_method': 'bare',
-        'normalize': True,
-        'expected_comps': expected_comps,
-        'dist_shape_update': True,
-        'K': K,
-        'epochs': epochs,
-        'show_movie': False,
-        'min_num_trial': global_params['min_num_trial'],
-        'use_peak_max': True,
-        'thresh_CNN_noisy': global_params['thresh_CNN_noisy'],
-        'sniper_mode': global_params['sniper_mode'],
-        'use_dense': False,
-        'update_freq': global_params['update_freq']
+        'data': {
+                'decay_time': decay_time,
+                'fnames': fls,
+                'fr': fr,
+                },
+        'init': {
+                'gSig': gSig,
+                'K': K,
+                'nb': gnb,
+                },
+        'online': {
+                  'dist_shape_update': True,
+                  'ds_factor': ds_factor,
+                  'epochs': epochs,
+                  'expected_comps': expected_comps,
+                  'init_batch': init_batch,
+                  'init_method': 'bare',
+                  'min_num_trial': global_params['min_num_trial'],
+                  'min_SNR': global_params['min_SNR'],
+                  'motion_correct': global_params['mot_corr'],
+                  'normalize': True,
+                  'rval_thr': global_params['rval_thr'],
+                  'show_movie': False,
+                  'sniper_mode': global_params['sniper_mode'],
+                  'thresh_CNN_noisy': global_params['thresh_CNN_noisy'],
+                  'update_freq': global_params['update_freq']
+                  'use_dense': False,
+                  'use_peak_max': True,
+                  },
+        'preprocess': {
+                      'p': global_params['p'],
+                      },
+        'quality': {
+                   'min_SNR': global_params['min_SNR'],
+                   'rval_thr': global_params['rval_thr'],
+                   },
+        'spatial': {
+                   'nb': gnb,
+                   },
+        'temporal': {
+                    'nb': gnb,
+                    'p': global_params['p'],
+                    },
     }
     opts = cnmf.params.CNMFParams(params_dict=params_dict)
 

--- a/caiman/tests/test_motion_correction.py
+++ b/caiman/tests/test_motion_correction.py
@@ -128,10 +128,14 @@ def _test_motion_correct_rigid(D):
     Y, C, S, A, centers, dims, shifts = gen_data(D)
     fname = 'testMovie.tif'
     cm.movie(Y).save(fname)
-    params_dict = {'max_shifts': (4, 4),   # maximum allowed rigid shifts (in pixels)
-                   'pw_rigid': False,      # flag for performing non-rigid motion correction
-                   'border_nan': True,
-                   'is3D': D == 3}
+    params_dict = {
+                   'motion': {
+                             'border_nan': True,
+                             'is3D': D == 3,
+                             'max_shifts': (4, 4), # maximum allowed rigid shifts (in pixels)
+                             'pw_rigid': False,    # flag for performing non-rigid motion correction
+                             }   
+                  }
     opts = cm.source_extraction.cnmf.params.CNMFParams(params_dict=params_dict)
     mc = MotionCorrect(fname, dview=None, **opts.get_group('motion'))
     mc.motion_correct(save_movie=True)

--- a/caiman/tests/test_onacid.py
+++ b/caiman/tests/test_onacid.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+import code
 import numpy.testing as npt
 import os
 from caiman.source_extraction import cnmf
@@ -25,25 +27,46 @@ def demo():
     K = 4              # max number of components in each patch
 
     params_dict = {
-        'fr': fr,
-        'fnames': fname,
-        'decay_time': decay_time,
-        'gSig': gSig,
-        'p': p,
-        'motion_correct': False,
-        'min_SNR': min_SNR,
-        'nb': gnb,
-        'init_batch': init_batch,
-        'init_method': init_method,
-        'rf': patch_size // 2,
-        'stride': stride,
-        'sniper_mode': True,
-        'thresh_CNN_noisy': thresh_CNN_noisy,
-        'K': K
+                  'data': {
+                          'decay_time': decay_time,
+                          'fr': fr,
+                          'fnames': fname
+                          },
+                  'init': {
+                          'K': K,
+                          'gSig': gSig,
+                          'nb': gnb
+                          },
+                  'online': {
+                            'init_batch': init_batch,
+                            'init_method': init_method,
+                            'min_SNR': min_SNR,
+                            'motion_correct': False,
+                            'sniper_mode': True,
+                            'thresh_CNN_noisy': thresh_CNN_noisy
+                            },
+                  'patch':{
+                          'rf': patch_size // 2,
+                          'stride': stride
+                          },
+                  'preprocess': {
+                                'p': p
+                                },
+                  'quality': {
+                             'min_SNR': min_SNR # FIXME duplicated between online.min_SNR and quality.min_SNR
+                             },
+                  'spatial': {
+                             'nb': gnb # FIXME duplicated between init.nb and spatial.nb and temporal.nb
+                             },
+                  'temporal': {
+                              'nb': gnb, # FIXME duplicated between init.nb and spatial.nb and temporal.nb
+                              'p': p, # FIXME duplicated between preprocess.p and temporal.p
+                              },
     }
     opts = cnmf.params.CNMFParams(params_dict=params_dict)
     cnm = cnmf.online_cnmf.OnACID(params=opts)
     cnm.fit_online()
+    #code.interact(local=dict(globals(), **locals()) )
     cnm.save('test_online.hdf5')
     cnm2 = cnmf.online_cnmf.load_OnlineCNMF('test_online.hdf5')
     npt.assert_allclose(cnm.estimates.A.sum(), cnm2.estimates.A.sum())
@@ -52,4 +75,4 @@ def demo():
 
 def test_onacid():
     demo()
-    pass
+

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -650,7 +650,7 @@ def get_caiman_version() -> tuple[str, str]:
     # 'GITW' ) git rev-parse if caiman is built from "pip install -e ." and we are working
     #    out of the checkout directory (the user may have since updated without reinstall)
     # 'RELF') A release file left in the process to cut a release. Should have a single line
-    #    in it whick looks like "Version:1.4"
+    #    in it which looks like "Version:1.4"
     # 'FILE') The date of some frequently changing files, which act as a very rough
     #    approximation when no other methods are possible
     #


### PR DESCRIPTION
This is a breaking change that fixes crucial bugs with CNMFParams, and it also adds json loading/saving functions for the same.

1) CNMFParams stores a lot of params with the same names (and even one parameter shares a name with a top level dictionary in the object), causing really weird bugs (including #1153 ). The parser in the codebase (before this diff lands) didn't treat subkeys as being pathed, so whenever a new params dictionary was passed in (including during initialisation) it would be copied to every subkey with its name, not allowing them to be independently set and sometimes causing the code to crash when a bizarre value landed over what was supposed to be a simple scalar. This entirely reworks the change_params() method to instead take a dict with paths inside it that matches the internal structure of CNMFParams
2) Tests are updated to match
3) It adds json functions to CNMFParams to make it possible to provide JSON files as canned configurations (intended for demos)
4) The to_dict() method now uses the same names for its export as the internal data structures in CNMFParams, making it possible to save and then load a set of parameters and have it actually work (this did not work correctly before)
5) change_params() no longer returns self (this was not used by any code I could find)

Before this lands:
A) All the demos need to be adjusted too
B) We need to do some outreach because this is a breaking change that will be painful for users
C) I need to look into whether the set() method needs similar adjustments
D) Consider making change_params() and set() if we change it validate its inputs and complain if it is passed parameters that it doesn't know how to set (right now these are just ignored). Ideally gate this behind a validate:bool argument or something like that