### PR TITLE
Improve get_file_size efficiency for .npy files

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -2033,7 +2033,7 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                     elif version == (2, 0):
                         shape, _, _ = np.lib.format.read_array_header_2_0(f)
                     else:
-                        raise ValueError(f"Unsupported .npy file version: {version}. Update this code to handle it.")
+                        raise ValueError(f"Unsupported .npy file version: {version}. Update caiman.base.movies.get_file_size() to handle it.")
                 T = shape[0]
                 dims = shape[1:]
             elif extension in ('.sbx'):

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -2026,7 +2026,14 @@ def get_file_size(file_name, var_name_hdf5:str='mov') -> tuple[tuple, Union[int,
                     raise Exception('Variable not found. Use one of the above')
                 T, dims = siz[0], siz[1:]
             elif extension in ('.npy', ):
-                shape = np.load(file_name, allow_pickle=False).shape
+                with open(file_name, 'rb') as f:
+                    version = np.lib.format.read_magic(f)
+                    if version == (1, 0):
+                        shape, _, _ = np.lib.format.read_array_header_1_0(f)
+                    elif version == (2, 0):
+                        shape, _, _ = np.lib.format.read_array_header_2_0(f)
+                    else:
+                        raise ValueError(f"Unsupported .npy file version: {version}. Update this code to handle it.")
                 T = shape[0]
                 dims = shape[1:]
             elif extension in ('.sbx'):


### PR DESCRIPTION
# Description

Currently, `caiman.bsae.movies.get_file_size` requires reading an entire `.npy` file into memory to infer its shape. This update modifies the function to read only the file header, greatly improving runtime efficiency.

Fixed #1431

Fixes # (issue)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Branching
- All PRs should be made against the **dev** branch. The main branch is not often merged back to dev.
- If you want to get your PR out to the world faster (urgent bugfix), poke pgunn to cut a release; this will get it onto github and into conda faster

# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

```caimanmanager test```

and

```caimanmanager demotest```

prior to submitting your pull request. 

Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.

No additional tests were added, as the change modifies internal behavior without introducing new user-facing functionality or regressions. Existing test coverage should adequately validate this change.
