### PR TITLE
Minor tweaks in notebooks for next 1.10 patch

### DIFF
--- a/demos/notebooks/demo_pipeline.ipynb
+++ b/demos/notebooks/demo_pipeline.ipynb
@@ -1219,7 +1219,7 @@
     "\n",
     "Traditionally, the baseline value was calculated during some initial period of queiscience (e.g., in the visual system, when the animal was sitting in the dark). However, it is problematic to make any assumptions about a \"quiet\" baseline period, so researchers have started to use a moving average to calculate $F_0$. This is also what Caiman does.\n",
     "\n",
-    "More specifically, in Caiman the baseline is a running percentile calculated over a `frames_window` moving window. You can calculate $\\Delta F/F$ using raw traces or the denoised traces in C (this is toggled using the `use_residuals` argument). Caiman defaults to using the raw traces because the denoised traces can have very low values, and dividing by low numbers is sometimes troublesome:"
+    "More specifically, in Caiman the baseline is a running percentile calculated over a `frames_window` moving window. You can calculate $\\Delta F/F$ using raw traces or the denoised traces in C (this is toggled using the `use_residuals` argument)."
    ]
   },
   {
@@ -1232,7 +1232,8 @@
     "    print('Calculating estimates.F_dff')\n",
     "    cnmf_refit.estimates.detrend_df_f(quantileMin=8, \n",
     "                                      frames_window=250,\n",
-    "                                      use_residuals=True);  # set to False to use denoised data: may see divide by zero warnings!\n",
+    "                                      flag_auto=False,\n",
+    "                                      use_residuals=False);  \n",
     "else:\n",
     "    print(\"estimates.F_dff already defined\")"
    ]

--- a/demos/notebooks/demo_pipeline.ipynb
+++ b/demos/notebooks/demo_pipeline.ipynb
@@ -5,13 +5,15 @@
    "metadata": {},
    "source": [
     "# CNMF demo pipeline: Intro\n",
-    "A full pipeline for the analysis of a two-photon calcium imaging dataset using the CaImAn software package. It demonstrates how to use Caiman for the following analysis steps:\n",
+    "This demo provides a full pipeline for the analysis of a two-photon calcium imaging dataset using the CaImAn software package. It demonstrates how to use Caiman for the following analysis steps:\n",
     "\n",
     "![Full CNMF Workflow](https://raw.githubusercontent.com/flatironinstitute/CaImAn/main/docs/img/full_cnmf_workflow.jpg)\n",
     "\n",
     "1) Apply the nonrigid motion correction (NoRMCorre) algorithm for motion correction.\n",
     "2) Apply the constrained nonnegative matrix factorization (CNMF) source separation algorithm to extract initial estimates of neuronal spatial footprints and calcium traces.  \n",
     "3) Apply quality control metrics to evaluate the initial estimates, and narrow down to the final set of estimates.\n",
+    "\n",
+    "In addition to the above core analysis steps, the demo also shows how to extract $\\Delta F/F$ for the calcium traces, and  how to use Caiman's multiple visualization tools on your data to inspect the results at each stage.\n",
     "\n",
     "The CNMF algorithm is best for data with relatively low background noise, like most two-photon data and *some* one photon data (e.g., certain light sheet data). For a demo analysis pipeline of a one-photon microendoscopic data set see `demo_pipeline_cnmfE.ipynb`."
    ]
