### PR TITLE
Fix problem with using reloaded cnmf object

### DIFF
--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -927,8 +927,11 @@ class CNMFParams(object):
         if self.data['dims'] is None and self.data['fnames'] is not None:
             self.data['dims'] = caiman.base.movies.get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0]
         if self.data['fnames'] is not None:
-            # following handles reloaded data where strings are byte-encoded
-            if not isinstance(self.data['fnames'][0], str):
+            # if fname was stored as string instead of list
+            if isinstance(self.data['fnames'], str):
+                self.data['fnames'] = [self.data['fnames']]
+            # convert reloaded data fnames from byte-encoded to string
+            if isinstance(self.data['fnames'][0], np.bytes_):
                 self.data['fnames'] = [fname.decode('utf-8') for fname in self.data['fnames']]
             T = caiman.base.movies.get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[1]
             if len(self.data['fnames']) > 1:

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -927,8 +927,9 @@ class CNMFParams(object):
         if self.data['dims'] is None and self.data['fnames'] is not None:
             self.data['dims'] = caiman.base.movies.get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[0]
         if self.data['fnames'] is not None:
-            if isinstance(self.data['fnames'], str):
-                self.data['fnames'] = [self.data['fnames']]
+            # following handles reloaded data where strings are byte-encoded
+            if not isinstance(self.data['fnames'][0], str):
+                self.data['fnames'] = [fname.decode('utf-8') for fname in self.data['fnames']]
             T = caiman.base.movies.get_file_size(self.data['fnames'], var_name_hdf5=self.data['var_name_hdf5'])[1]
             if len(self.data['fnames']) > 1:
                 T = T[0]


### PR DESCRIPTION
# Description
Issue raised with using reloaded data, the way things are serialized with hdf5, they are loaded as byte-encoded, so when you try to change parameters things don't work (e.g., filename validation throws an error). Rather than digging deeply into serialization in `recursively_load_dict_contents_from_group()` (or the corresponding save function), I added a check for the dtype in `check_consistency()` and if the filenames are not string, do the conversion. This is a bit hacky, but I tested it and it works 😬 

Maybe later we can do more internal validation in the load function, but for now I think this is a good workaround.

Thanks @JohnStout for pointing it out.

Closes #1264 

# Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Tests   
caimanmanager test works fine. I tested saving/loading and then changing parameters which was broken before, and now it works. 