### PR TITLE
Fix map_async call on DirectView causing error

### DIFF
--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -504,7 +504,7 @@ def threshold_components(A, dims, medw=None, thr_method='max', maxthr=0.1, nrgth
             res = dview.map_async(
                 threshold_components_parallel, pars).get(4294967)
         else:
-            res = dview.map_async(threshold_components_parallel, pars)
+            res = dview.map_sync(threshold_components_parallel, pars)
     else:
         res = list(map(threshold_components_parallel, pars))
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1348 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Such a minor change that I did not run the full test suite, but confirmed that the issue I was experiencing was fixed as expected. I also did a search for other calls to map_async on an ipyparallel DirectView that could cause an issue, and did not find any (the one exception called `res.get()` right afterwards, which should have the same effect).