@@ -31,7 +33,7 @@
    "metadata": {},
    "source": [
     "## Imports and general setup\n",
-    "We first need to import the Python libraries we will use in the rest of the notebook and tweak some general settings. Don't worry about these details now, we will explain the important things when they come up. Note in the following, we import `caiman` as `cm`, so when you see `cm` in the rest of the notebook, it just means you are using something from the Caiman package.  "
+    "We first need to import the Python libraries we will use in the rest of the notebook and tweak some general settings. Don't worry about these details now, we will explain the important things when they come up. We import `caiman` as `cm`, so when you see `cm` in the rest of the notebook, it just means you are using something custom-written from the Caiman package.  "
    ]
   },
   {
@@ -106,9 +108,9 @@
    "metadata": {},
    "source": [
     "## Set up path to data\n",
-    "For this demo, we will analyze the data file `Sue_2x_3000_40_-46.tif`. This 3000-frame movie, provided courtesy of Sue Koay and David Tank (Princeton University), is two-photon data from supragranular parietal cortex of a GCaMP6f-expressing mouse during a virtual reality task. It was collected at 30Hz, and to save space, the demo data has been spatially cropped and downsampled by a factor of 2 compared to the original.  \n",
+    "For this demo, we will analyze the data file `Sue_2x_3000_40_-46.tif`. This 3000-frame movie, provided courtesy of Sue Koay and David Tank, is two-photon data from supragranular parietal cortex of a GCaMP6f-expressing mouse during a virtual reality task. It was collected at 30Hz, and to save space, the demo data has been spatially cropped and downsampled by a factor of 2 compared to the original.  \n",
     "\n",
-    "To get the data, we will use Caiman's built-in `download_demo()` function. It will download the data to  `~/caiman_data/example_movies/` where `~` is your home directory (the path format and home directory will depend on your operating system). If you already have the movie, it will just return the path to the movie. "
+    "To get the data, we will use Caiman's built-in `download_demo()` function. It will download the data to  `~/caiman_data/example_movies/`, where `~` is your home directory (the path format and home directory will depend on your operating system). If you already have the movie, it will just return the path to the movie. "
    ]
   },
   {
@@ -129,7 +131,7 @@
     "\n",
     "    movie_path = 'full/path/to/your/your_movie.extension'\n",
     "\n",
-    "While this demo uses a movie that has been stored in <i>tif</i> format, Caiman can handle movies in multiple common (and not so common) formats, including hdf5/h5, n5, zarr, avi, nwb, mat, and npz.  Please reach out if you have problems loading your data into Caiman and it is a common data format!"
+    "While this demo uses a movie that has been stored in <i>tif</i> format, Caiman can handle movies in multiple common (and not so common) formats, including hdf5/h5, n5, zarr, avi, nwb, mat, and npz.  Please reach out if you have problems loading your data into Caiman and it is a common format!"
    ]
   },
   {
@@ -138,17 +140,17 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "    <h2>Working with multiple files or sessions</h2>\n",
-    "     What if you have a recording that is broken up into multiple files, which is common for many acquisition systems? It is  easy to adapt the current demo for such cases. There are a couple of changes you would need to make. First, you would need to create a <i>list</i> of filepaths.:\n",
+    "     What if you have a recording that is broken up into multiple files, which is common for many acquisition systems? It is  easy to adapt the current demo for such cases. There are a couple of changes you would need to make. First, you would need to create a <i>list</i> of filepaths:<br>\n",
     "\n",
     "    movie_path1 = download_demo('Sue_Split1.tif')\n",
     "    movie_path2 = download_demo('Sue_Split2.tif')\n",
     "    movie_paths = [movie_path1, movie_path2]\n",
     "\n",
-    "Second, when creating the movie object instead of using <em>cm.load()</em> you would use <em>cm.load_movie_chain()</em> which takes in a list as an argument:\n",
+    "<br>Second, when creating the movie object, instead of using <em>cm.load()</em> you would use <em>cm.load_movie_chain()</em> which takes in a list as an argument:\n",
     "\n",
     "    movie_orig = cm.load_movie_chain(movie_paths)\n",
     "    \n",
-    "Also, what if you have <b>noncontiguous</b> recording sessions, for instance data in files from sessions separated by many days or weeks, and you need to match the neurons from these sessions? This is a different use case, and the demo can be found at <a href=\"./demo_multisession_registration.ipynb\">demo_multisession_registration.ipynb</a>.\n",
+    "<br>Also, what if you have <b>noncontiguous</b> recording sessions, for instance data in files from sessions separated by many days or weeks, and you need to match the neurons from these sessions? This is a different use case, and the demo can be found at <a href=\"./demo_multisession_registration.ipynb\">demo_multisession_registration.ipynb</a>.\n",
     "</div> "
    ]
   },
@@ -157,7 +159,7 @@
    "metadata": {},
    "source": [
     "## Visualize raw data\n",
-    "Caiman has a built-in movie class for movie-viewing (documentation [here](https://caiman.readthedocs.io/en/latest/Handling_Movies.html)). Once you have loaded a movie using `cm.load()`, you can view it using `movie.play()`. The `play()` function has multiple parameters: \n",
+    "Caiman has a built-in movie class for movie-viewing (documentation [here](https://caiman.readthedocs.io/en/latest/Handling_Movies.html)). Once you have loaded a movie using `cm.load()`, you can view it using `movie.play()`. The `play()` function has multiple parameters you can use to adjust the appearance of the movie: \n",
     "\n",
     "    gain: brightness \n",
     "    fr:  frame rate\n",
@@ -168,7 +170,7 @@
     "    \n",
     "The movie object also has a `resize()` method, which we use in the following to downsample the movie before playing.\n",
     "\n",
-    "Playing the movie uses the `OpenCV` library, so the following cell runs a blocking function (a function that blocks execution of all other code until it is stopped), opening a separate window which doesn't run in Jupyter. You will need to press `q` on that window to close it. "
+    "Playing the movie uses the `OpenCV` library, so the following cell runs a blocking function (a function that blocks execution of all other code until it is stopped): it will open a separate window that doesn't run in Jupyter. You will need to press `q` on that window to close it (or just wait until it is finished running). "
    ]
   },
   {
@@ -194,12 +196,13 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\">\n",
-    "    <h2>Displaying large files</h2>\n",
-    "Loading a movie with <em>cm.load()</em> pulls the data into memory, which is not always feasible. When working with your own data, you might need to adapt the above code when working with extremely large files. Caiman provides tools to handle this use case. One, you can just load some of your data into a movie object using the `subindices` argument to the `load()` function. For example, if you just want to load the first 500 frames of a movie, you can send it <em>subindices=np.arange(0,500)</em>. \n",
+    "    <h2>Displaying large files</h2><br>\n",
+    "    \n",
+    "Loading a movie with <em>cm.load()</em> pulls the data into memory, which is not always feasible. When working with your own data, you might need to adapt the above code when working with extremely large files. Caiman provides tools to handle this use case. One, you can just load some of your data into a movie object using the `subindices` argument to the `load()` function. For example, if you just want to load the first 500 frames of a movie, you can send it <em>subindices=np.arange(0,500)</em>.<br>\n",
     "\n",
-    "<p>If you don't want to truncate your movie, there is a <em>play_movie()</em> function that behaves just like <em>movie.play()</em>, but it doesn't load the movie into memory. Rather, it takes the filename as an argument and loads frames from disk as they are shown. If you want to use it, just import using <em>from caiman.base.movies import play_movie</em> and read the documentation. We don't use it for this demo because the demo movie is small, and we do some calculations on the loaded movie array.</p>\n",
+    "If you don't want to truncate your movie, there is a <em>play_movie()</em> function that behaves just like <em>movie.play()</em>, but it doesn't load the movie into memory. Rather, it takes the filename as an argument and loads frames from disk as they are shown. If you want to use it, just import using <em>from caiman.base.movies import play_movie</em> and read the documentation. We don't use it for this demo because the demo movie is small, and we do some calculations on the loaded movie array.<br>\n",
     "\n",
-    "<p>Another option for viewing very large movies is to use the <a href=https://github.com/fastplotlib/fastplotlib>fastplotlib library</a>, which leverages the GPU to provide interactive visualization within Jupyter notebooks (we discuss this more below).</p>\n",
+    "Another option for viewing very large movies is to use the <a href=https://github.com/fastplotlib/fastplotlib>fastplotlib library</a>, which leverages the GPU to provide interactive visualization within Jupyter notebooks (we discuss this more below).\n",
     "</div>"
    ]
   },
