### PR TITLE
SBX utils: ensure correct photometric setting for TIFs and allow extracting single plane

### DIFF
--- a/caiman/tests/test_sbx.py
+++ b/caiman/tests/test_sbx.py
@@ -3,12 +3,15 @@
 import numpy as np
 import numpy.testing as npt
 import os
+import tifffile
 
 import caiman as cm
 from caiman.paths import caiman_datadir
 from caiman.utils import sbx_utils
 
-testdata_path = os.path.join(caiman_datadir(), 'testdata')
+TESTDATA_PATH = os.path.join(caiman_datadir(), 'testdata')
+SHAPE_2D = (10, 512, 796)
+SHAPE_3D = (2, 512, 796, 4)
 
 def subinds_to_ix(subinds, array_shape):
     """Helper to avoid advanced slicing"""
@@ -18,12 +21,12 @@ def subinds_to_ix(subinds, array_shape):
 
 
 def test_load_2d():
-    file_2d = os.path.join(testdata_path, '2d_sbx.sbx')
+    file_2d = os.path.join(TESTDATA_PATH, '2d_sbx.sbx')
     data_2d = sbx_utils.sbxread(file_2d)
     meta_2d = sbx_utils.sbx_meta_data(file_2d)
     
     assert data_2d.ndim == 3, 'Loaded 2D data has wrong dimensionality'
-    assert data_2d.shape == (10, 512, 796), 'Loaded 2D data has wrong shape'
+    assert data_2d.shape == SHAPE_2D, 'Loaded 2D data has wrong shape'
     assert data_2d.shape == (meta_2d['num_frames'], *meta_2d['frame_size']), 'Shape in metadata does not match loaded data'
     npt.assert_array_equal(data_2d[0, 0, :10], [712, 931, 1048, 825, 1383, 882, 601, 798, 1022, 966], 'Loaded 2D data has wrong values')
 
@@ -34,12 +37,12 @@ def test_load_2d():
 
 
 def test_load_3d():
-    file_3d = os.path.join(testdata_path, '3d_sbx_1.sbx')
+    file_3d = os.path.join(TESTDATA_PATH, '3d_sbx_1.sbx')
     data_3d = sbx_utils.sbxread(file_3d)
     meta_3d = sbx_utils.sbx_meta_data(file_3d)
     
     assert data_3d.ndim == 4, 'Loaded 3D data has wrong dimensionality'
-    assert data_3d.shape == (2, 512, 796, 4), 'Loaded 3D data has wrong shape'
+    assert data_3d.shape == SHAPE_3D, 'Loaded 3D data has wrong shape'
     assert data_3d.shape == (meta_3d['num_frames'], *meta_3d['frame_size'], meta_3d['num_planes']), 'Shape in metadata does not match loaded data'
     npt.assert_array_equal(data_3d[0, 0, :10, 0], [2167, 2525, 1713, 1747, 1887, 1741, 1873, 1244, 1747, 1637], 'Loaded 2D data has wrong values')
 
@@ -50,7 +53,7 @@ def test_load_3d():
 
 
 def test_load_subind():
-    file_2d = os.path.join(testdata_path, '2d_sbx.sbx')
+    file_2d = os.path.join(TESTDATA_PATH, '2d_sbx.sbx')
     data_2d_full = cm.load(file_2d)
 
     # Just frame subset
@@ -71,7 +74,7 @@ def test_load_subind():
     npt.assert_array_equal(data_2d_full[subinds_to_ix(subind_t_y_x, data_2d_full.shape)], data_2d_t_y_x)
 
     # Check 3D file
-    file_3d = os.path.join(testdata_path, '3d_sbx_1.sbx')
+    file_3d = os.path.join(TESTDATA_PATH, '3d_sbx_1.sbx')
     data_3d_full = cm.load(file_3d, is3D=True)
     data_3d_first = cm.load(file_3d, is3D=True, subindices=slice(0, 1))
     npt.assert_array_equal(data_3d_full[:1], data_3d_first)
@@ -79,29 +82,50 @@ def test_load_subind():
     data_3d_t_y_x_z = cm.load(file_3d, is3D=True, subindices=subind_t_y_x_z)
     npt.assert_array_equal(data_3d_full[subinds_to_ix(subind_t_y_x_z, data_3d_full.shape)], data_3d_t_y_x_z)
 
