### PR TITLE
Extensions starts with a dot

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1951,8 +1951,8 @@ def load_iter(file_name: Union[str, list[str]], subindices=None, var_name_hdf5: 
                             yield frame # was frame[..., 0].astype(outtype)
                         return
                 
-            elif extension in ('.hdf5', '.h5', '.nwb', '.mat', 'n5', 'zarr'):
-                if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
+            elif extension in ('.hdf5', '.h5', '.nwb', '.mat', '.n5', '.zarr'):
+                if extension in ('.n5', '.zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
                     f = zarr.open(file_name, "r")
                 else:
                     f = h5py.File(file_name, "r")


### PR DESCRIPTION
When attempting to motioncorrect data in a zarr file, then:
MotionCorrect(fname)

claim the extension was not found. It should be ".zarr" and ".n5" with
dots at the beginning. Including this fix uncovers a different problem
later (zarr array does not have .keys()). 

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.

# Branching
- All PRs should be made against the **dev** branch. The main branch is not often merged back to dev.
- If you want to get your PR out to the world faster (urgent bugfix), poke pgunn to cut a release; this will get it onto github and into conda faster

# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

```caimanmanager test```

and

```caimanmanager demotest```

prior to submitting your pull request. 

Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.