@@ -392,10 +395,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set up a cluster\n",
+    "## Set up multicore processing\n",
     "Caiman is optimized for parallel computing, and distributes computations to multiple CPU cores for motion correction and CNMF. Setting up the multicore processing is done with the `setup_cluster()` function below. \n",
     "\n",
-    "First, let's see how many CPUs we have available, and set the number of processors we want to use. If you set `num_processors_to_use` to `None`, then `setup_cluster()` will set it to the default of one less than the total number available:"
+    "First, let's see how many CPUs we have available, and set the number of processors we want to use. If you set `num_processors_to_use` to `None`, then `setup_cluster()` will set it to the default of *one less* than the total number available:"
    ]
   },
   {
@@ -412,7 +415,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set up a cluster of processors. If one has already been set up (the `cluster` variable is already in your namespace), then that cluster will be closed and a new one created."
+    "Initialize a cluster of processors. If one has already been set up (the `cluster` variable is already in your namespace), then that cluster will be closed and a new one created."
    ]
   },
   {
@@ -428,7 +431,7 @@
     "_, cluster, n_processes = cm.cluster.setup_cluster(backend='multiprocessing', \n",
     "                                                   n_processes=num_processors_to_use, \n",
     "                                                   ignore_preexisting=False)\n",
-    "print(f\"Successfully set up cluster with {n_processes} processes\")"
+    "print(f\"Successfully initilialized multicore processing with a pool of {n_processes} CPU cores\")"
    ]
   },
   {
@@ -445,12 +448,13 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" markdown=\"1\">\n",
-    "    <h2 style=\"margin-top: 0;\">Optimizing performance</h2>  \n",
-    "If you hit memory issues later, there are a few things you can do. First, you may want to lower the number of processors you are using. Each processor uses more RAM, and on a workstation with many processors, you can sometimes get better performance by reducing <em>num_processors_to_use</em>.The best way to determine the optimal number is by trial and error. When you set <em>num_processors_to_use</em> variable to <em>None</em>, it defaults to <i>one</i> less than the total number of CPU cores available (the reason we don't automatically set it to the total number of cores is because in practice this typically leads to worse performance).\n",
+    "    <h2 style=\"margin-top: 0;\">Optimizing performance</h2>\n",
+    "<br>    \n",
+    "If you hit memory issues later, there are a few things you can do. First, you may want to lower the number of processors you are using. Each processor uses more RAM, and on a workstation with many processors, you can sometimes get better performance by reducing <em>num_processors_to_use</em>.The best way to determine the optimal number is by trial and error. When you set <em>num_processors_to_use</em> variable to <em>None</em>, it defaults to <i>one</i> less than the total number of CPU cores available (the reason we don't automatically set it to the total number of cores is because in practice this typically leads to worse performance).<br>\n",
     "\n",
-    "<p>Second, if your system has less than 32GB of RAM, and things are running slowly or you are running out of memory, then get more RAM. While you can sometimes get away with less, we recommend a *bare minimum* level of 16GB of RAM, but more is better. 32GB RAM is acceptable, 64GB or more is best. Obviously, this will depend on the size of your data sets.</p>\n",
+    "Second, if your system has less than 32GB of RAM, and things are running slowly or you are running out of memory, then get more RAM. While you can sometimes get away with less, we recommend a *bare minimum* level of 16GB of RAM, but more is better. 32GB RAM is acceptable, 64GB or more is best. Obviously, this will depend on the size of your data sets.<br>\n",
     "\n",
-    "<p>Third, if none of your memory optimizations work, you may just have too much data for offline CNMF. For this case, we also provide an online version of CNMF (OnACID), which uses a small number of frames to initialize the spatial and temporal components, and iteratively updates them with new data. This uses much less memory than the offline approach. The demo notebook for OnACID is found in <a href=\"./demo_OnACID_mesoscope.ipynb\">demo_OnACID_mesoscope.ipynb</a>. See the <a href=\"https://pubmed.ncbi.nlm.nih.gov/30652683/\">Caiman paper</a> for more discussion.</p>\n",
+    "Third, if none of your memory optimizations work, you may just have too much data for offline CNMF. For this case, we also provide an online version of CNMF (OnACID), which uses a small number of frames to initialize the spatial and temporal components, and iteratively updates them with new data. This uses much less memory than the offline approach. The demo notebook for OnACID is found in <a href=\"./demo_OnACID_mesoscope.ipynb\">demo_OnACID_mesoscope.ipynb</a>. See the <a href=\"https://pubmed.ncbi.nlm.nih.gov/30652683/\">Caiman paper</a> for more discussion.\n",
     "</div>"
    ]
   },
