### PR TITLE
Fix and add more options for non-optical flow register_ROIs; add feature to interpolate shifts based on patch locations in tile_and_correct

### DIFF
--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -430,12 +430,12 @@ def register_ROIs(A1,
                 "max_shifts": (10, 10),
                 "shifts_opencv": True,
                 "upsample_factor_grid": 4,
-                "interp_shifts_precisely": True,
+                "shifts_interpolate": True,
                 "max_deviation_rigid": 2
                 # any other argument to tile_and_correct can also be used in align_options
             }
 
-            if align_options is not None:
+            if align_options:
                 # override defaults with input options
                 align_defaults.update(align_options)
             align_options = align_defaults

--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -312,14 +312,14 @@ def register_ROIs(A1,
                   D=None,
                   max_thr=0,
                   use_opt_flow=True,
-                  align_options: Optional[dict] = None,
                   thresh_cost=.7,
                   max_dist=10,
                   enclosed_thr=None,
                   print_assignment=False,
                   plot_results=False,
                   Cn=None,
-                  cmap='viridis'):
+                  cmap='viridis',
+                  align_options: Optional[dict] = None):
     """
     Register ROIs across different sessions using an intersection over union 
     metric and the Hungarian algorithm for optimal matching
@@ -352,9 +352,6 @@ def register_ROIs(A1,
         use_opt_flow: bool
             use dense optical flow to align templates
 
-        align_options: Optional[dict]
-            mcorr options to override defaults when align_flag is True and use_opt_flow is False
-
         thresh_cost: scalar
             maximum distance considered
 
@@ -376,6 +373,9 @@ def register_ROIs(A1,
 
         cmap: string
             colormap for background image
+        
+        align_options: Optional[dict]
+            mcorr options to override defaults when align_flag is True and use_opt_flow is False
 
     Returns:
         matched_ROIs1: list

--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -437,8 +437,8 @@ def register_ROIs(A1,
             shifts_x = np.reshape(_sh_[:, 1], patch_grid, order='C').astype(np.float32)
             shifts_y = np.reshape(_sh_[:, 0], patch_grid, order='C').astype(np.float32)
 
-            x_remap = interpolate_shifts(-shifts_x, patch_centers, tuple(range(d) for d in dims))
-            y_remap = interpolate_shifts(-shifts_y, patch_centers, tuple(range(d) for d in dims))
+            x_remap = interpolate_shifts(-shifts_x, patch_centers, tuple(range(d) for d in dims)).astype(np.float32)
+            y_remap = interpolate_shifts(-shifts_y, patch_centers, tuple(range(d) for d in dims)).astype(np.float32)
 
         A_2t = np.reshape(A2, dims + (-1,), order='F').transpose(2, 0, 1)
         A2 = np.stack([cv2.remap(img.astype(np.float32), x_remap, y_remap, cv2.INTER_NEAREST) for img in A_2t], axis=0)

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -1835,10 +1835,12 @@ def sliding_window_dims(dims: tuple[int, ...], overlaps: tuple[int, ...], stride
             the dimensions of the image
 
         overlaps: tuple
-            overlap of patches (except possibly last one) in each dimension
+            overlap of patches in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of overlap
 
         strides: tuple
-            stride in each dimension
+            stride in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of stride
 
      Returns:
          iterator containing 3 items:
@@ -1862,10 +1864,12 @@ def sliding_window(image: np.ndarray, overlaps: tuple[int, int], strides: tuple[
             image that needs to be sliced
 
         overlaps: tuple
-            overlap of patches (except possibly last one) in each dimension 
+            overlap of patches in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of overlap
 
         strides: tuple
-            stride in each dimension
+            stride in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of stride
 
      Returns:
          iterator containing five items
@@ -1889,10 +1893,12 @@ def sliding_window_3d(image: np.ndarray, overlaps: tuple[int, int, int], strides
             image that needs to be sliced
 
         overlaps: tuple
-            overlap of patches (except possibly last one) in each dimension 
+            overlap of patches in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of overlap 
 
         strides: tuple
-            stride in each dimension
+            stride in each dimension, except that the last patch will be all the way
+            at the bottom/right regardless of stride
 
      Returns:
          iterator containing seven items

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -79,7 +79,7 @@ class MotionCorrect(object):
                  strides=(96, 96), overlaps=(32, 32), splits_els=14, num_splits_to_process_els=None,
                  upsample_factor_grid=4, max_deviation_rigid=3, shifts_opencv=True, nonneg_movie=True, gSig_filt=None,
                  use_cuda=False, border_nan=True, pw_rigid=False, num_frames_split=80, var_name_hdf5='mov', is3D=False,
-                 indices=(slice(None), slice(None))):
+                 indices=(slice(None), slice(None)), interp_shifts_precisely=False):
         """
         Constructor class for motion correction operations
 
