### PR TITLE
fix bug in correlation image calculation

### DIFF
--- a/caiman/summary_images.py
+++ b/caiman/summary_images.py
@@ -201,7 +201,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
     Returns:
         rho: d1 x d2 [x d3] matrix, cross-correlation with adjacent pixels
     """
-
+    print("Testing corr func")
     if swap_dim:
         Y = np.transpose(Y, tuple(np.hstack((Y.ndim - 1, list(range(Y.ndim))[:-1]))))
 
@@ -248,14 +248,14 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
                 rho_d1 = rho_d1
                 rho_d2 = rho_d2
                 rho[:-1, :-1] = rho[:-1, :-1] * rho_d2
-                rho[1:,   1:] = rho[1:,   1:] * rho_d1
+                rho[1:,   1:] = rho[1:,   1:] * rho_d2
                 rho[1:,  :-1] = rho[1:,  :-1] * rho_d1
-                rho[:-1,  1:] = rho[:-1,  1:] * rho_d2
+                rho[:-1,  1:] = rho[:-1,  1:] * rho_d1
             else:
                 rho[:-1, :-1] = rho[:-1, :-1] + rho_d2**(order_mean)
-                rho[1:,   1:] = rho[1:,   1:] + rho_d1**(order_mean)
+                rho[1:,   1:] = rho[1:,   1:] + rho_d2**(order_mean)
                 rho[1:,  :-1] = rho[1:,  :-1] + rho_d1**(order_mean)
-                rho[:-1,  1:] = rho[:-1,  1:] + rho_d2**(order_mean)
+                rho[:-1,  1:] = rho[:-1,  1:] + rho_d1**(order_mean)
 
             neighbors = 8 * np.ones(np.shape(Y)[1:3])
             neighbors[0,   :] = neighbors[0,   :] - 3


### PR DESCRIPTION
# Description

Fixes bug pointed out by @rcalfredson and implements fix suggested by @j-friedrich in discussion #1190 

# Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# Has your PR been tested?
`caimanmanager test` passes. 

I ran:
`np.allclose(corr_im_local, corr_im_fft, rtol=1e-05, atol=1e-05, equal_nan=True)`

Where `corr_im_local` is the output of the buggy function `cm.local_correlations()`, and `corr_im_fft` is the output of the more canonical fft-based correlation function `cm.summary_images.local_correlations_fft()`

until it came back `True`. 

I haven't added this to the test suite. It might be a good idea though. 
Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.