@@ -597,12 +601,12 @@
    "source": [
     "<div class=\"alert alert-info\" markdown=\"1\">\n",
     "    <h2 style=\"margin-top: 0;\">If you don't need to run motion correction</h2>  \n",
-    "If you don't need to run motion correction  (for instance if your movie has no movement -- which is often the case in slice praparations), you can directly memory map your file to prepare for subsequent processing:\n",
+    "If you don't need to run motion correction  (for instance if your movie has no movement -- which is often the case in slice praparations), you can directly memory map your file to prepare for subsequent processing:<br>\n",
     "\n",
     "    mc_memmapped_fname = cm.save_memmap(movie_path, base_name='memmap_',\n",
     "                                         order='C', border_to_0=0, dview=cluster)\n",
     "\n",
-    "You would need to modify the rest of your code accordingly (e.g., don't run motion correction, and don't run the following code cell that creates a memmapped file from the motion correction estimator object). \n",
+    "<br>You would need to modify the rest of your code accordingly (e.g., don't run motion correction, and don't run the following code cell that creates a memmapped file from the motion correction estimator object). \n",
     "</div>"
    ]
   },
@@ -699,7 +703,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once initialized, we we could immediately run `cnmf_model.fit(images)` if we knew the parameters were good -- the parameters in your CNMF estimator object are accessible in `cnmf_model.params`. Before running the algorithm, let's go over the critical parameters that you will most likely need to tweak when running CNMF on your own data. "
+    "Once initialized, we we could immediately run `cnmf_model.fit(images)` if we knew the parameters were good -- the parameters in your CNMF estimator object are accessible in `cnmf_model.params`. Before running the algorithm, let's go over the key parameters for CNMF. The default values typically work fine for most parameters: there are just a few that you will need to alter based on your data:"
    ]
   },
   {
@@ -710,11 +714,11 @@
     "\n",
     "`rf (int)`: *patch half-width*\n",
     "\n",
-    "> `rf` ('receptive field') is the half width of patches in pixels (the actual patch width is `2*rf + 1`). `rf` should be *at least* 3-4 times larger than the observed neuron diameter. The larger the patch size, the less parallelization will be used by Caiman. If `rf` is set to `None`, then CNMF will be run on the entire field of view. \n",
+    "> `rf` ('receptive field') is the half width of patches that in pixels (the actual patch width is `2*rf + 1`). See previous image for a representation of how the field of view is split up into patches for parallel procesing. `rf` should be *at least* 3-4 times larger than the observed neuron diameter. The larger the patch size, the less parallelization will be used by Caiman. If `rf` is set to `None`, then CNMF will be run on the entire field of view. \n",
     "\n",
-    "`stride_cnmf (int)`: *patch overlap*\n",
+    "`stride (int)`: *patch overlap*\n",
     "\n",
-    "> `stride_cnmf` is the overlap between patches in pixels (the actual overlap is `stride_cnmf + 1`). This should be at least the diameter of a neuron. The larger the overlap, the greater the computational load, but the results will be more accurate when stitching together results from different patches. \n",
+    "> `stride` is the overlap between patches in pixels (the actual overlap is `stride + 1`). This should be at least the diameter of a neuron. The larger the overlap, the greater the computational load, but the results will be more accurate when stitching together results from different patches. \n",
     "\n",
     "`K (int)`: *components per patch*\n",
     "\n",
@@ -722,14 +726,14 @@
     "\n",
     "`gSig (int, int)`: *half-width of neurons*\n",
     "\n",
-    "> `gSig` is roughly the half-width of neurons in your movie in pixels (height, width): it is the sigma parameter of a Gaussian filter run on all the images during initialization. If the filter matches the neurons, you will get a much better estimate. `gSig` goes with `gSiz`, which is the kernel size (height and width in pixels) used for the same filter. See the `GaussianBlur()` OpenCV function for more details on the sigma and size parameters.\n",
+    "> `gSig` is roughly the half-width of neurons in your movie in pixels (height, width): it is the sigma parameter of a Gaussian filter run on all the images during initialization. If the filter matches the neurons, you will get a much better estimate. `gSig` goes with `gSiz`, which is the kernel size (height and width in pixels) used for the filter. See the `GaussianBlur()` OpenCV function for more details on the sigma and size parameters.\n",
     "    \n",
     "   \n",
     "`merge_thr (float)`: *merge threshold* \n",
     "\n",
     "> If two spatially overlapping components are correlated above `merge_thr`, they will be merged into one component. The correlation coefficient is calculated using their calcium traces. If Caiman identifies a \"component\" that clearly contains two overlapping components, then increase `merge_thr`. \n",
     "\n",
-    "You typically will set `rf` and `stride` infrequently, so `K`, `gSig`, and `merge_thr` are the main parameters you will tweak when analyzing a given session. Note these are not the *only* important parameters. They just tend to be the *most* important, while many others tend to depend on your calcium indicator or other factors that don't vary within an experimental session. "
+    "You typically will set `rf` and `stride` infrequently, so `K`, `gSig`, and `merge_thr` are the main parameters you will tweak when analyzing a given session. Note these are not the *only* important parameters. They just tend to be the *most* important: the others tend to depend on your calcium indicator or other factors that don't vary within an experimental session. "
    ]
   },
   {
@@ -737,8 +741,7 @@
    "metadata": {},
    "source": [
     "### Selecting spatial parameters\n",
-    "The previous section provided some guidelines on how to select parameters via inspection of your data. Basically you need to look at your movie, or a summary image for your movie, and pick values close to those suggested by the guidelines above. \n",
-    "It is helpful to use `view_quilt()` function to see if our critical spatial parameters are in the right ballpark (note we recommend running this viewer in interactive qt mode so you can interact with it and get a better feel for the parameters):"
+    "To select the spatial parameters (`gSig`, `rf`, `stride`, `K`), you need to look at your movie, or a summary image for your movie, and pick values close to those suggested by the guidelines above. It is helpful to use `view_quilt()` function to see if our key spatial parameters are in the right ballpark (note we recommend running this viewer in interactive qt mode so you can interact with it and get a better feel for the parameters):"
    ]
   },
   {
@@ -774,7 +777,7 @@
     "- When in interactive mode, you can zoom and inspect the average width of each neuron in pixels. Is `gSig` about half that? Yes. Each neuron is about 6-8 pixels wide, and `gSig` is 4.\n",
     "- For `K`: how many neurons are in each patch? Remember you want an upper bound, not an average. The current value of 4 seems good.\n",
     "\n",
-    "Keep in mind that there is typically no *perfect* parameter value, and ultimately the only way to know if a set of parameters is good is to fit the model and see how well it performs. Sometimes you just have to iteratively search a bit in parameter space. "
+    "Keep in mind that there is typically no *perfect* set of parameter values: ultimately the only way to know if a set of parameters is good is to fit the model and see how well it performs. Sometimes you just have to iteratively search a bit in parameter space. "
    ]
   },
   {
@@ -784,13 +787,12 @@
     "<div class=\"alert alert-info\" markdown=\"1\">\n",
     "    <h2 style=\"margin-top: 0;\">How to change parameters</h2>  \n",
     "    \n",
-    "<p>If the parameters were <em>not</em> good, then you could change them using the `change_params()` method of the parameters object, which takes in a dictionary of new parameter values. For instance, if we wanted to change gSig to 5:</p>\n",
+    "If the parameters were <em>not</em> good, then you could change them using the `change_params()` method, which takes in a dictionary of new parameter values. For instance, if we wanted to change gSig to 5:<br>\n",
     "\n",
     "    new_parameters = {'gSig': 5}\n",
     "    cnmf_model.params.change_params(params_dict=new_parameters)\n",
     "      \n",
-    "<p>It is not always efficient to cobble together iterative parameter search from scratch, especially if you end up needing to do a grid search in a large parameter space. <a href=https://github.com/nel-lab/mesmerize-core>Mesmerize</a> is a great package built to make parameter exploration in Caiman faster and more convenient: it keeps track of all your different results, and includes powerful GPU-based tools (based on the <a href=\"https://github.com/fastplotlib/fastplotlib\">fastplotlib library</a>) for visualization of results in Jupyter notebooks.</p>\n",
-    "    \n",
+    "<br>It is not always efficient to cobble together iterative parameter search from scratch, especially if you end up needing to do a grid search in a large parameter space. <a href=https://github.com/nel-lab/mesmerize-core>Mesmerize</a> is a great package built to make parameter exploration in Caiman faster and more convenient: it keeps track of all your different results, and includes powerful GPU-based tools (based on the <a href=\"https://github.com/fastplotlib/fastplotlib\">fastplotlib library</a>) for visualization of results in Jupyter notebooks.\n",
     "</div>"
    ]
   },
