### PR TITLE
Fix medw loading as b'NoneType' instead of None

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -562,7 +562,7 @@ def recursively_load_dict_contents_from_group(h5file:h5py.File, path:str) -> dic
     for key, item in h5file[path].items():
         if isinstance(item, h5py._hl.dataset.Dataset):
             val = item[()]
-            if val == 'NoneType' or val == b'NoneType':
+            if isinstance(val, str) and val == 'NoneType' or isinstance(val, bytes) and val == b'NoneType':
                 ans[key] = None
             elif key in ['dims', 'medw', 'sigma_smooth_snmf',
                          'dxy', 'max_shifts', 'strides', 'overlaps'] and isinstance(val, np.ndarray):

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -561,25 +561,16 @@ def recursively_load_dict_contents_from_group(h5file:h5py.File, path:str) -> dic
 
     for key, item in h5file[path].items():
         if isinstance(item, h5py._hl.dataset.Dataset):
-            val_set = np.nan
-            if isinstance(item[()], str):
-                if item[()] == 'NoneType':
-                    ans[key] = None
-                else:
-                    ans[key] = item[()]
-
-            elif key in ['dims', 'medw', 'sigma_smooth_snmf', 'dxy', 'max_shifts', 'strides', 'overlaps']:
-                if isinstance(item[()], np.ndarray):
-                    ans[key] = tuple(item[()])
-                else:
-                    ans[key] = item[()]
+            val = item[()]
+            if val == 'NoneType' or val == b'NoneType':
+                ans[key] = None
+            elif key in ['dims', 'medw', 'sigma_smooth_snmf',
+                         'dxy', 'max_shifts', 'strides', 'overlaps'] and isinstance(val, np.ndarray):
+                    ans[key] = tuple(val)
+            elif isinstance(val, np.bool_): # sigh
+                ans[key] = bool(val)
             else:
-                if isinstance(item[()], np.bool_): # sigh
-                    ans[key] = bool(item[()])
-                else:
-                    ans[key] = item[()]
-                    if isinstance(ans[key], bytes) and ans[key] == b'NoneType':
-                        ans[key] = None
+                ans[key] = item[()]
 
         elif isinstance(item, h5py._hl.group.Group):
             if key in ('A', 'W', 'Ab', 'downscale_matrix', 'upscale_matrix'):


### PR DESCRIPTION
# Description

I encountered a bug when running a CNMF refit after loading the CNMF object from HDF5. This was caused by `params.spatial['medw']` being `b'NoneType'` rather than `None`.

`None` parameters are currently converted to the string 'NoneType' during saving, which is read back into Python as `b'NoneType'`, and this should be converted back to `None`, but due to the way the conditionals are structured, parameters which should be converted to tuples if not None are not converted if they equal `b'NoneType'`. (They are converted if they are the regular string `'NoneType'`.) I fixed it so that both NoneType cases are handled first, and otherwise simplified the conditional structure (but that should be the only change in behavior).

Partially addresses #1264.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Yes, `caimanmanager test` and `caimanmanager demotest` pass.