### PR TITLE
fix version string

### DIFF
--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -72,6 +72,9 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
             shutil.copy(stdmovie, os.path.join(targdir, 'example_movies'))
         for extrafile in extra_files:
             shutil.copy(extrafile, targdir)
+    if 'CAIMAN_RELEASE' in os.environ:
+        with open(os.path.join(targdir, 'RELEASE'), 'w') as verfile_fh:
+            print(f"Version:{caiman.__version__}", file=verfile_fh)
     print("Installed " + targdir)
 
 

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -675,7 +675,7 @@ def get_caiman_version() -> tuple[str, str]:
             for line in sfh:
                 if ':' in line: # expect a line like "Version:1.3"
                     _, version = line.rstrip().split(':')
-                    return 'RELF', version 
+                    return 'RELEASE', version 
 
     # Attempt: 'FILE'
     # Right now this samples the utils directory


### PR DESCRIPTION
This fixes a small bug in how caiman versions are calculated/reported (and is paired with some changes in the conda-forge plumbing). It's very low-impact (the fallback logic was being used routinely and this will make that less so, and the version string is not used for much).