@@ -845,7 +847,7 @@
    "metadata": {},
    "source": [
     "### Re-run (seeded) CNMF  on the full field of view \n",
-    "It is typically helpful to refine the initial estimates by re-running the CNMF algorithm seeded just on the spatial estimates from the previous step using the `refit()` method. "
+    "It is usually helpful to refine the initial estimates by re-running the CNMF algorithm seeded just on the spatial estimates from the previous step using the `refit()` method. "
    ]
   },
   {
@@ -888,17 +890,19 @@
    "metadata": {},
    "source": [
     "# The estimates class\n",
-    "The main point of the CNMF algorithm is to perform source separation: to extract the location of neurons, and calcium activity traces from your raw data. This information, and many useful methods for visualization and analysis, are contained in Caiman's `Estimates` class. In the above code, an `estimates` object was generated when you ran the CNMF algorithm (you can find it in `cnmf_refit.estimates`). \n",
+    "The main point of the CNMF algorithm is to perform source separation to extract the location of neurons and calcium activity traces from your raw data. This information, and many useful methods for visualization and analysis, are contained in Caiman's `Estimates` class. In the above code, an `estimates` object was generated when you ran the CNMF algorithm (you can find it in `cnmf_refit.estimates`). \n",
     "\n",
-    "The rest of this notebook, from component evaluation to calculation of DFoF, is effectively an exploration of the properties and methods of the `Estimates` class. The most important estimates generated are:\n",
+    "The rest of this notebook, from component evaluation to calculation of DFoF, is effectively an exploration of the properties and methods of the `Estimates` class. The most important estimates generated, which are properties of the `cnmf_refit.estimates`, are given in the following table:\n",
     "\n",
-    "    C: denoised calcium traces (num components x num frames) -- the temporal traces\n",
-    "    A: spatial components (num pixels x num components) - the spatial footprints\n",
-    "    YrA: residual for each calcium trace (num components x num frames)\n",
-    "    S: spike count estimate from deconvolution, if used (num components x num frames)\n",
-    "    F_dff: deltaF/F -- calcium traces relative to moving percentile baseline (num components x num frames)\n",
+    "| Variable | Meaning | Shape |\n",
+    "|:-------- |:------------- |:--------------------- |\n",
+    "| **C** | Denoised calcium traces |  num components x num_frames |\n",
+    "| **F_dff** | $\\Delta F/F$ |  num_components x num_frames |\n",
+    "| **S** | Spike count estimate for each component from deconvolution, if used |  num_components x num_frames |\n",
+    "| **YrA** | Residual for each trace |  num_components x num_frames |\n",
+    "| **A** | Spatial components/footprints |  num pixels x num components |\n",
     "\n",
-    "To recover raw calcium traces, you can add together the denoised calcium traces and their residuals (`C + YrA`). The `F_dff` calculation is not done automatically, so when you run `fit()` the `F_dff` field will initially be `None`. We will show how to do populate that field below."
+    "To recover raw calcium traces, you can add together the denoised calcium traces and their residuals (`C + YrA`). Note that the `F_dff` calculation is not done automatically, so when you run `fit()` the `F_dff` field will initially be `None`. We will show how to do populate that field below."
    ]
   },
   {
@@ -916,8 +920,9 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" markdown=\"1\">\n",
-    "    <h2 style=\"margin-top: 0;\">More on Estimates</h2>  \n",
-    "The estimates object contains a great deal of information. The attributes are discussed in more detail <a href=\"https://caiman.readthedocs.io/en/latest/Getting_Started.html#result-interpretation\">in the documentation</a>, but you might also find exploring the <a href=\"https://github.com/flatironinstitute/CaImAn/blob/main/caiman/source_extraction/cnmf/estimates.py\">source code</a> helpful. For instance, while most users initially care about the extracted calcium signals <em>C</em> and spatial footprints <em>A</em>, the <b>background model</b> is also very important. The background model is included in the estimate in fields <em>b</em> and <em>f</em> (which correspond to the spatial and temporal components of the low-rank background model, respectively). We discuss the background model more below.\n",
+    "    <h2 style=\"margin-top: 0;\">More on Estimates</h2>\n",
+    "    \n",
+    "The estimates object contains a great deal of information. The attributes are discussed in more detail <a href=\"https://caiman.readthedocs.io/en/latest/Getting_Started.html#result-interpretation\">in the documentation</a>, but you might also find exploring the <a href=\"https://github.com/flatironinstitute/CaImAn/blob/main/caiman/source_extraction/cnmf/estimates.py\">source code</a> helpful. For instance, while most users initially care about the extracted calcium signals <em>C</em> and spatial footprints <em>A</em>, the <b>background model</b> is also very important. The background model is included in the estimate in fields <em>b</em> and <em>f</em> (which correspond to the spatial and temporal components of the low-rank background model, respectively). We discuss the background model more below.<br>\n",
     "\n",
     "<p>We realize that attribute names like <em>A</em> are not very informative or Pythonic. These names are rooted in mathematical conventions from the original papers in the literature.</p>\n",
     "</div>"
@@ -1008,7 +1013,7 @@
     "In practice, SNR is the most important evaluation factor. The spatial correlation factors are less important. In particular, the CNN for spatial evaluation may be inaccurate if your neural components are not \"canonically\" shaped somata. \n",
     "\n",
     "\n",
-    "<p>When running <em>evaluate_components()</em> the three evaluation thresholds are appied <em>inclusively</em>: if a component is above <em>any</em> of the thresholds, it will pass muster. This was found in practice to be reasonable (e.g., a low SNR component that is very strongly neuronally shaped tends to not be an accident: it is just a very low SNR neuron). However, there is a second set of <b>absolute</b> threshold parameters  set for each criterion. If a component is <em>below</em> this absolute threshold for any of the evaluation parameters, it will be discarded: these are the <em>SNR_lowest</em>, <em>rval_lowest</em>, and <em>cnn_lowest</em>, respectively.</p> \n",
+    "<br>When running <em>evaluate_components()</em> the three evaluation thresholds are appied <em>inclusively</em>: if a component is above <em>any</em> of the thresholds, it will pass muster. This was found in practice to be reasonable (e.g., a low SNR component that is very strongly neuronally shaped tends to not be an accident: it is just a very low SNR neuron). However, there is a second set of <b>absolute</b> threshold parameters  set for each criterion. If a component is <em>below</em> this absolute threshold for any of the evaluation parameters, it will be discarded: these are the <em>SNR_lowest</em>, <em>rval_lowest</em>, and <em>cnn_lowest</em>, respectively. \n",
     "</div>"
    ]
   },