+    # subind vs. plane
+    data_3d_plane0_3d = sbx_utils.sbxread(file_3d, subindices=(slice(None), slice(None), slice(None), [0]))
+    data_3d_plane0_2d = sbx_utils.sbxread(file_3d, plane=0)
+    assert data_3d_plane0_3d.shape == SHAPE_3D[:3] + (1,), 'Shape when loading plane with subindices is incorrect'
+    assert data_3d_plane0_2d.shape == SHAPE_3D[:3], 'Shape when loading plane with plane argument is incorrect'
+    npt.assert_array_equal(data_3d_plane0_3d[:, :, :, 0], data_3d_plane0_2d)
+
 
 def test_sbx_to_tif():
     tif_file = os.path.join(caiman_datadir(), 'temp', 'from_sbx.tif')
     try:
-        file_2d = os.path.join(testdata_path, '2d_sbx.sbx')
+        file_2d = os.path.join(TESTDATA_PATH, '2d_sbx.sbx')
         data_2d_from_sbx = cm.load(file_2d)
         sbx_utils.sbx_to_tif(file_2d, fileout=tif_file)
         data_2d_from_tif = cm.load(tif_file)
         npt.assert_array_almost_equal(data_2d_from_sbx, data_2d_from_tif,
                                       err_msg='Data do not match when loaded from .sbx vs. .tif')
         
-        file_3d = os.path.join(testdata_path, '3d_sbx_1.sbx')
+        file_3d = os.path.join(TESTDATA_PATH, '3d_sbx_1.sbx')
         data_3d_from_sbx = cm.load(file_3d, is3D=True)
         sbx_utils.sbx_to_tif(file_3d, fileout=tif_file)
         data_3d_from_tif = cm.load(tif_file, is3D=True)
         npt.assert_array_almost_equal(data_3d_from_sbx, data_3d_from_tif,
                                       err_msg='3D data do not match when loaded from .sbx vs. .tif')
+        # make sure individual planes are not saved as 3D (i.e. RGB)
+        Y = tifffile.TiffFile(tif_file).series[0]
+        assert Y.shape == SHAPE_3D, 'Shape of data in tif file is wrong'
+        if Y[0].shape != SHAPE_3D[2:]:
+            if Y[0].shape == SHAPE_3D[1:]:
+                assert False, 'Tif "plane" is 3-dimensional (i.e., has channel dimension)'
+            else:
+                assert False, 'Shape of tif plane is wrong'
         
         # with subindices
         subinds = (slice(0, None, 2), [0, 1, 3], slice(None))
         sbx_utils.sbx_to_tif(file_2d, fileout=tif_file, subindices=subinds)
         sub_data_from_tif = cm.load(tif_file)
         npt.assert_array_almost_equal(data_2d_from_sbx[subinds_to_ix(subinds, data_2d_from_sbx.shape)], sub_data_from_tif)
+
+        # with plane
+        sbx_utils.sbx_to_tif(file_3d, fileout=tif_file, plane=0)
+        plane_data_from_tif = cm.load(tif_file)
+        npt.assert_array_almost_equal(data_3d_from_sbx[:, :, :, 0], plane_data_from_tif)
+
 
     finally:
         # cleanup
@@ -112,9 +136,9 @@ def test_sbx_to_tif():
 def test_sbx_chain_to_tif():
     tif_file = os.path.join(caiman_datadir(), 'temp', 'from_sbx.tif')
     try:
-        file_3d_1 = os.path.join(testdata_path, '3d_sbx_1.sbx')
+        file_3d_1 = os.path.join(TESTDATA_PATH, '3d_sbx_1.sbx')
         data_3d_1 = sbx_utils.sbxread(file_3d_1)
-        file_3d_2 = os.path.join(testdata_path, '3d_sbx_2.sbx')
+        file_3d_2 = os.path.join(TESTDATA_PATH, '3d_sbx_2.sbx')
         data_3d_2 = sbx_utils.sbxread(file_3d_2)
 
         # normal chain

--- a/caiman/utils/sbx_utils.py
+++ b/caiman/utils/sbx_utils.py
@@ -54,7 +54,7 @@ def _todict(matobj) -> dict:
     return ret
 
 
