### PR TITLE
Include background component indices when removing empty/nan components in spatial.py

### DIFF
--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -180,7 +180,7 @@ def update_spatial_components(Y, C=None, f=None, A_in=None, sn=None, dims=None,
         A_in = caiman.utils.stats.csc_column_remove(A_in, list(ff))
         C = np.delete(C, list(ff), 0)
         # update indices
-        ind_list = list(range(nr-np.size(ff)))
+        ind_list = list(range(nr+nb-np.size(ff)))
         for i in ff:
             ind_list.insert(i, 0)
         ind_list = np.array(ind_list, dtype=int)


### PR DESCRIPTION
# Description

This fixes an indexing error in the "Eliminating empty and nan components" step that occurs when using seeded CNMF. The error I was getting is as follows:

```python
Traceback (most recent call last):
  File "/u/ethan/mesmerize-core/mesmerize_core/algorithms/cnmf.py", line 94, in run_algo
    cnm = cnm.fit(images)
          ^^^^^^^^^^^^^^^
  File "/u/ethan/CaImAn/caiman/source_extraction/cnmf/cnmf.py", line 523, in fit
    self.update_spatial(Yr, use_init=True)
  File "/u/ethan/CaImAn/caiman/source_extraction/cnmf/cnmf.py", line 915, in update_spatial
    update_spatial_components(Y, C=self.estimates.C, f=self.estimates.f, A_in=self.estimates.A,
  File "/u/ethan/CaImAn/caiman/source_extraction/cnmf/spatial.py", line 189, in update_spatial_components
    ind2_ = [ind_list[np.setdiff1d(a,ff)] if len(a) else a for a in ind2_]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/u/ethan/CaImAn/caiman/source_extraction/cnmf/spatial.py", line 189, in <listcomp>
    ind2_ = [ind_list[np.setdiff1d(a,ff)] if len(a) else a for a in ind2_]
             ~~~~~~~~^^^^^^^^^^^^^^^^^^^^
IndexError: index 1637 is out of bounds for axis 0 with size 1637
```

It looks like this is happening because when `A_in` is provided and has type bool, the following lines add indices corresponding to the spatial components (>= `nr`) to non-empty entries of `ind2_`:

https://github.com/flatironinstitute/CaImAn/blob/ce2cb179cb801c3541f40d0c370ae961381acf34/caiman/source_extraction/cnmf/spatial.py#L1066-L1067

However, the code to remove empty components assumes that the highest original component number is `nr-1`: 

https://github.com/flatironinstitute/CaImAn/blob/ce2cb179cb801c3541f40d0c370ae961381acf34/caiman/source_extraction/cnmf/spatial.py#L183-L187

To fix this, I changed this to use `nr + nb`. However, I'm not 100% sure that the behavior of adding indices for background components is correct in the first place, since it seems inconsistent with what happens with no masks passed in.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Has your PR been tested?

The CNMF run I that was failing for me before now succeeds. Since there wasn't a failing test before, I'm guessing this part of the code (under the condition of seeded CNMF) wasn't being tested, which could be changed.