@@ -198,6 +198,7 @@ class MotionCorrect(object):
         self.var_name_hdf5 = var_name_hdf5
         self.is3D = bool(is3D)
         self.indices = indices
+        self.interp_shifts_precisely = interp_shifts_precisely
         if self.use_cuda:
             logger.warn("cuda is no longer supported; this kwarg will be removed in a future version of caiman")
 
@@ -301,7 +302,8 @@ class MotionCorrect(object):
                 border_nan=self.border_nan,
                 var_name_hdf5=self.var_name_hdf5,
                 is3D=self.is3D,
-                indices=self.indices)
+                indices=self.indices,
+                interp_shifts_precisely=self.interp_shifts_precisely)
             if template is None:
                 self.total_template_rig = _total_template_rig
 
@@ -362,7 +364,7 @@ class MotionCorrect(object):
                     num_splits_to_process=None, num_iter=num_iter, template=self.total_template_els,
                     shifts_opencv=self.shifts_opencv, save_movie=save_movie, nonneg_movie=self.nonneg_movie, gSig_filt=self.gSig_filt,
                     use_cuda=self.use_cuda, border_nan=self.border_nan, var_name_hdf5=self.var_name_hdf5, is3D=self.is3D,
-                    indices=self.indices)
+                    indices=self.indices, interp_shifts_precisely=self.interp_shifts_precisely)
             if not self.is3D:
                 if show_template:
                     plt.imshow(new_template_els)
@@ -2718,7 +2720,8 @@ def compute_metrics_motion_correction(fname, final_size_x, final_size_y, swap_di
 def motion_correct_batch_rigid(fname, max_shifts, dview=None, splits=56, num_splits_to_process=None, num_iter=1,
                                template=None, shifts_opencv=False, save_movie_rigid=False, add_to_movie=None,
                                nonneg_movie=False, gSig_filt=None, subidx=slice(None, None, 1), use_cuda=False,
-                               border_nan=True, var_name_hdf5='mov', is3D=False, indices=(slice(None), slice(None))):
+                               border_nan=True, var_name_hdf5='mov', is3D=False, indices=(slice(None), slice(None)),
+                               interp_shifts_precisely=False):
     """
     Function that perform memory efficient hyper parallelized rigid motion corrections while also saving a memory mappable file
 
@@ -2838,7 +2841,7 @@ def motion_correct_batch_rigid(fname, max_shifts, dview=None, splits=56, num_spl
                                                              dview=dview, save_movie=save_movie, base_name=base_name, subidx = subidx,
                                                              num_splits=num_splits_to_process, shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
                                                              use_cuda=use_cuda, border_nan=border_nan, var_name_hdf5=var_name_hdf5, is3D=is3D,
-                                                             indices=indices)
+                                                             indices=indices, interp_shifts_precisely=interp_shifts_precisely)
         if is3D:
             new_templ = np.nanmedian(np.stack([r[-1] for r in res_rig]), 0)           
         else:
@@ -2861,7 +2864,7 @@ def motion_correct_batch_pwrigid(fname, max_shifts, strides, overlaps, add_to_mo
                                  splits=56, num_splits_to_process=None, num_iter=1,
                                  template=None, shifts_opencv=False, save_movie=False, nonneg_movie=False, gSig_filt=None,
                                  use_cuda=False, border_nan=True, var_name_hdf5='mov', is3D=False,
-                                 indices=(slice(None), slice(None))):
+                                 indices=(slice(None), slice(None)), interp_shifts_precisely=False):
     """
     Function that perform memory efficient hyper parallelized rigid motion corrections while also saving a memory mappable file
 
