### PR TITLE
Convert all uses of np.matrix to np.ndarray, handling API diffs

### DIFF
--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -34,9 +34,9 @@ def make_G_matrix(T, g):
     if isinstance(g, np.ndarray):
         if len(g) == 1 and g < 0:
             g = 0
-        gs = np.matrix(np.hstack((1, -(g[:]).T)))
-        ones_ = np.matrix(np.ones((T, 1)))
-        G = spdiags((ones_ * gs).T, list(range(0, -len(g) - 1, -1)), T, T)
+        gs = np.hstack((1, -(g[:]).T))
+        ones_ = np.ones((T, 1))
+        G = spdiags((ones_ @ gs).T, list(range(0, -len(g) - 1, -1)), T, T)
 
         return G
     else:

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -34,7 +34,7 @@ def make_G_matrix(T, g):
     if isinstance(g, np.ndarray):
         if len(g) == 1 and g < 0:
             g = 0
-        gs = np.hstack((1, -(g[:]).T))
+        gs = np.array([np.hstack((1, -(g[:]).T))])
         ones_ = np.ones((T, 1))
         G = spdiags((ones_ @ gs).T, list(range(0, -len(g) - 1, -1)), T, T)
 

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -926,9 +926,9 @@ def order_components(A, C):
     A = np.array(A.todense())
     nA2 = np.sqrt(np.sum(A**2, axis=0))
     K = len(nA2)
-    A = np.array(np.matrix(A) * spdiags(1./nA2, 0, K, K))
+    A = np.array(A @ spdiags(1./nA2, 0, K, K))
     nA4 = np.sum(A**4, axis=0)**0.25
-    C = np.array(spdiags(nA2, 0, K, K) * np.matrix(C))
+    C = np.array(spdiags(nA2, 0, K, K) @ C)
     mC = np.ndarray.max(np.array(C), axis=1)
     srt = np.argsort(nA4 * mC)[::-1]
     A_or = A[:, srt] * spdiags(nA2[srt], 0, K, K)

--- a/caiman/tests/test_temporal.py
+++ b/caiman/tests/test_temporal.py
@@ -11,7 +11,7 @@ def test_make_G_matrix():
     G = cnmf.temporal.make_G_matrix(T, g)
     G = G.todense()
     # yapf: disable
-    true_G = np.matrix(
+    true_G = np.array(
         [[1., 0., 0., 0., 0., 0.],
          [-1., 1., 0., 0., 0., 0.],
          [-2., -1., 1., 0., 0., 0.],

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -81,8 +81,7 @@ def view_patches(Yr, A, C, b, f, d1, d2, YrA=None, secs=1):
     A2.data **= 2
     nA2 = np.sqrt(np.array(A2.sum(axis=0))).squeeze()
     if YrA is None:
-        Y_r = np.array(A.T * np.matrix(Yr) - (A.T * np.matrix(b[:, np.newaxis])) * np.matrix(
-            f[np.newaxis]) - (A.T.dot(A)) * np.matrix(C) + C)
+        Y_r = np.array(A.T @ Yr - (A.T @ b[:, np.newaxis]) @ f[np.newaxis] - (A.T.dot(A)) @ C + C)
     else:
         Y_r = YrA + C
 
@@ -162,9 +161,8 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, thr=0.
     f = np.squeeze(f)
     if YrA is None:
         Y_r = np.array(spdiags(1 / nA2, 0, nr, nr) *
-                       (A.T * np.matrix(Yr) -
-                        (A.T * np.matrix(b[:, np.newaxis])) * np.matrix(f[np.newaxis]) -
-                        A.T.dot(A) * np.matrix(C)) + C)
+                       (A.T @ Yr -
+                        (A.T @ b[:, np.newaxis]) @ f[np.newaxis] - A.T.dot(A) @ C) + C)
     else:
         Y_r = C + YrA
 
@@ -321,9 +319,7 @@ def hv_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, denois
     if YrA is None:
         Y_r = np.array(
             spdiags(1 / nA2, 0, nr, nr) *
-            (A.T * np.matrix(Yr) -
-             (A.T * np.matrix(b[:, np.newaxis])) * np.matrix(f[np.newaxis]) -
-             A.T.dot(A) * np.matrix(C)) + C)
+            (A.T @ Yr - (A.T @ b[:, np.newaxis]) @ f[np.newaxis] - A.T.dot(A) @ C) + C)
     else:
         Y_r = C + YrA
     if image_neurons is None:


### PR DESCRIPTION
np.matrix is deprecated, and with changes made in numpy sometime back, it no longer offers a compelling use over np.ndarray. We now get deprecation warnings when using it; fortunately we don't pass np.matrix around that freely in the codebase so this hopefully is all we need to do.