-def sbxread(filename: str, subindices: Optional[FileSubindices] = slice(None), channel: Optional[int] = None) -> np.ndarray:
+def sbxread(filename: str, subindices: Optional[FileSubindices] = slice(None), channel: Optional[int] = None, keep3d: bool = False) -> np.ndarray:
     """
     Load frames of an .sbx file into a new NumPy array
 
@@ -68,14 +68,17 @@ def sbxread(filename: str, subindices: Optional[FileSubindices] = slice(None), c
 
         channel: int | None
             which channel to save (required if data has >1 channel)
+
+        keep3d: bool
+            if indexing a 3D array such that only one z-plane remains, whether to keep the singleton z dimension
     """
     if subindices is None:
         subindices = slice(None)
-    return _sbxread_helper(filename, subindices=subindices, channel=channel, chunk_size=None)
+    return _sbxread_helper(filename, subindices=subindices, channel=channel, keep3d=keep3d, chunk_size=None)
 
 
 def sbx_to_tif(filename: str, fileout: Optional[str] = None, subindices: Optional[FileSubindices] = slice(None),
-               channel: Optional[int] = None, chunk_size: int = 1000):
+               channel: Optional[int] = None, keep3d: bool = False, chunk_size: int = 1000):
     """
     Convert a single .sbx file to .tif format
 
@@ -92,6 +95,9 @@ def sbx_to_tif(filename: str, fileout: Optional[str] = None, subindices: Optiona
 
         channel: int | None
             which channel to save (required if data has >1 channel)
+
+        keep3d: bool
+            if indexing a 3D array such that only one z-plane remains, whether to keep the singleton z dimension
 
         chunk_size: int | None
             how many frames to load into memory at once (None = load the whole thing)
@@ -114,15 +120,17 @@ def sbx_to_tif(filename: str, fileout: Optional[str] = None, subindices: Optiona
 
     # Find the shape of the file we need
     save_shape = _get_output_shape(filename, subindices)[0]
+    if len(save_shape) == 4 and save_shape[3] == 1 and not keep3d:
+        save_shape = save_shape[:3]
 
     # Open tif as a memmap and copy to it
-    memmap_tif = tifffile.memmap(fileout, shape=save_shape, dtype='uint16')
-    _sbxread_helper(filename, subindices=subindices, channel=channel, out=memmap_tif, chunk_size=chunk_size)
+    memmap_tif = tifffile.memmap(fileout, shape=save_shape, dtype='uint16', photometric='MINISBLACK')
+    _sbxread_helper(filename, subindices=subindices, channel=channel, out=memmap_tif, keep3d=keep3d, chunk_size=chunk_size)
 
 
 def sbx_chain_to_tif(filenames: list[str], fileout: str, subindices: Optional[ChainSubindices] = slice(None),
                      bigtiff: Optional[bool] = True, imagej: bool = False, to32: bool = False,
-                     channel: Optional[int] = None, chunk_size: int = 1000) -> None:
+                     channel: Optional[int] = None, keep3d: bool = False, chunk_size: int = 1000) -> None:
     """
     Concatenate a list of sbx files into one tif file.
     Args:
@@ -140,7 +148,7 @@ def sbx_chain_to_tif(filenames: list[str], fileout: str, subindices: Optional[Ch
         to32: bool
             whether to save in float32 format (default is to keep as uint16)
 
-        channel, chunk_size: see sbx_to_tif
+        channel, keep3d, chunk_size: see sbx_to_tif
     """
     if subindices is None:
         subindices = slice(None)
@@ -180,19 +188,22 @@ def sbx_chain_to_tif(filenames: list[str], fileout: str, subindices: Optional[Ch
     Ns = list(map(int, all_shapes_out[:, 0]))
     N = sum(Ns)
     save_shape = (N,) + common_shape
+    if len(save_shape) == 4 and save_shape[3] == 1 and not keep3d:
+        save_shape = save_shape[:3]
 
     extension = os.path.splitext(fileout)[1].lower()
     if extension not in ['.tif', '.tiff', '.btf']:
         fileout = fileout + '.tif'
 
     dtype = np.float32 if to32 else np.uint16
-    tifffile.imwrite(fileout, data=None, mode='w', shape=save_shape, bigtiff=bigtiff, imagej=imagej, dtype=dtype)
+    tifffile.imwrite(fileout, data=None, mode='w', shape=save_shape, bigtiff=bigtiff, imagej=imagej,
+                     dtype=dtype, photometric='MINISBLACK')
 
     # Now convert each file
     tif_memmap = tifffile.memmap(fileout, series=0)
     offset = 0
     for filename, subind, file_N in zip(filenames, subindices, Ns):
-        _sbxread_helper(filename, subindices=subind, channel=channel, out=tif_memmap[offset:offset+file_N], chunk_size=chunk_size)
+        _sbxread_helper(filename, subindices=subind, channel=channel, out=tif_memmap[offset:offset+file_N], keep3d=keep3d, chunk_size=chunk_size)
         offset += file_N
 
 
@@ -361,7 +372,7 @@ def sbx_meta_data(filename: str):
 
 
 def _sbxread_helper(filename: str, subindices: FileSubindices = slice(None), channel: Optional[int] = None,
-                     out: Optional[np.memmap] = None, chunk_size: Optional[int] = 1000) -> np.ndarray:
+                     out: Optional[np.memmap] = None, keep3d: bool = False, chunk_size: Optional[int] = 1000) -> np.ndarray:
     """
     Load frames of an .sbx file into a new NumPy array, or into the given memory-mapped file.
 
@@ -376,7 +387,10 @@ def _sbxread_helper(filename: str, subindices: FileSubindices = slice(None), cha
             which channel to save (required if data has >1 channel)
 
         out: np.memmap | None
-            existing memory-mapped file to write into (in which case fileout is ignored)
+            existing memory-mapped file to write into
+
+        keep3d: bool
+            if indexing a 3D array such that only one z-plane remains, whether to keep the singleton z dimension
 
         chunk_size: int | None
             how many frames to load into memory at once (None = load the whole thing)
@@ -417,8 +431,11 @@ def _sbxread_helper(filename: str, subindices: FileSubindices = slice(None), cha
         raise Exception('Invalid scanbox metadata')
 
     save_shape, subindices = _get_output_shape(data_shape, subindices)
-    frame_stride = _interpret_subindices(subindices[0], n_frames)[1]
     N = save_shape[0]
+    if len(save_shape) == 4 and save_shape[3] == 1 and not keep3d:
+        save_shape = save_shape[:3]
+
+    frame_stride = _interpret_subindices(subindices[0], n_frames)[1]
 
     if out is not None and out.shape != save_shape:
         raise Exception('Existing memmap is the wrong shape to hold loaded data')
@@ -430,9 +447,12 @@ def _sbxread_helper(filename: str, subindices: FileSubindices = slice(None), cha
             chunk = np.invert(np.fromfile(sbx_file, dtype='uint16', count=frame_size//2 * n))
             chunk = np.reshape(chunk, data_shape[:4] + (n,), order='F')  # (chans, X, Y, Z, frames)
             chunk = np.transpose(chunk, (0, 4, 2, 1, 3))[channel]  # to (frames, Y, X, Z)
-            if not is3D:
+            if not is3D:  # squeeze out singleton plane dim
                 chunk = np.squeeze(chunk, axis=3)
-            return chunk[(slice(None),) + np.ix_(*subindices[1:])]
+            chunk = chunk[(slice(None),) + np.ix_(*subindices[1:])]
+            if is3D and len(save_shape) == 3:  # squeeze out plane dim after selecting
+                chunk = np.squeeze(chunk, axis=3)
+            return chunk
 
         if frame_stride == 1:
             sbx_file.seek(subindices[0][0] * frame_size, 0)


### PR DESCRIPTION
# Description

This PR includes two changes:
- A bugfix for the condition when a 3D SBX with 3 or 4 planes is converted to TIF. By default, tifffile assumes the 4th dimension is the color channel, so it is necessary to set `photometric` to `MINISBLACK` to avoid each plane being 3-dimensional.
- An added feature, the `plane` argument to SBX loading/conversion functions, which allows extraction of a single plane without keeping the singleton dimension. This is useful when opting to process each plane of a volumetric dataset individually.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

Yes, ```caimanmanager test``` passes and new tests have been added for both of these changes.