### PR TITLE
Handle cases where parameters end up with bad values for OnACID given long movies

### DIFF
--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -115,6 +115,12 @@ class OnACID(object):
         self.dview = dview
         if Ain is not None:
             self.estimates.A = Ain
+        if self.params.motion['splits_rig'] > self.params.online['init_batch']/2:
+            raise Exception("In params, online.init_batch and motion.num_frames_split have incompatible values; consider increasing online.init_batch to be a small multiple of the other")
+            # See issue #1483; it would actually be better to change initialisation so it ignores splits_rig (either using a default
+            # value or providing an alternate parameter for that), but that's a much more intrusive change and would potentially
+            # change things for code/notebooks that've worked for a long time; we should save such changes for a major rewrite
+            # (if someone takes a particular interest in that).
 
     @profile
     def _prepare_object(self, Yr, T, new_dims=None, idx_components=None):

--- a/caiman/source_extraction/cnmf/params.py
+++ b/caiman/source_extraction/cnmf/params.py
@@ -885,8 +885,8 @@ class CNMFParams(object):
             'pw_rigid': False,                  # flag for performing pw-rigid motion correction
             'shifts_interpolate': False,        # interpolate shifts based on patch locations instead of resizing
             'shifts_opencv': True,              # flag for applying shifts using cubic interpolation (otherwise FFT)
-            'splits_els': 14,                   # number of splits across time for pw-rigid registration
-            'splits_rig': 14,                   # number of splits across time for rigid registration
+            'splits_els': 14,                   # number of splits across time for pw-rigid registration (usually overridden by code)
+            'splits_rig': 14,                   # number of splits across time for rigid    registration (usually overridden by code)
             'strides': (96, 96),                # how often to start a new patch in pw-rigid registration
             'upsample_factor_grid': 4,          # motion field upsampling factor during FFT shifts
             'use_cuda': False,                  # flag for using a GPU


### PR DESCRIPTION
This has the OnACID (online) constructor catch when the number of splits appropriate for mainline processing are bad for initialisation, telling the user they need to adjust provided parameters.

It's not necessarily the best way to handle this; I thought about:
A) having it automatically increase the batch size for initialisation, 
B) Having it ignore splits_rig for initialisation

On the first, it seems this would be a major change in behaviour of the code, possibly disrupting existing workflows (finding more components, increasing memory requirements, ???)
On the second, this would be a lot of work and may also change behaviour of the code in ways I can't anticipate

For now, raising an exception and letting the user handle it by providing different parameters seems less disruptive, and at least here we give the user some feedback on what to do rather than having it fail in numpy.

Addresses #1483 