### PR TITLE
Fix unbound local error in online_cnmf when use_corr_img is true but is1p is false

### DIFF
--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -270,7 +270,6 @@ class OnACID(object):
 
         if self.is1p:
             estim = self.estimates
-            d1, d2 = estim.dims    
             estim.Yres_buf -= estim.b0
             if ssub_B == 1:
                 estim.Atb = estim.Ab.T.dot(estim.W.dot(estim.b0) - estim.b0)
@@ -389,6 +388,7 @@ class OnACID(object):
                 else:
                     Yres -= estim.upscale_matrix.dot(estim.W.dot(
                         estim.downscale_matrix.dot(Yres)))
+            d1, d2 = self.estimates.dims
             Yres = Yres.reshape((d1, d2, -1), order='F')
 
             (self.estimates.first_moment, self.estimates.second_moment,


### PR DESCRIPTION
# Description

Currently, in the method `OnACID._prepare_object` , `d1` and `d2` are only set when `self.is1p` is true, but are only used if the parameter `online['use_corr_img'] is true. I was trying to run it with `use_corr_img` but without setting the other parameters in a way that causes `is1p` to be true, so I got an unbound local error.

Since these variables are only used in one place in this function, I just moved the line that defines them to be right before they are used. I'm not 100% sure the functionality is correct, but the line just reads from `estimates.dims`, which seems pretty straightforward.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Did not run the tests myself (relying on CI) but I did check that making this change prevented the error I was getting when trying to call `fit_online` with these parameters.
