### PR TITLE
Fix removeBL for 3D movies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,7 @@ __pycache__/
 
 # C extensions
 *.so
-*.c
-*.cpp
+caiman/source_extraction/cnmf/oasis.cpp
 
 #movie tif
 *.tif

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ __pycache__/
 # C extensions
 *.so
 *.c
+*.cpp
 
 #movie tif
 *.tif

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -552,15 +552,15 @@ class movie(caiman.base.timeseries.timeseries):
     
     def to2DPixelxTime(self, order='F'):
         """
-        Transform 3D movie into 2D
+        Transform 3D or 4D movie into 2D
         """
-        return self.transpose([2,1,0]).reshape((-1,self.shape[0]),order=order)  
+        return self.transpose().reshape((-1,self.shape[0]),order=order)
 
     def to3DFromPixelxTime(self, shape, order='F'):
         """
-            Transform 2D movie into 3D
+            Transform 2D movie into 3D or 4D
         """
-        return to_3D(self,shape[::-1],order=order).transpose([2,1,0])
+        return to_3D(self,shape[::-1],order=order).transpose()
     
     def computeDFF(self, secsWindow: int = 5, quantilMin: int = 8, method: str = 'only_baseline', in_place: bool = False,
                    order: str = 'F') -> tuple[Any, Any]:

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -550,17 +550,17 @@ class movie(caiman.base.timeseries.timeseries):
             self -= caiman.movie(cv2.resize(res,pixs.shape[::-1]),fr=self.fr).to3DFromPixelxTime(self.shape) 
             return self
     
-    def to2DPixelxTime(self, order='F'):
+    def to2DPixelxTime(self, order='F') -> 'movie':
         """
-        Transform 3D or 4D movie into 2D
+        Transform 3D or 4D movie into 2D (pixels x time)
         """
-        return self.transpose().reshape((-1,self.shape[0]),order=order)
+        return self.T.reshape((-1,self.shape[0]),order=order)
 
-    def to3DFromPixelxTime(self, shape, order='F'):
+    def to3DFromPixelxTime(self, shape, order='F') -> 'movie':
         """
-            Transform 2D movie into 3D or 4D
+        Transform 2D movie (pixels x time) into 3D or 4D
         """
-        return to_3D(self,shape[::-1],order=order).transpose()
+        return to_3D(self,shape[::-1],order=order).T
     
     def computeDFF(self, secsWindow: int = 5, quantilMin: int = 8, method: str = 'only_baseline', in_place: bool = False,
                    order: str = 'F') -> tuple[Any, Any]:

--- a/caiman/summary_images.py
+++ b/caiman/summary_images.py
@@ -591,8 +591,7 @@ def local_correlations_movie(file_name,
                              stride: int = 1,
                              swap_dim: bool = False,
                              eight_neighbours: bool = True,
-                             mode: str = 'simple',
-                             is3D: bool = False):
+                             mode: str = 'simple'):
     """
     Compute an online correlation image as moving average
 
@@ -615,15 +614,13 @@ def local_correlations_movie(file_name,
             Use 18 neighbors if true, and 6 if false for 4D data
         mode: 'simple', 'exponential', or 'cumulative'
             Mode of moving average
-        is3D: Boolean
-            Whether the movie has 3 spatial dimensions
 
     Returns:
         corr_movie: caiman.movie (3D or 4D).
             local correlation movie
 
     """
-    Y = caiman.load(file_name, is3D=is3D) if isinstance(file_name, str) else file_name
+    Y = caiman.load(file_name) if isinstance(file_name, str) else file_name
     Y = Y[..., :tot_frames] if swap_dim else Y[:tot_frames]
     first_moment, second_moment, crosscorr, col_ind, row_ind, num_neigbors, M, cn = \
         prepare_local_correlations(Y[..., :window] if swap_dim else Y[:window],
@@ -665,8 +662,7 @@ def local_correlations_movie_offline(file_name,
                                      remove_baseline: bool = False,
                                      winSize_baseline: int = 50,
                                      quantil_min_baseline: float = 8,
-                                     gaussian_blur: bool=False,
-                                     is3D: bool = False):
+                                     gaussian_blur: bool=False):
     """
     Efficient (parallel) computation of correlation image in shifting windows 
     with option for prior baseline removal
@@ -709,9 +705,6 @@ def local_correlations_movie_offline(file_name,
             
         gaussian_blur: bool (False)
             Gaussian smooth the signal
-        
-        is3D: bool (False)
-            Whether movie has 3 spatial dimensions
 
     Returns:
         mm: caiman.movie (3D or 4D).
@@ -723,12 +716,12 @@ def local_correlations_movie_offline(file_name,
 
     params:list = [[file_name, range(j, j + window), eight_neighbours, swap_dim,
                      order_mean, ismulticolor, remove_baseline, winSize_baseline,
-                     quantil_min_baseline, gaussian_blur, is3D]
+                     quantil_min_baseline, gaussian_blur]
                     for j in range(0, Tot_frames - window, stride)]
 
     params.append([file_name, range(Tot_frames - window, Tot_frames), eight_neighbours, swap_dim,
                    order_mean, ismulticolor, remove_baseline, winSize_baseline,
-                   quantil_min_baseline, gaussian_blur, is3D])
+                   quantil_min_baseline, gaussian_blur])
 
     if dview is None:
         parallel_result = list(map(local_correlations_movie_parallel, params))
@@ -745,9 +738,8 @@ def local_correlations_movie_offline(file_name,
 
 
 def local_correlations_movie_parallel(params:tuple) -> np.ndarray:
-    (mv_name, idx, eight_neighbours, swap_dim, order_mean, ismulticolor,
-     remove_baseline, winSize_baseline, quantil_min_baseline, gaussian_blur, is3D) = params
-    mv = caiman.load(mv_name, subindices=idx, in_memory=True, is3D=is3D)
+    mv_name, idx, eight_neighbours, swap_dim, order_mean, ismulticolor, remove_baseline, winSize_baseline, quantil_min_baseline, gaussian_blur = params
+    mv = caiman.load(mv_name, subindices=idx, in_memory=True)
     if gaussian_blur:
         mv = mv.gaussian_blur_2D()
 
@@ -764,8 +756,7 @@ def mean_image(file_name,
                  Tot_frames=None,
                  fr: float = 10.,
                  window: int = 100,
-                 dview=None,
-                 is3D: bool = False):
+                 dview=None):
     """
     Efficient (parallel) computation of mean image in chunks
 
