### PR TITLE
Add npy support to load_memmap

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -46,9 +46,12 @@ def load_memmap(filename: str, mode: str = 'r') -> tuple[Any, tuple, int]:
 
     """
     logger = logging.getLogger("caiman")
-    if pathlib.Path(filename).suffix != '.mmap':
+    allowed_extensions = {'.mmap', '.npy'}
+    
+    extension = pathlib.Path(filename).suffix
+    if extension not in allowed_extensions:
         logger.error(f"Unknown extension for file {filename}")
-        raise ValueError(f'Unknown file extension for file {filename} (should be .mmap)')
+        raise ValueError(f'Unknown file extension for file {filename} (should be .mmap or .npy)')
     # Strip path components and use CAIMAN_DATA/example_movies
     # TODO: Eventually get the code to save these in a different dir
     #fn_without_path = os.path.split(filename)[-1]
@@ -63,7 +66,11 @@ def load_memmap(filename: str, mode: str = 'r') -> tuple[Any, tuple, int]:
     #d1, d2, d3, T, order = int(fpart[-9]), int(fpart[-7]), int(fpart[-5]), int(fpart[-1]), fpart[-3]
 
     filename = caiman.paths.fn_relocated(filename)
-    Yr = np.memmap(filename, mode=mode, shape=prepare_shape((d1 * d2 * d3, T)), dtype=np.float32, order=order)
+    if extension == '.mmap':
+        Yr = np.memmap(filename, mode=mode, shape=prepare_shape((d1 * d2 * d3, T)), dtype=np.float32, order=order)
+    elif extension == '.npy':
+        Yr = np.load(filename, mmap_mode=mode)
+
     if d3 == 1:
         return (Yr, (d1, d2), T)
     else:


### PR DESCRIPTION
# Description

The `caiman.mmapping.load_memmap` function currently supports only `.mmap` files. Since `.npy` files store data in the same format as `.mmap` files, they can be used interchangeably with minor adjustments during loading (due to the header present in `.npy` files).

This update extends `load_memmap` to support `.npy` files, enabling their use in the CNMF parallelization framework.

Fixes #1431 

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Branching
- All PRs should be made against the **dev** branch. The main branch is not often merged back to dev.
- If you want to get your PR out to the world faster (urgent bugfix), poke pgunn to cut a release; this will get it onto github and into conda faster

# Has your PR been tested?

If you're fixing a bug or introducing a new feature it is recommended you run the tests by typing

```caimanmanager test```

and

```caimanmanager demotest```

prior to submitting your pull request. 

Please describe any additional tests that you ran to verify your changes. If they are fast you can also
include them in the folder 'caiman/tests/` and name them `test_***.py` so they can be included in our lists of tests.

No additional tests were added, as the change modifies internal behavior without introducing new user-facing functionality or regressions. Existing test coverage should adequately validate this change.