@@ -2966,7 +2969,7 @@ def motion_correct_batch_pwrigid(fname, max_shifts, strides, overlaps, add_to_mo
                                                             base_name=base_name, num_splits=num_splits_to_process,
                                                             shifts_opencv=shifts_opencv, nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
                                                             use_cuda=use_cuda, border_nan=border_nan, var_name_hdf5=var_name_hdf5, is3D=is3D,
-                                                            indices=indices)
+                                                            indices=indices, interp_shifts_precisely=interp_shifts_precisely)
         if is3D:
             new_templ = np.nanmedian(np.stack([r[-1] for r in res_el]), 0)
         else:
@@ -3021,7 +3024,7 @@ def tile_and_correct_wrapper(params):
     img_name, out_fname, idxs, shape_mov, template, strides, overlaps, max_shifts,\
         add_to_movie, max_deviation_rigid, upsample_factor_grid, newoverlaps, newstrides, \
         shifts_opencv, nonneg_movie, gSig_filt, is_fiji, use_cuda, border_nan, var_name_hdf5, \
-        is3D, indices = params
+        is3D, indices, interp_shifts_precisely = params
 
 
     if isinstance(img_name, tuple):
@@ -3047,7 +3050,8 @@ def tile_and_correct_wrapper(params):
                                                                        upsample_factor_fft=10, show_movie=False,
                                                                        max_deviation_rigid=max_deviation_rigid,
                                                                        shifts_opencv=shifts_opencv, gSig_filt=gSig_filt,
-                                                                       use_cuda=use_cuda, border_nan=border_nan)
+                                                                       use_cuda=use_cuda, border_nan=border_nan,
+                                                                       interp_shifts_precisely=interp_shifts_precisely)
             shift_info.append([total_shift, start_step, xyz_grid])
             
         else:
@@ -3058,7 +3062,8 @@ def tile_and_correct_wrapper(params):
                                                                        upsample_factor_fft=10, show_movie=False,
                                                                        max_deviation_rigid=max_deviation_rigid,
                                                                        shifts_opencv=shifts_opencv, gSig_filt=gSig_filt,
-                                                                       use_cuda=use_cuda, border_nan=border_nan)
+                                                                       use_cuda=use_cuda, border_nan=border_nan,
+                                                                       interp_shifts_precisely=interp_shifts_precisely)
             shift_info.append([total_shift, start_step, xy_grid])
 
     if out_fname is not None:
@@ -3079,7 +3084,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
                                 upsample_factor_grid=4, order='F', dview=None, save_movie=True,
                                 base_name=None, subidx = None, num_splits=None, shifts_opencv=False, nonneg_movie=False, gSig_filt=None,
                                 use_cuda=False, border_nan=True, var_name_hdf5='mov', is3D=False,
-                                indices=(slice(None), slice(None))):
+                                indices=(slice(None), slice(None)), interp_shifts_precisely=False):
     """
 
     """
