### PR TITLE
Get correct centers of mass from rois.com even when swap_dim is True in get_contours

### DIFF
--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -28,18 +28,18 @@ except:
     pass
 
 
-def com(A, *dims: int, order='F') -> np.ndarray:
+def com(A, d1: int, d2: int, d3: Optional[int] = None, order: str = 'F') -> np.ndarray:
     """Calculation of the center of mass for spatial components
 
      Args:
          A: np.ndarray or scipy.sparse array or matrix
-              matrix of spatial components (d x K); column indices map to dimensions according to F-order.
+              matrix of spatial components (d x K).
 
-         *dims: D ints
-              each positional argument after A defines the extent of one of the dimensions of the data.
+         d1, d2, d3: ints
+              d1, d2, and (optionally) d3 are the original dimensions of the data.
             
          order: 'C' or 'F'
-              how each column of A should be reshaped to match dims.
+              how each column of A should be reshaped to match the given dimensions.
 
      Returns:
          cm:  np.ndarray
@@ -47,6 +47,10 @@ def com(A, *dims: int, order='F') -> np.ndarray:
     """
     if 'csc_matrix' not in str(type(A)):
         A = scipy.sparse.csc_matrix(A)
+
+    dims = [d1, d2]
+    if d3 is not None:
+        dims.append(d3)
 
     # make coordinate arrays where coor[d] increases from 0 to npixels[d]-1 along the dth axis
     coors = np.meshgrid(*[range(d) for d in dims], indexing='ij')

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -20,7 +20,7 @@ from scipy.sparse import issparse, spdiags, coo_matrix, csc_matrix
 from skimage.measure import find_contours
 import sys
 from tempfile import NamedTemporaryFile
-from typing import Any, Optional, Literal, Union
+from typing import Any, Optional
 from warnings import warn
 
 import caiman.base.rois
@@ -366,7 +366,7 @@ def hv_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, denois
                 .redim.range(unit_id=(0, nr-1), scale=(0.0, 1.0)))
 
 
