### PR TITLE
Numpy 2.0 compatibility: change all np.Inf to np.inf

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -671,7 +671,7 @@ class movie(caiman.base.timeseries.timeseries):
         T, h, w = self.shape
         Y = np.reshape(self, (T, h * w))
         Y = Y - np.percentile(Y, 1)
-        Y = np.clip(Y, 0, np.Inf)
+        Y = np.clip(Y, 0, np.inf)
         estimator = sklearn.decomposition.NMF(n_components=n_components, init=init, tol=tol, **kwargs)
         time_components = estimator.fit_transform(Y)
         components_ = estimator.components_

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -594,7 +594,7 @@ class CNMF(object):
                 if self.params.get('patch', 'nb_patch') > 0:
 
                     while len(self.estimates.merged_ROIs) > 0:
-                        self.merge_comps(Yr, mx=np.Inf, fast_merge=True)
+                        self.merge_comps(Yr, mx=np.inf, fast_merge=True)
 
                     logger.info("update temporal")
                     self.update_temporal(Yr, use_init=False)
@@ -607,7 +607,7 @@ class CNMF(object):
                     self.update_temporal(Yr, use_init=False)
                 else:
                     while len(self.estimates.merged_ROIs) > 0:
-                        self.merge_comps(Yr, mx=np.Inf, fast_merge=True)
+                        self.merge_comps(Yr, mx=np.inf, fast_merge=True)
                         #if len(self.estimates.merged_ROIs) > 0:
                             #not_merged = np.setdiff1d(list(range(len(self.estimates.YrA))),
                             #                          np.unique(np.concatenate(self.estimates.merged_ROIs)))
@@ -626,7 +626,7 @@ class CNMF(object):
                         self.estimates.S = self.estimates.C
             else:
                 while len(self.estimates.merged_ROIs) > 0:
-                    self.merge_comps(Yr, mx=np.Inf)
+                    self.merge_comps(Yr, mx=np.inf)
 
                 logger.info("update temporal")
                 self.update_temporal(Yr, use_init=False)

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -1253,7 +1253,7 @@ def greedyROI_corr(Y, Y_ds, max_number=None, gSiz=None, gSig=None, center_psf=Tr
         logger.info('Merging components')
         A, C = caiman.source_extraction.cnmf.merging.merge_components(
             B, A, [], C, None, [], C, [], o, options['spatial'],
-            dview=None, thr=options['merging']['merge_thr'], mx=np.Inf, fast_merge=True)[:2]
+            dview=None, thr=options['merging']['merge_thr'], mx=np.inf, fast_merge=True)[:2]
         A = A.astype(np.float32)
         C = C.astype(np.float32)
         logger.info('Updating spatial components')
@@ -1302,7 +1302,7 @@ def greedyROI_corr(Y, Y_ds, max_number=None, gSiz=None, gSig=None, center_psf=Tr
         logger.info('Merging components')
         A, C = caiman.source_extraction.cnmf.merging.merge_components(
             B, A, [], C, None, [], C, [], o, options['spatial'],
-            dview=None, thr=options['merging']['merge_thr'], mx=np.Inf, fast_merge=True)[:2]
+            dview=None, thr=options['merging']['merge_thr'], mx=np.inf, fast_merge=True)[:2]
         A = A.astype(np.float32)
         C = C.astype(np.float32)
         logger.info('Updating spatial components')

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -381,7 +381,7 @@ def update_iteration(parrllcomp, len_parrllcomp, nb, C, S, bl, nr,
                          f" out of total {nr} temporal components updated")
 
         for ii in np.arange(nr, nr + nb):
-            cc = np.maximum(YrA[:, ii] + Cin[ii], -np.Inf)
+            cc = np.maximum(YrA[:, ii] + Cin[ii], -np.inf)
             YrA -= AA[ii, :].T.dot((cc - Cin[ii])[None, :]).T
             C[ii, :] = cc
 


### PR DESCRIPTION
# Description

NumPy 2.0 removed the `np.Inf` constant. To ensure compatibility with newer versions of NumPy, all instances of `np.Inf` have been replaced with `np.inf`. This change is fully backward-compatible, as `np.inf` has always been defined in NumPy.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break back-compatibility)
- [ ] Changes in documentation or new examples for demos and/or use cases.


# Has your PR been tested?

Verified that `np.inf` works across multiple NumPy versions.