@@ -3134,7 +3139,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
         pars.append([fname, fname_tot, idx, shape_mov, template, strides, overlaps, max_shifts, np.array(
             add_to_movie, dtype=np.float32), max_deviation_rigid, upsample_factor_grid,
             newoverlaps, newstrides, shifts_opencv, nonneg_movie, gSig_filt, is_fiji,
-            use_cuda, border_nan, var_name_hdf5, is3D, indices])
+            use_cuda, border_nan, var_name_hdf5, is3D, indices, interp_shifts_precisely])
 
     if dview is not None:
         logger.info('** Starting parallel motion correction **')

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -558,9 +558,6 @@ class CNMFParams(object):
             gSig_filt: int or None, default: None
                 size of kernel for high pass spatial filtering in 1p data. If None no spatial filtering is performed
 
-            interp_shifts_precisely: bool, default: False
-                use patch locations to interpolate shifts rather than just upscaling to size of image (for pw_rigid only)
-
             is3D: bool, default: False
                 flag for 3D recordings for motion correction
 
@@ -590,6 +587,9 @@ class CNMFParams(object):
 
             pw_rigid: bool, default: False
                 flag for performing pw-rigid motion correction.
+
+            shifts_interpolate: bool, default: False
+                use patch locations to interpolate shifts rather than just upscaling to size of image (for pw_rigid only)
 
             shifts_opencv: bool, default: True
                 flag for applying shifts using cubic interpolation (otherwise FFT)
