### PR TITLE
environment.yml: handle variant and newer condas better

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          environment-file: environment.yml
+          environment-file: environment-minimal.yml
           activate-environment: caiman
 
       - name: Install OS Dependencies

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -9,6 +9,7 @@ dependencies:
 - h5py
 - holoviews >=1.16.2
 - ipyparallel
+- ipywidgets
 - matplotlib
 - moviepy
 - numpy <2.0.0

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -13,7 +13,7 @@ dependencies:
 - matplotlib
 - moviepy
 - nose
-- numpy <2.0.0,>=1.20
+- numpy <2.0.0,>=1.26
 - numpydoc
 - opencv
 - peakutils

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -1,4 +1,3 @@
-channel_priority: true
 channels:
 - conda-forge
 - defaults

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -16,6 +16,7 @@ dependencies:
 - numpydoc
 - opencv
 - peakutils
+- pims
 - psutil
 - pynwb
 - scikit-image >=0.19.0

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -1,5 +1,7 @@
+channel_priority: true
 channels:
 - conda-forge
+- defaults
 dependencies:
 - python <=3.12
 - av

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -13,7 +13,7 @@ dependencies:
 - matplotlib
 - moviepy
 - nose
-- numpy <2.0.0
+- numpy <2.0.0,>=1.20
 - numpydoc
 - opencv
 - peakutils

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -5,13 +5,14 @@ dependencies:
 - python <=3.12
 - av
 - cython
-- future
 - h5py
 - holoviews >=1.16.2
+- ipython
 - ipyparallel
 - ipywidgets
 - matplotlib
 - moviepy
+- nose
 - numpy <2.0.0
 - numpydoc
 - opencv

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -5,7 +5,7 @@ dependencies:
 - python <=3.12
 - av
 - cython
-- h5py
+- h5py >=3.4.0
 - holoviews >=1.16.2
 - ipython
 - ipyparallel

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,3 @@
-channel_priority: true
 channels:
 - conda-forge
 - defaults

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - moviepy
 - mypy
 - nose
-- numpy <2.0.0
+- numpy <2.0.0,>=1.20
 - numpydoc
 - opencv
 - panel >=1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,7 @@
+channel_priority: true
 channels:
 - conda-forge
+- defaults
 dependencies:
 - python <=3.12
 - av

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - moviepy
 - mypy
 - nose
-- numpy <2.0.0,>=1.20
+- numpy <2.0.0,>=1.26
 - numpydoc
 - opencv
 - panel >=1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - bokeh >=3.1.1
 - coverage
 - cython
-- h5py
+- h5py >=3.4.0
 - holoviews >=1.16.2
 - ipykernel
 - ipython


### PR DESCRIPTION
Be smarter about alternate builds of conda, set channel-priority to handle if user/distro has set it to something else.

This is an attempt to improve on the install issues seen with #1332 

Note that the `channel_priority: true` may seem wrong, but it's a ternary value, with false meaning disabled, true meaning flexible, and strict (a new value) meaning strict. We don't want strict, at least as long as we need tensorflow on Windows. Flexible should do the job.