@@ -1214,7 +1219,7 @@
     "\n",
     "Traditionally, the baseline value was calculated during some initial period of queiscience (e.g., in the visual system, when the animal was sitting in the dark). However, it is problematic to make any assumptions about a \"quiet\" baseline period, so researchers have started to use a moving average to calculate $F_0$. This is also what Caiman does.\n",
     "\n",
-    "More specifically, in Caiman the baseline is a running percentile calculated over a `frames_window` moving window. You can calculate $\\Delta F/F$ using raw traces or the denoised traces in C (this is toggled using the `use_residuals` argument):"
+    "More specifically, in Caiman the baseline is a running percentile calculated over a `frames_window` moving window. You can calculate $\\Delta F/F$ using raw traces or the denoised traces in C (this is toggled using the `use_residuals` argument). Caiman defaults to using the raw traces because the denoised traces can have very low values, and dividing by low numbers is sometimes troublesome:"
    ]
   },
   {
@@ -1227,7 +1232,7 @@
     "    print('Calculating estimates.F_dff')\n",
     "    cnmf_refit.estimates.detrend_df_f(quantileMin=8, \n",
     "                                      frames_window=250,\n",
-    "                                      use_residuals=False);  # use denoised data\n",
+    "                                      use_residuals=True);  # set to False to use denoised data: may see divide by zero warnings!\n",
     "else:\n",
     "    print(\"estimates.F_dff already defined\")"
    ]