@@ -861,7 +861,6 @@ class CNMFParams(object):
         self.motion = {
             'border_nan': 'copy',               # flag for allowing NaN in the boundaries
             'gSig_filt': None,                  # size of kernel for high pass spatial filtering in 1p data
-            'interp_shifts_precisely': False,   # interpolate shifts based on patch locations instead of reizing
             'is3D': False,                      # flag for 3D recordings for motion correction
             'max_deviation_rigid': 3,           # maximum deviation between rigid and non-rigid
             'max_shifts': (6, 6),               # maximum shifts per dimension (in pixels)
@@ -873,6 +872,7 @@ class CNMFParams(object):
             'num_splits_to_process_rig': None,  # DO NOT MODIFY
             'overlaps': (32, 32),               # overlap between patches in pw-rigid motion correction
             'pw_rigid': False,                  # flag for performing pw-rigid motion correction
+            'shifts_interpolate': False,        # interpolate shifts based on patch locations instead of resizing
             'shifts_opencv': True,              # flag for applying shifts using cubic interpolation (otherwise FFT)
             'splits_els': 14,                   # number of splits across time for pw-rigid registration
             'splits_rig': 14,                   # number of splits across time for rigid registration

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -558,6 +558,9 @@ class CNMFParams(object):
             gSig_filt: int or None, default: None
                 size of kernel for high pass spatial filtering in 1p data. If None no spatial filtering is performed
 
+            interp_shifts_precisely: bool, default: False
+                use patch locations to interpolate shifts rather than just upscaling to size of image (for pw_rigid only)
+
             is3D: bool, default: False
                 flag for 3D recordings for motion correction
 
@@ -858,6 +861,7 @@ class CNMFParams(object):
         self.motion = {
             'border_nan': 'copy',               # flag for allowing NaN in the boundaries
             'gSig_filt': None,                  # size of kernel for high pass spatial filtering in 1p data
+            'interp_shifts_precisely': False,   # interpolate shifts based on patch locations instead of reizing
             'is3D': False,                      # flag for 3D recordings for motion correction
             'max_deviation_rigid': 3,           # maximum deviation between rigid and non-rigid
             'max_shifts': (6, 6),               # maximum shifts per dimension (in pixels)


### PR DESCRIPTION
# Description

## The problem

This addresses an issue I raised on the slack where the non-optical flow path of `register_ROIs` seems to have a mistake. It works by finding piecewise-rigid shifts between the two template images using `tile_and_correct`. Then, the matrix of shifts for each patch should be interpolated into a shift map of the same size as the image, to be used for `cv2.remap`. However, these lines:

https://github.com/flatironinstitute/CaImAn/blob/bb55800806f0898592d79dcc705a0b53ccd01ec3/caiman/base/rois.py#L434-L435

actually just [repeat the entries of the matrix, in C-order, to fill in a new matrix of the requested shape](https://numpy.org/doc/1.26/reference/generated/numpy.resize.html), so the result will make no sense.

I used this test script: https://gist.github.com/ethanbb/12e6efa6ba31733f769c0b6c3f82ee98 to confirm that it gives weirdly warped results. Note that with the current code, setting `use_opt_flow` to False always gives an error, because the `tile_and_correct` call sets `shifts_opencv=True`, but this path does not return a value for `xy_grid`, which is then used on the next line. So, for testing, I temporarily changed `shifts_opencv` to False. Here are the results with the current code:

![register_rois_test_result_orig_dev2](https://github.com/user-attachments/assets/4053079f-385c-4893-b3d6-20cd449f3510)

In this case, it seems like we should just stick with optical flow. However, one thing I've observed and which motivated this inquiry is that optical flow struggles with larger shifts. Here is what happens when I increase the amount of non-rigid offset from 2 to 6:

![register_rois_test_result_orig_dev6](https://github.com/user-attachments/assets/1f2d7faf-f21f-4f95-8942-d4df2fc88843)

Clearly, neither method is satisfactory.

## Solving the general problem

Up-sampling shifts from patches does not only happen in `register_ROIs`. It occurs in multiple places in the motion correction code as well, but for this PR I just focused on `tile_and_correct` and `tile_and_correct_3d`. In these functions, resizing occurs for both the OpenCV (to full image size in order to use `cv2.remap`) and non-OpenCV (to an Nx denser grid, depending on `upsample_factor_grid`) methods. I realized when looking into this that it was not being done in the most rigorously correct way; it is implemented as a standard image resize, but the patch centers at the borders do not coincide with the borders of the new image, and these centers may not even be evenly spaced (at the lower and right edges).

This imprecision may not usually be a big deal for large images, and may be necessary in order to correct whole movies efficiently. However, I thought that at least for the case of aligning just 2 images, I may as well add a way to up-sample more precisely by interpolating using the exact location of each patch. Thus, I added `get_patch_centers` and `interpolate_shifts` to interpolate shifts to/from specific pixel locations using scipy (I don't think OpenCV has an easy way of doing this). I also added the flag `interp_shifts_precisely` for the two tile_and_correct functions to enable this method. I haven't tested it on a full motion correction run yet, but it could potentially be promoted to a new parameter in the future. 

Finally, I used the same functions to do the interpolation correctly within `register_ROIs`. Using the new `get_patch_centers` function, the `xy_grid` output is unnecessary, so it works with either setting of `shifts_opencv`. I also set `interp_shifts_precisely` to True here, and it seems to be working fine.

Results with `nr_offset = 2`:
![register_rois_test_result_fixed_dev2](https://github.com/user-attachments/assets/d94db968-eaf0-4448-bc00-ce2d2cc7aa7a)

And with `nr_offset = 6`:
![register_rois_test_result_fixed_dev6](https://github.com/user-attachments/assets/4dfb62fe-1979-4804-b95d-a160a09a8da0)

## Other changes to register_ROIs

- I added an optional argument `align_options` to allow overriding default motion correction params (for `tile_and_correct` method only). This is necessary, among other things, to increase `max_deviation_rigid` from 2 in order to deal with cases like the second example above.
- I added a clause to deal with the rigid case (if setting `max_deviation_rigid = 0`)
- For the optical flow branch, I noticed that the images are being multiplied by 255 and converted to uint8 twice in a row, causing lots of overflow. I assumed this was a bug, so I removed the second one.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Has your PR been tested?

Aside from the [test script]( https://gist.github.com/ethanbb/12e6efa6ba31733f769c0b6c3f82ee98) mentioned above, `caimanmanager test` passes. I'm trying to run demotest, having some issues with it but I'll update if I can get it working.