@@ -784,24 +775,21 @@ def mean_image(file_name,
 
         dview: map object
             Use it for parallel computation
-        
-        is3D: bool (False)
-            Whether movie has 3 spatial dimensions
     
     Returns:
-        mm: caiman.movie (2D or 3D).
+        mm: caiman.movie (2D).
             mean image
 
     """
     if Tot_frames is None:
         _, Tot_frames = caiman.base.movies.get_file_size(file_name)
 
-    params:list = [[file_name, range(j * window, (j + 1) * window), is3D]
+    params:list = [[file_name, range(j * window, (j + 1) * window)]
                     for j in range(int(Tot_frames / window))]
 
     remain_frames = Tot_frames - int(Tot_frames / window) * window
     if remain_frames > 0:
-        params.append([file_name, range(int(Tot_frames / window) * window, Tot_frames), is3D])
+        params.append([file_name, range(int(Tot_frames / window) * window, Tot_frames)])
 
     if dview is None:
         parallel_result = list(map(mean_image_parallel, params))
@@ -820,6 +808,6 @@ def mean_image(file_name,
     return mean_image
 
 def mean_image_parallel(params:tuple) -> np.ndarray:
-    mv_name, idx, is3D = params
-    mv = caiman.load(mv_name, subindices=idx, in_memory=True, is3D=is3D)
+    mv_name, idx = params
+    mv = caiman.load(mv_name, subindices=idx, in_memory=True)
     return mv.mean(axis=0)[np.newaxis,:,:]

--- a/caiman/tests/test_movies.py
+++ b/caiman/tests/test_movies.py
@@ -2,18 +2,37 @@
 import numpy as np
 import numpy.testing as npt
 import os
-from caiman.base.movies import load, load_iter
+from caiman.base import movies
 from caiman.paths import caiman_datadir
 
 
 def test_load_iter():
     fname = os.path.join(caiman_datadir(), 'example_movies', 'demoMovie.tif')
     for subindices in (None, slice(100, None, 2)):
-        m = load_iter(fname, subindices=subindices)
+        m = movies.load_iter(fname, subindices=subindices)
         S = 0
         while True:
             try:
                 S += np.sum(next(m))
             except StopIteration:
                 break
-        npt.assert_allclose(S, load(fname, subindices=subindices).sum(), rtol=1e-6)
+        npt.assert_allclose(S, movies.load(fname, subindices=subindices).sum(), rtol=1e-6)
+
+
+def test_to2D_to3D():
+    def reference_to2D(mov, order: str):
+        return mov.T.reshape((-1, mov.shape[0]), order=order)
+
+    # set up small test movies
+    rng = np.random.default_rng()
+    T, y, x, z = 10, 6, 4, 2
+    movie_3D = movies.movie(rng.random((T, y, x)))
+    movie_4D = movies.movie(rng.random((T, y, x, z)))
+
+    for movie in (movie_3D, movie_4D):
+        for order in ('F', 'C'):
+            shape = movie.shape
+            movie_flat = movie.to2DPixelxTime(order=order)
+            npt.assert_array_equal(movie_flat, reference_to2D(movie, order))
+            movie_from_flat = movie_flat.to3DFromPixelxTime(shape, order)
+            npt.assert_array_equal(movie_from_flat, movie)


### PR DESCRIPTION
# Description

This PR is mainly focused on making sure `local_correlations_movie` works for 3D movies, by adding an `is3D` flag for passing to `caiman.load` and also slightly modifying `movie.removeBL`. I also fixed other occurrences in local_correlations.py where `caiman.load` is used without an `is3D` flag; however, I have not tested whether all these functions actually work for 3D movies.

This fix is necessary to get mesmerize-core's motion correction routine to work for 3D data. But I'd understand if you want to make it a little more broad.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

```caimanmanager test``` and ```caimanmanager demotest``` pass. I tested manually by running some of my data through `local_correlations_movie` (both from mesmerize-core and otherwise).