@@ -1236,7 +1241,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `estimates` object will now have a `F_dff` field, which makes it easier to compare traces across neurons/sessions because the data is normalized. Note that F_dff values can be positive or negative because it is relative to a baseline value that is the \"zero\" value."
+    "The `estimates` object will now have a `F_dff` field, which makes it easier to compare traces across neurons/sessions because the data is normalized. Note that F_dff values can be positive or negative because it is relative to a baseline value that is the \"zero\" value.\n",
+    "\n",
+    "We can plot a temporal trace of a dff with time. In the following, we'll generate a `frame_time` variable for plotting. This is an  idealized time representation using `linspace()`, which assumes that images were acquired at a constant frequency throughout the session. In practice your hardware probably returns the time at which each frame was acquired, so you can use that information in your own analysis if you have it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frame_rate = cnmf_refit.params.data['fr']\n",
+    "frame_pd = 1/frame_rate\n",
+    "frame_times = np.linspace(0, num_frames*frame_pd, num_frames);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot F_dff\n",
+    "idx_to_plot = 30\n",
+    "idx_accepted = cnmf_refit.estimates.idx_components\n",
+    "component_number = idx_accepted[idx_to_plot]\n",
+    "f, ax = plt.subplots(figsize=(7,2))\n",
+    "ax.plot(frame_times, \n",
+    "        cnmf_refit.estimates.F_dff[component_number, :], \n",
+    "        linewidth=0.5,\n",
+    "        color='k');\n",
+    "ax.set_xlabel('Time (s)')\n",
+    "ax.set_ylabel('$\\Delta F/F$')\n",
+    "ax.set_title(f\"$\\Delta F/F$ for unit {component_number}\");\n",
+    "plt.tight_layout()"
    ]
   },
   {
@@ -1245,7 +1284,7 @@
    "source": [
     "<div class=\"alert alert-info\" markdown=\"1\">\n",
     "    <h2 style=\"margin-top: 0;\">More on $\\Delta F/F$</h2>  \n",
-    "The above discussion of dff leaves out some details about it is actually calculated in Caiman. Behind the scenes, Caiman projects the background activity to the spatial footprint of the neuron and adds a moving percentile of this projected trace to the denominator (see the discussion on the background model below). This acts as an empirical fudge factor that can keep results from getting too large when very low values for $F_0$ are in the denominator (especially when using denoised traces). Users may prefer to use the more traditional equation directly. Thanks to Peter Rupprecht for a helpful discussion of this topic. \n",
+    "The above discussion of dff leaves out some details about it is actually calculated in Caiman. Behind the scenes, Caiman projects the background activity to the spatial footprint of the neuron and adds a moving percentile of this projected trace to the denominator as an additional normalizing term (see the discussion on the background model below). This acts as an empirical fudge factor that can keep $\\Delta F/F$ from getting too large for very small values of $F_0$ (especially when using denoised traces). Users may prefer to use the more traditional equation directly. Thanks to Peter Rupprecht for a helpful discussion of this topic. \n",
     "</div>"
    ]
   },
@@ -1304,7 +1343,7 @@
     "## Save results to csv\n",
     "When we showed how to save/load the cnmf model above, that was for working with the entire estimator object (for instance if you want to save your work and start again later). Often users just want to save certain results such as the calcium traces in `C` to csv and do downstream analysis later. In Python it is easiest to do this using the Pandas package.\n",
     "\n",
