### PR TITLE
Motion correction with lazy loading and open multiseries tifffile

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -983,7 +983,7 @@ def motion_correct_online_lazyLoading(file_name, add_to_movie=0, max_shift_w=25,
 
             buffer_frames.append(new_img)
 
-            if count % 100 == 0 and count>0:
+            if count % buffer_size_frames == 0 and count>0:
                 if count >= (buffer_size_frames):
                     template_old = template.copy()
                     template = bin_median(np.array(buffer_frames))
@@ -1000,7 +1000,6 @@ def motion_correct_online_lazyLoading(file_name, add_to_movie=0, max_shift_w=25,
                     template, template_tmp, t_shift, avg_corr = motion_correct_iteration(
                         template_old, template, count, max_shift_w=max_shift_w, max_shift_h=max_shift_h, bilateral_blur=bilateral_blur)
                     template_shift_tmp.append(t_shift)
-
                     if (save_base_name is not None) and not (save_as_memmap):
                         if append is None:
                             append = False if count >buffer_size_frames else True


### PR DESCRIPTION
# Description

- Changes caiman.base.movies to work with multiseries tifffiles and nd2 files 
- Changed caiman.motion_correction to do motion correction with lazy loading and sve files into tiff format

## Opening multiseries tiff files

- Created _load_all_purpose_tiff_ function to open multiseries and multi page tiff files.
- Changed _load_ and _load_iter_ functions to allow multiseries tiff files and .nds (Nikon format) files.

## Lazy loading motion correction

- Created _motion_correction_online_lazyLoading_ function to do online motion correction frame by frame. This allows to work with recordings on the go. This function saves files in the tiff format and also saves the templates used for motion correction
- Created a function to optimize the gSig_filt parameter.
- Changed the multi files motion correction function to allow multiple save names.
