### PR TITLE
Added bokeh implementation of view_quilt

### DIFF
--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -1344,7 +1344,6 @@ def view_quilt(template_image: np.ndarray,
         
     Note: 
         Currently assumes square patches so takes in a single number for stride/overlap.
-        TODO: implement bokeh version of this function
     """
     im_dims = template_image.shape
     patch_rows, patch_cols = get_rectangle_coords(im_dims, stride, overlap)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -1424,8 +1424,8 @@ def nb_view_quilt(template_image: np.ndarray,
     plot.rect(x='center_x', y='center_y', width='width', height='height', source=source, color=color, alpha=alpha)
     
     # Create sliders
-    stride_slider = Slider(start=1, end=100, value=rf, step=1, title="Patch half-size (rf)")
-    overlap_slider = Slider(start=0, end=100, value=stride_input, step=1, title="Overlap (stride)")
+    stride_slider = bokeh.models.Slider(start=1, end=100, value=rf, step=1, title="Patch half-size (rf)")
+    overlap_slider = bokeh.models.Slider(start=0, end=100, value=stride_input, step=1, title="Overlap (stride)")
     
     callback = CustomJS(args=dict(source=source, im_dims=im_dims, stride_slider=stride_slider, overlap_slider=overlap_slider), code="""
         function get_rectangle_coords(im_dims, stride, overlap) {

--- a/demos/notebooks/demo_pipeline.ipynb
+++ b/demos/notebooks/demo_pipeline.ipynb
@@ -73,7 +73,7 @@
     "from caiman.source_extraction.cnmf import cnmf, params\n",
     "from caiman.utils.utils import download_demo\n",
     "from caiman.utils.visualization import plot_contours, nb_view_patches, nb_plot_contour\n",
-    "from caiman.utils.visualization import view_quilt\n",
+    "from caiman.utils.visualization import nb_view_quilt\n",
     "\n",
     "bpl.output_notebook()\n",
     "hv.notebook_extension('bokeh')"
@@ -741,7 +741,7 @@
    "metadata": {},
    "source": [
     "### Selecting spatial parameters\n",
-    "To select the spatial parameters (`gSig`, `rf`, `stride`, `K`), you need to look at your movie, or a summary image for your movie, and pick values close to those suggested by the guidelines above. It is helpful to use `view_quilt()` function to see if our key spatial parameters are in the right ballpark (note we recommend running this viewer in interactive qt mode so you can interact with it and get a better feel for the parameters):"
+    "To select the spatial parameters (`gSig`, `rf`, `stride`, `K`), you need to look at your movie, or a summary image for your movie, and pick values close to those suggested by the guidelines above. It is helpful to use the interactive `nb_view_quilt()` function or `view_quilt()` function to see if our key spatial parameters are in the right ballpark (you can use the sliders in the interactive version to change the `rf` and `stride` parameters and get a better feel for them):"
    ]
   },
   {
@@ -757,13 +757,9 @@
     "print(f'Patch width: {cnmf_patch_width} , Stride: {cnmf_patch_stride}, Overlap: {cnmf_patch_overlap}');\n",
     "\n",
     "# plot the patches\n",
-    "patch_ax = view_quilt(correlation_image, \n",
-    "                      cnmf_patch_stride, \n",
-    "                      cnmf_patch_overlap, \n",
-    "                      vmin=np.percentile(np.ravel(correlation_image),50), \n",
-    "                      vmax=np.percentile(np.ravel(correlation_image),99.5),\n",
-    "                      figsize=(4,4));\n",
-    "patch_ax.set_title(f'CNMF Patches Width {cnmf_patch_width}, Overlap {cnmf_patch_overlap}');"
+    "patch_ax = nb_view_quilt(correlation_image, \n",
+    "                      cnmf_model.params.patch['rf'], \n",
+    "                      cnmf_model.params.patch['stride']);"
    ]
   },
   {


### PR DESCRIPTION
# Description

This PR adds the function `nb_view_quilt()` which is a 1:1 implementation of the `view_quilt()` function in Bokeh. The demo_pipeline notebook referred to an interactive version of the view_quilt function but I was unable to find it. The view_quilt function had a todo for implanting a bokeh version.

When this function is evoked, it shows the quilt plot with 2 sliders for changing the `rf` and `stride` parameters. I opted for modifying the underlaying parameters with the sliders instead of the patch size and overlap, because some width values are impossible to use. For example, the patches can never have a size of 22 because of the formula `patch size = (rf * 2) + 1`.

The demo_pipeline notebook was also modified to use the Bokeh version.


- [x] New feature (non-breaking change which adds functionality)
- [x] Changes in documentation or new examples for demos and/or use cases.


# Has your PR been tested?

```caimanmanager demotest``` ran without any issues.

```caimanmanager test``` failed at `caiman.tests.test_sbx...` but had no other issues.

 The `nb_view_quilt()` have also been manually tested and it always produced the exact same output as `view_quilt()`, given identical inputs.
