### PR TITLE
Fix error when saving array with NaNs (occurs with corr_img when use_corr_img is True)

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -516,7 +516,7 @@ def recursively_save_dict_contents_to_group(h5file:h5py.File, path:str, dic:dict
             except:
                 item = np.array(item).astype('|S32')
                 h5file[path + key] = item
-            if not np.array_equal(h5file[path + key][()], item):
+            if not np.array_equal(h5file[path + key][()], item, equal_nan=item.dtype == 'f'):  # just using True gives "ufunc 'isnan' not supported for the input types"
                 raise ValueError(f'Error while saving ndarray {key} of dtype {item.dtype}')
         # save dictionaries
         elif isinstance(item, dict):


### PR DESCRIPTION
# Description

The function `recursively_save_dict_contents_to_group` checks that an ndarray was written correctly to the HDF5 file by calling `np.array_equal`, but it currently does not set the option `equal_nan=True`, meaning that if there are any NaNs in the array, it returns false. Regardless of whether NaNs are expected, this is probably not what we want if we are just doing a fidelity check.

I initially tried just changing this to true, but apparently it can fail with a TypeError ("ufunc 'isnan' not supported for the input types") in some cases. So I changed it to only be true if the ndarray is of a floating-point type, which seems to work.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Have not tested beyond this; may be good to add a unit test for it, which I can come back and do later.