### PR TITLE
Save memory by returning a sparse array from extract_binary_masks_from_structural_channel

### DIFF
--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as pl
 import numpy as np
 import os
 import scipy
+import scipy.sparse
 from scipy.ndimage import label, gaussian_filter
 from scipy.optimize import linear_sum_assignment
 import shutil
@@ -106,7 +107,7 @@ def extract_binary_masks_from_structural_channel(Y,
     th = remove_small_objects(th, min_size=min_area_size)
     areas = label(th)
 
-    A = np.zeros((np.prod(th.shape), areas[1]), dtype=bool)
+    A = scipy.sparse.lil_array((areas[1], np.prod(th.shape)), dtype=bool)
 
     for i in range(areas[1]):
         temp = (areas[0] == i + 1)
@@ -115,9 +116,9 @@ def extract_binary_masks_from_structural_channel(Y,
         elif expand_method == 'closing':
             temp = closing(temp, footprint=selem)
 
-        A[:, i] = temp.flatten('F')
+        A.getrowview(i)[:] = temp.flatten('F')
 
-    return A, mR
+    return A.tocsr().T, mR
 
 
 def mask_to_2d(mask):


### PR DESCRIPTION
# Description

The docstring for `extract_binary_masks_from_structural_channel` says that it returns a sparse column format matrix, but it actually just returns an ndarray. I was running out of memory when trying to use this to generate a mask to input to CNMF. This changes the function to return a `scipy.sparse.csc_array` instead.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

```caimanmanager test``` and ```caimanmanager demotest``` pass. I don't think it's a good idea to add a test for memory usage, but here is what I see for my use case: 

Before:
```
>>> tracemalloc.start()
>>> Ain, _ = rois.extract_binary_masks_from_structural_channel(mean_img, gSig=9)
>>> curr_mem, peak_mem = tracemalloc.get_traced_memory()
>>> curr_mem
1822996704
```

After:
```
>>> tracemalloc.start()
>>> Ain, _ = rois.extract_binary_masks_from_structural_channel(mean_img, gSig=9)
>>> curr_mem, peak_mem = tracemalloc.get_traced_memory()
>>> curr_mem
971327
```
