### PR TITLE
CNMF.initialization.greedyROI() - Add a limited mechanism to specify params in calls to sklearn's NMF

### DIFF
--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -941,7 +941,7 @@ def greedyROI(Y, nr=30, gSig=[5, 5], gSiz=[11, 11], nIter=5, kernel=None, nb=1,
         if 'init_method' in nmf_overrides:
             nmf_init_method = nmf_overrides['init_method']
 
-    model = NMF(n_components=nb, max_iter=max_iter_greedyroi, init=greedyroi_nmf_imethod)
+    model = NMF(n_components=nb, max_iter=nmf_max_iter, init=nmf_init_method)
 
     b_in = model.fit_transform(np.maximum(res, 0)).astype(np.float32)
     f_in = model.components_.astype(np.float32)

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -215,6 +215,14 @@ class CNMFParams(object):
             gSiz: [int, int], default: [int(round((x * 2) + 1)) for x in gSig],
                 half-size of bounding box for each neuron
 
+            greedyroi_nmf_init_method: str
+                When greedyROI is used, this is provided to sklearn's NMF() as the init method. Usually nndsvdar (the default)
+                is fine, but in some cases random or some other init is preferable; see the sklearn docs for your choices
+
+            greedyroi_nmf_max_iter: int
+                When greedyROI is used, this is provided to sklearn's NMF() as the max number of iterations; the ideal value
+                of this partly depends on the init method. See the sklearn docs for guidance.
+
             init_iter: int, default: 2
                 number of iterations during corr_pnr (1p) initialization
 
@@ -716,6 +724,8 @@ class CNMFParams(object):
             'gSig': gSig,
             # size of bounding box
             'gSiz': gSiz,
+            'greedyroi_nmf_init_method': 'nndsvdar', # init method used in calls to NMF if geedy_roi method for component initialisation is used (offline or online)
+            'greedyroi_nmf_max_iter': 200,           # max_iter used in calls to NMF if greedy_roi method for component initialisation is used (online or offline)
             'init_iter': init_iter,
             'kernel': None,           # user specified template for greedyROI
             'lambda_gnmf': 1,         # regularization weight for graph NMF


### PR DESCRIPTION
This adds a mechanism to greedyROI() to allow overriding of calls to sklearn's NMF(), passing in overrides as a dict.

(it also, as usual, includes some minor cleanups I spotted while looking at the code).

Will be WIP until the mechanism is plumbed up to CNMFParams, which will go through initialization.py:initialize_components() as well as utilities.py:manually_refine_components() although we may decide not to do it for the latter one maybe.

I went back-and-forth over whether to go with a dict or pass in params individually, but I think grouping them at least at this level is a little closer to where we eventually want to be - passing a structured deep dictionary parameters object around rather than having dozens of arguments everywhere and unwieldy gigantic signatures to all functions/methods.