### PR TITLE
caimanmanager detect editable

### DIFF
--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -55,6 +55,7 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
     global sourcedir_base
 
     try:
+        print("If you did an editable install (with -e), the install must happen within the source tree; otherwise, it must not")
         import importlib_metadata
         # A lot can change upstream with this code; I hope the APIs are stable, but just in case, make this best-effort
         if json.loads(importlib_metadata.Distribution.from_name('caiman').read_text('direct_url.json'))['dir_info']['editable']:

--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -3,6 +3,7 @@
 import argparse
 import filecmp
 import glob
+import json
 import os
 import platform
 import psutil
@@ -52,6 +53,15 @@ standard_movies = [
 
 def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> None:
     global sourcedir_base
+
+    try:
+        import importlib_metadata
+        # A lot can change upstream with this code; I hope the APIs are stable, but just in case, make this best-effort
+        if json.loads(importlib_metadata.Distribution.from_name('caiman').read_text('direct_url.json'))['dir_info']['editable']:
+            inplace = True
+    except:
+        pass
+
     ignore_pycache=shutil.ignore_patterns('__pycache__')
     if os.path.isdir(targdir) and not force:
         raise Exception(targdir + " already exists. You may move it out of the way, remove it, or use --force")

--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -55,13 +55,16 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
     global sourcedir_base
 
     try:
-        print("If you did an editable install (with -e), the install must happen within the source tree; otherwise, it must not")
+        import importlib
         import importlib_metadata
         # A lot can change upstream with this code; I hope the APIs are stable, but just in case, make this best-effort
         if json.loads(importlib_metadata.Distribution.from_name('caiman').read_text('direct_url.json'))['dir_info']['editable']:
             inplace = True
+            cwd = os.getcwd()
+            os.chdir(str(importlib.resources.files('caiman').joinpath('..')))
+            print(f"Used editable fallback, entered {os.getcwd()} directory")
     except:
-        pass
+        print("Did not use editable fallback")
 
     ignore_pycache=shutil.ignore_patterns('__pycache__')
     if os.path.isdir(targdir) and not force:
@@ -88,6 +91,8 @@ def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> N
         with open(os.path.join(targdir, 'RELEASE'), 'w') as verfile_fh:
             print(f"Version:{caiman.__version__}", file=verfile_fh)
     print("Installed " + targdir)
+    if cwd is not None:
+        os.chdir(cwd)
 
 
 def do_check_install(targdir: str, inplace: bool = False) -> None:

--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -53,6 +53,7 @@ standard_movies = [
 
 def do_install_to(targdir: str, inplace: bool = False, force: bool = False) -> None:
     global sourcedir_base
+    cwd = None # Assigning so it exists to avoid UnboundLocalError
 
     try:
         import importlib


### PR DESCRIPTION
This has caimanmanager try to detect (through some fragile code that's in a try/except) when it's running on an install in editable mode and automatically apply the "inplace" modifier to the install subcommand so the user doesn't need to remember to do that.

This lifts two restrictions on the editable mode install:
1) The need to add --inplace to `caimanmanager install`
2) The need (for inplace only) to be in the source directory (when the opposite is required for a `pip install` without `-e`)

Will merge this as soon as it passes CI as I'm preparing an urgent release to deal with upstream tensorflow breaking us