-    "The following shows how to save your calcium traces to a file called `C_traces.csv`, to the `caiman_data` folder. You can adapt this code to save other data fields such as dff. "
+    "The following shows how to save your calcium traces to a file called `C_traces.csv`, to the `caiman_data` folder. You can adapt this code to save other data fields such as dff. We will also save the frame times as a convenient reference."
    ]
   },
   {
@@ -1313,10 +1352,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frame_rate = cnmf_refit.params.data['fr']\n",
-    "frame_pd = 1/frame_rate\n",
-    "frame_times = np.linspace(0, num_frames*frame_pd, num_frames);\n",
-    "\n",
     "data_to_save = np.vstack((frame_times, cnmf_refit.estimates.C)).T  # Transpose so time series are in columns\n",
     "save_df = pd.DataFrame(data_to_save)\n",
     "save_df.rename(columns={0:'time'}, inplace=True)\n",
@@ -1328,8 +1363,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> In the above we have created an idealized time representation using `linspace()`, which assumes that images were acquired at a constant frequency throughout the session. In practice your hardware may return the time at which each frame was acquired, so you can use that data directly.\n",
-    "\n",
     "Set up file path and save using the Pandas `to_csv()` method:"
    ]
   },
@@ -1443,6 +1476,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "cnmf_refit.estimates.play_movie?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# press q to quit (can take a while to start running)\n",
     "cnmf_refit.estimates.play_movie(images, \n",
     "                                q_max=99.9, \n",
@@ -1450,6 +1492,7 @@
     "                                magnification=2,\n",
     "                                include_bck=True,\n",
     "                                use_color=True,\n",
+    "                                frame_range=slice(None, None, 5), # sample every 5th frame for speedup\n",
     "                                thr=0); # set thr to 0.1 to see contours"
    ]
   },
@@ -1464,7 +1507,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Where next?\n",
+    "# What next?\n",
     "The goal of Caiman is to help you extract high-quality signals from your data, and we have achieved that goal with the above steps. The next step, of doing actual *analysis* of these results, is where the most interesting neuroscience happens: what are the statistical features of these signals? How do they relate to other environmental, molecular, behavioral, and neuronal features that you are studying? What kinds of visualization and analysis tools can you build around this infrastructure? If you find/publish things that help, please share them with us, as we would love to hear about them! "
    ]
   },

--- a/demos/notebooks/demo_pipeline_cnmfE.ipynb
+++ b/demos/notebooks/demo_pipeline_cnmfE.ipynb
@@ -760,6 +760,7 @@
     "    print('Calculating estimates.F_dff')\n",
     "    cnmfe_model.estimates.detrend_df_f(quantileMin=8, \n",
     "                                      frames_window=250,\n",
+    "                                      flag_auto=False,\n",
     "                                      use_residuals=False);  # use denoised data\n",
     "else:\n",
     "    print(\"estimates.F_dff already defined\")"

--- a/demos/notebooks/demo_pipeline_cnmfE.ipynb
+++ b/demos/notebooks/demo_pipeline_cnmfE.ipynb
@@ -747,7 +747,7 @@
    "metadata": {},
    "source": [
     "## Extract $\\Delta F/F$ values\n",
-    "Currently in Caiman, we don't return a true dff value for 1p data. This is because, as mentioned in `demo_pipeline.ipynb`,  Caiman normalizes to both the baseline fluorescence and background activity, and the background activity in 1p is so ill-behaved (as discussed above in the sidebar on the ring model). Hence, we currently only *detrend* the data by subtracting away the baseline but do not normalize to baseline. This explains the warning you will see when you run the following:"
+    "Currently in Caiman, we don't return a true dff value for 1p data. This is because, as mentioned in `demo_pipeline.ipynb`,  Caiman normalizes to both the baseline fluorescence and background activity. The background activity in 1p is so ill-behaved (as discussed above in the sidebar on the ring model) that Caiman currently only *detrends* the data by subtracting away the baseline but not normalizing the data. This explains the warning you will see when you run the following:"
    ]
   },
   {
@@ -772,7 +772,7 @@
     "##  Deconvolution for 1p?\n",
     "While we haven't discussed deconvolution (the estimation of the spikes that generated the calcium traces in `C`), we suggest treating the spike counts returned for 1p data (in `estimates.S`) with CNMFE with some caution. Currently (as of early 2024) we are aware of no simultaneous ground-truth recordings (electrophysiology + 1p imaging) that could be used to evaluate deconvolution models for 1p data. There are quite a few such recordings for 2p data (for instance see [the Spikefinder paper](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006157)).\n",
     "\n",
-    "Because of this, most researchers analyze the calcium traces directly for 1p recordings (the data in `estimates.C`) or a normalized version of them."
+    "Because of this, most researchers analyze the calcium traces directly for 1p recordings (the data in `estimates.C`) or a normalized version of them, rather than `estimates.S`."
    ]
   },
   {


### PR DESCRIPTION
Expected to go out in next patch (with image link fix #1261 ). Improved formatting of estimates description. Improved discussion of $\Delta F/F$.  Added example plot of DFF trace. 

Still need to look over a couple of things wrt DFF, e.g., would like to fix infinite loop (#1262 ).