-def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: Union[int, Literal['auto']] = 'auto'):
+def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: Optional[int] = None):
     """Gets contour of spatial components and returns their coordinates
 
      Args:
@@ -389,9 +389,9 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
                   this is correct if the dimensions have not been reordered from (y, x[, z]).
                   If True, each column should be reshaped in C-order; this is correct for dims = ([z, ]x, y).
 
-             slice_dim: int or 'auto'
+             slice_dim: int or None
                   Which dimension to slice along if we have 3D data. (i.e., get contours on each plane along this axis).
-                  The default ('auto') is 0 if swap_dim is True, else -1.
+                  The default (None) is 0 if swap_dim is True, else -1.
 
      Returns:
          Coor: list of coordinates with center of mass and
@@ -465,7 +465,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
         else:
             # make a list of the contour coordinates for each 2D slice
             pars['coordinates'] = []
-            if slice_dim == 'auto':
+            if slice_dim is None:
                 slice_dim = 0 if swap_dim else -1
             for s in range(dims[slice_dim]):
                 B = Bmat.take(s, axis=slice_dim)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -392,18 +392,16 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False):
     if 'csc_matrix' not in str(type(A)):
         A = csc_matrix(A)
     d, nr = np.shape(A)
-    # if we are on a 3D video
-    if len(dims) == 3:
-        d1, d2, d3 = dims
-        x, y = np.mgrid[0:d2:1, 0:d3:1]
-    else:
-        d1, d2 = dims
-        x, y = np.mgrid[0:d1:1, 0:d2:1]
+    d1, d2 = dims[:2]
 
     coordinates = []
 
     # get the center of mass of neurons( patches )
-    cm = caiman.base.rois.com(A, *dims)
+    # com assumes F-order
+    if swap_dim:
+        cm = caiman.base.rois.com(A, *dims[::-1])[:, ::-1]
+    else:
+        cm = caiman.base.rois.com(A, *dims)
 
     # for each patches
     for i in range(nr):

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -1096,16 +1096,11 @@ def plot_contours(A, Cn, thr=None, thr_method='max', maxthr=0.2, nrgthr=0.9, dis
         plt.plot(*v.T, c=colors, **contour_args)
 
     if display_numbers:
-        d1, d2 = np.shape(Cn)
-        d, nr = np.shape(A)
-        cm = caiman.base.rois.com(A, d1, d2)
+        nr = A.shape[1]
         if max_number is None:
-            max_number = A.shape[1]
-        for i in range(np.minimum(nr, max_number)):
-            if swap_dim:
-                ax.text(cm[i, 0], cm[i, 1], str(i + 1), color=colors, **number_args)
-            else:
-                ax.text(cm[i, 1], cm[i, 0], str(i + 1), color=colors, **number_args)
+            max_number = nr
+        for i, c in zip(range(np.minimum(nr, max_number)), coordinates):
+            ax.text(c['CoM'][1], c['CoM'][0], str(i + 1), color=colors, **number_args)
     return coordinates
 
 def plot_shapes(Ab, dims, num_comps=15, size=(15, 15), comps_per_row=None,

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -401,7 +401,6 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
     if 'csc_matrix' not in str(type(A)):
         A = csc_matrix(A)
     d, nr = np.shape(A)
-    d1, d2 = dims[:2]
 
     coordinates = []
 
@@ -443,6 +442,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
 
         def get_slice_coords(B: np.ndarray) -> np.ndarray:
             """Get contour coordinates for a 2D slice"""
+            d1, d2 = B.shape
             vertices = find_contours(B.T, thr)
             # this fix is necessary for having disjoint figures and borders plotted correctly
             v = np.atleast_2d([np.nan, np.nan])
@@ -451,8 +451,8 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
                 if num_close_coords < 2:
                     if num_close_coords == 0:
                         # case angle
-                        newpt = np.round(vtx[-1, :] / [d2, d1]) * [d2, d1]
-                        vtx = np.concatenate((vtx, newpt[np.newaxis, :]), axis=0)
+                        newpt = np.round(np.mean(vtx[[0, -1], :], axis=0) / [d2, d1]) * [d2, d1]
+                        vtx = np.concatenate((newpt[np.newaxis, :], vtx, newpt[np.newaxis, :]), axis=0)
                     else:
                         # case one is border
                         vtx = np.concatenate((vtx, vtx[0, np.newaxis]), axis=0)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -397,11 +397,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False):
     coordinates = []
 
     # get the center of mass of neurons( patches )
-    # com assumes F-order
-    if swap_dim:
-        cm = caiman.base.rois.com(A, *dims[::-1])[:, ::-1]
-    else:
-        cm = caiman.base.rois.com(A, *dims)
+    cm = caiman.base.rois.com(A, *dims, order='C' if swap_dim else 'F')
 
     # for each patches
     for i in range(nr):


### PR DESCRIPTION
# Description

The issue is that the `rois.com` function always assumes that each column of `A` is in F-order, but `get_contours` was not taking that into account when calling it with `swap_dim=True`.* In particular, `plot_contours` transposes the image and reverses the order of dimensions input to `get_contours` when `swap_dim` is true. This means that `A` is now in C-order relative to the dimensions.

This solution rewrites `rois.com` to take an `order` parameter. So when `swap_dim` is true, `order` should be 'C'.

Also, with this call fixed, it's unnecessary to call `com` again in `plot_contours` (I believe); the 'CoM' field of each coordinates dict can be used to plot the labels.

\* (I doubt this option is commonly used, but I was using it for 3D CNMF because the way it handles 3D arrays (iterating over the first dimension) means it made more sense to used swapped dims so that it was iterating over planes. Not sure if this should also be changed, though.)

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

I added a test to `test_toydata.py` (not sure if this is a good place) to ensure that the contours and coms are the same regardless of orientation for the 2D case. (I don't think there's a straightforward way to `swap_dim` for the 3D case because of the way planes are handled when finding contours). ```caimanmanager test``` and ```caimanmanager demotest``` pass.

Also, I did some manual testing with the demo notebook. I had to cut the test movie in half along the x-axis to reproduce the bug because it only matters when the x and y sizes differ and the demo movie is square.

Before this change, with swap_dim = True (note that the label coordinates are incorrect):
<img width="593" alt="Screenshot 2024-07-02 142337" src="https://github.com/flatironinstitute/CaImAn/assets/8973825/2f3504e2-2afd-457f-9720-e839df5890fa">

After change with swap_dim = True - labels now line up with contours
<img width="593" src="https://github.com/flatironinstitute/CaImAn/assets/8973825/749bee81-b3da-49bc-bd50-d237a8f44d29">

After change with swap_dim = False:
<img width="593" src="https://github.com/flatironinstitute/CaImAn/assets/8973825/b99d4238-5e79-4830-b985-504f4da381d7">


