### PR TITLE
caiman.base.movies.get_file_size fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-modified beep beep 
 <a href="https://colab.research.google.com/drive/1vkp-uPV8tKavmX12bcN2L-jYH8_MgmHL?usp=sharing"><img src="https://img.shields.io/badge/-Colab%20Demo-blue" /></a>
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+modified beep beep 
 <a href="https://colab.research.google.com/drive/1vkp-uPV8tKavmX12bcN2L-jYH8_MgmHL?usp=sharing"><img src="https://img.shields.io/badge/-Colab%20Demo-blue" /></a>
 
 

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -2025,6 +2025,11 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                     logger.error(f'The file does not contain a variable named {var_name_hdf5}')
                     raise Exception('Variable not found. Use one of the above')
                 T, dims = siz[0], siz[1:]
+            elif extension in ('.npy', ):
+                shape = np.load(file_name, allow_pickle=False).shape
+                T = shape[0]
+                dims = shape[1:]
+
             elif extension in ('.sbx'):
                 shape = caiman.utils.sbx_utils.sbx_shape(file_name[:-4])
                 T = shape[-1]

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -2029,7 +2029,6 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                 shape = np.load(file_name, allow_pickle=False).shape
                 T = shape[0]
                 dims = shape[1:]
-
             elif extension in ('.sbx'):
                 shape = caiman.utils.sbx_utils.sbx_shape(file_name[:-4])
                 T = shape[-1]


### PR DESCRIPTION
# Description

Fixes #1431

Fixed inability of `caiman.base.movies.get_file_size` to handle `.npy` files. Makes assumption `.npy` files are a tensor with frames as the first dimension. 

# Type of change
Bug fix

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Branching
- All PRs should be made against the **dev** branch. The main branch is not often merged back to dev.
- If you want to get your PR out to the world faster (urgent bugfix), poke pgunn to cut a release; this will get it onto github and into conda faster

# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

```caimanmanager test```

and

```caimanmanager demotest```

prior to submitting your pull request. 

Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.

No additional tests
