### PR TITLE
fix mat support

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1518,7 +1518,7 @@ def load(file_name: Union[str, list[str]],
                     if extension == '.mat':
                         raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
                     else:
-                        raise Exception(f"Problem in loading {file_name}: Unknown format.")
+                        raise Exception(f"Problem loading {file_name}: Unknown format.")
             ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with get_file_size() !!
             fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
             if len(fkeys) == 1: # If the file we're parsing has only one dataset inside it,
@@ -1951,7 +1951,7 @@ def load_iter(file_name: Union[str, list[str]], subindices=None, var_name_hdf5: 
                         if extension == '.mat':
                             raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
                         else:
-                            raise Exception(f"Problem in loading {file_name}: Unknown format.")
+                            raise Exception(f"Problem loading {file_name}: Unknown format.")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed.
                 fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(fkeys) == 1: # If the hdf5 file we're parsing has only one dataset inside it,
@@ -2045,7 +2045,7 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                         if extension == '.mat':
                             raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
                         else:
-                            raise Exception(f"Problem in loading {file_name}: Unknown format.")
+                            raise Exception(f"Problem loading {file_name}: Unknown format.")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with movies.my:load() !!
                 kk = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(kk) == 1: # TODO: Consider recursing into a group to find a dataset

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1512,7 +1512,13 @@ def load(file_name: Union[str, list[str]],
             if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
                 f = zarr.open(file_name, "r")
             else:
-                f = h5py.File(file_name, "r")
+                try:
+                    f = h5py.File(file_name, "r")
+                except:
+                    if extension == '.mat':
+                        raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
+                    else:
+                        raise Exception(f"Problem in loading {file_name}: Unknown format.")
             ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with get_file_size() !!
             fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
             if len(fkeys) == 1: # If the file we're parsing has only one dataset inside it,
@@ -1939,7 +1945,13 @@ def load_iter(file_name: Union[str, list[str]], subindices=None, var_name_hdf5: 
                 if extension in ('.n5', '.zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
                     f = zarr.open(file_name, "r")
                 else:
-                    f = h5py.File(file_name, "r")
+                    try:
+                        f = h5py.File(file_name, "r")
+                    except:
+                        if extension == '.mat':
+                            raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
+                        else:
+                            raise Exception(f"Problem in loading {file_name}: Unknown format.")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed.
                 fkeys = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(fkeys) == 1: # If the hdf5 file we're parsing has only one dataset inside it,
@@ -2027,7 +2039,13 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                 if extension in ('n5', 'zarr'): # Thankfully, the zarr library lines up closely with h5py past the initial open
                     f = zarr.open(file_name, "r")
                 else:
-                    f = h5py.File(file_name, "r")
+                    try:
+                        f = h5py.File(file_name, "r")
+                    except:
+                        if extension == '.mat':
+                            raise Exception(f"Problem loading {file_name}: Unknown format. This may be in the original version 1 (non-hdf5) mat format; please convert it first")
+                        else:
+                            raise Exception(f"Problem in loading {file_name}: Unknown format.")
                 ignore_keys = ['__DATA_TYPES__'] # Known metadata that tools provide, add to this as needed. Sync with movies.my:load() !!
                 kk = list(filter(lambda x: x not in ignore_keys, f.keys()))
                 if len(kk) == 1: # TODO: Consider recursing into a group to find a dataset

--- a/docs/source/file_formats.md
+++ b/docs/source/file_formats.md
@@ -15,7 +15,7 @@ Notes for specific formats follow:
 
 Matlab (\*.mat)
 ---------------
-Caiman may be able to handle Matlab's mat files, although it is not a desirable format. We rely on the scipy.io.matlab functions to handle files of this type, except for certain versions of the format which are actually hdf5 files
+Caiman can handle Matlab's V2 mat files (which are HDF5 files in a certain format). If you need old-style support, reach out and we can consider adding it.
 
 TIFF (\*.tiff, \*.tif, \*.btf)
 ------------------------------


### PR DESCRIPTION
This fixes use of scipy APIs that are no longer in scipy to read old-style .mat files. ( #1336 )

Support for the newer hdf5-based mat format is retained (and by newer we're talking about a change made a long time ago).

There were two other ways to fix the import problem:
1) Have a slightly friendlier user message for people trying to load old mat files, by doing try/except in a few places, catching the exception, and guessing that they were trying to load the earlier format and tell them.
2) Attempt to use scipy.io.matlab.loadmat() instead, building support for that back into the codebase (classic mat handling had been broken for awhile and would've needed some work)

I decided not to do the first because it complicates some already complicated code for the sake of an obsolete format (and the try/exception model actually wouldn't tell us for sure why an OSError was thrown so it could be confusing no matter what).
I decided not to do the second because it's a bit of work for a format people shouldn't be using anymore and it's something we may have decided to stop supporting anyhow even if the code was working (unless users told us they need it).

If some users of old-style mat files turn up and tell us they really need the old format (even though it hasn't worked in caiman for several releases at least), I can move to the second solution, but I'm otherwise happy with this choice.