### PR TITLE
np.shape(obj) to obj.shape

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -187,7 +187,7 @@ class movie(caiman.base.timeseries.timeseries):
                 median image
 
         """
-        T, d1, d2 = np.shape(self)
+        T, d1, d2 = self.shape
         num_windows = int(T // window)
         num_frames = num_windows * window
         return np.nanmedian(np.nanmean(np.reshape(self[:num_frames], (window, num_windows, d1, d2)), axis=0), axis=0)
@@ -207,7 +207,7 @@ class movie(caiman.base.timeseries.timeseries):
                 median image
 
         """
-        T, d1, d2, d3 = np.shape(self)
+        T, d1, d2, d3 = self.shape
         num_windows = int(T // window)
         num_frames = num_windows * window
         return np.nanmedian(np.nanmean(np.reshape(self[:num_frames], (window, num_windows, d1, d2, d3)), axis=0),
@@ -465,18 +465,18 @@ class movie(caiman.base.timeseries.timeseries):
         if np.min(self) <= 0 and method != 'only_baseline':
             raise ValueError("All pixels must be positive")
 
-        numFrames, linePerFrame, pixPerLine = np.shape(self)
+        numFrames, linePerFrame, pixPerLine = self.shape
         downsampfact = int(secsWindow * self.fr)
         logger.debug(f"Downsample factor: {downsampfact}")
         elm_missing = int(np.ceil(numFrames * 1.0 / downsampfact) * downsampfact - numFrames)
         padbefore = int(np.floor(elm_missing / 2.))
         padafter = int(np.ceil(elm_missing / 2.))
 
-        logger.debug(f'Initial Size Image: {np.shape(self)}')
+        logger.debug(f'Initial Size Image: {self.shape}')
         sys.stdout.flush()
         mov_out = movie(np.pad(self.astype(np.float32), ((padbefore, padafter), (0, 0), (0, 0)), mode='reflect'),
                         **self.__dict__)
-        numFramesNew, linePerFrame, pixPerLine = np.shape(mov_out)
+        numFramesNew, linePerFrame, pixPerLine = mov_out.shape
 
         # compute baseline quickly
         logger.debug("binning data ...")
@@ -540,7 +540,7 @@ class movie(caiman.base.timeseries.timeseries):
         """
 
         # vectorize the images
-        num_frames, h, w = np.shape(self)
+        num_frames, h, w = self.shape
         frame_size = h * w
         frame_samples = np.reshape(self, (num_frames, frame_size)).T
 
@@ -611,7 +611,7 @@ class movie(caiman.base.timeseries.timeseries):
         joint_ics = ica.fit_transform(eigenstuff)
 
         # extract the independent frames
-        _, h, w = np.shape(self)
+        _, h, w = self.shape
         frame_size = h * w
         ind_frames = joint_ics[:frame_size, :]
         ind_frames = np.reshape(ind_frames.T, (componentsICA, h, w))
@@ -623,7 +623,7 @@ class movie(caiman.base.timeseries.timeseries):
         Create a denoised version of the movie using only the first 'components' components
         """
         _, _, clean_vectors = self.IPCA(components, batch)
-        self = self.__class__(np.reshape(np.float32(clean_vectors.T), np.shape(self)), **self.__dict__)
+        self = self.__class__(np.reshape(np.float32(clean_vectors.T), self.shape), **self.__dict__)
         return self
 
     def local_correlations(self,
@@ -1214,7 +1214,7 @@ def load(file_name: Union[str, list[str]],
 
             if input_arr.ndim == 2:
                 if shape is not None:
-                    _, T = np.shape(input_arr)
+                    _, T = input_arr.shape
                     d1, d2 = shape
                     input_arr = np.transpose(np.reshape(input_arr, (d1, d2, T), order='F'), (2, 0, 1))
                 else:
@@ -1361,13 +1361,13 @@ def load_movie_chain(file_list: list[str],
             if m.ndim == 2:
                 m = m[np.newaxis, :, :]
 
-            _, h, w = np.shape(m)
+            _, h, w = m.shape
             m = m[:, top:h - bottom, left:w - right]
         else:
             if m.ndim == 3:
                 m = m[np.newaxis, :, :, :]
 
-            _, h, w, d = np.shape(m)
+            _, h, w, d = m.shape
             m = m[:, top:h - bottom, left:w - right, z_top:d - z_bottom]
 
         mov.append(m)

--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -123,14 +123,14 @@ def extract_binary_masks_from_structural_channel(Y,
 def mask_to_2d(mask):
     # todo todocument
     if mask.ndim > 2:
-        _, d1, d2 = np.shape(mask)
+        _, d1, d2 = mask.shape
         dims = d1, d2
         return scipy.sparse.coo_matrix(np.reshape(mask[:].transpose([1, 2, 0]), (
             np.prod(dims),
             -1,
         ), order='F'))
     else:
-        dims = np.shape(mask)
+        dims = mask.shape
         return scipy.sparse.coo_matrix(np.reshape(mask, (
             np.prod(dims),
             -1,
@@ -140,7 +140,7 @@ def mask_to_2d(mask):
 def get_distance_from_A(masks_gt, masks_comp, min_dist=10) -> list:
     # todo todocument
 
-    _, d1, d2 = np.shape(masks_gt)
+    _, d1, d2 = masks_gt.shape
     dims = d1, d2
     A_ben = scipy.sparse.csc_matrix(np.reshape(masks_gt[:].transpose([1, 2, 0]), (
         np.prod(dims),
@@ -214,7 +214,7 @@ def nf_match_neurons_in_binary_masks(masks_gt,
     """
     logger = logging.getLogger("caiman")
 
-    _, d1, d2 = np.shape(masks_gt)
+    _, d1, d2 = masks_gt.shape
     dims = d1, d2
 
     # transpose to have a sparse list of components, then reshaping it to have a 1D matrix red in the Fortran style
@@ -244,8 +244,8 @@ def nf_match_neurons_in_binary_masks(masks_gt,
 
     # compute precision and recall
     TP = np.sum(np.array(costs) < thresh_cost) * 1.
-    FN = np.shape(masks_gt)[0] - TP
-    FP = np.shape(masks_comp)[0] - TP
+    FN = masks_gt.shape[0] - TP
+    FP = masks_comp.shape[0] - TP
     TN = 0
 
     performance = dict()
@@ -259,9 +259,9 @@ def nf_match_neurons_in_binary_masks(masks_gt,
     idx_tp_ben = matches[0][idx_tp]    # ground truth
     idx_tp_cnmf = matches[1][idx_tp]   # algorithm - comp
 
-    idx_fn = np.setdiff1d(list(range(np.shape(masks_gt)[0])), matches[0][idx_tp])
+    idx_fn = np.setdiff1d(list(range(masks_gt.shape[0])), matches[0][idx_tp])
 
-    idx_fp = np.setdiff1d(list(range(np.shape(masks_comp)[0])), matches[1][idx_tp])
+    idx_fp = np.setdiff1d(list(range(masks_comp.shape[0])), matches[1][idx_tp])
 
     idx_fp_cnmf = idx_fp
 
@@ -736,8 +736,8 @@ def distance_masks(M_s:list, cm_s: list[list], max_dist: float, enclosed_thr: Op
         test_comp = test_comp.copy()[:, :]
 
         # the number of components for each
-        nb_gt = np.shape(gt_comp)[-1]
-        nb_test = np.shape(test_comp)[-1]
+        nb_gt   = gt_comp.shape[-1]
+        nb_test = test_comp.shape[-1]
         D = np.ones((nb_gt, nb_test))
 
         cmgt_comp = np.array(cmgt_comp)

--- a/caiman/behavior/behavior.py
+++ b/caiman/behavior/behavior.py
@@ -46,7 +46,7 @@ def select_roi(img: np.ndarray, n_rois: int = 1) -> list:
         fig = plt.figure()
         plt.imshow(img, cmap=matplotlib.cm.gray)
         pts = fig.ginput(0, timeout=0)
-        mask = np.zeros(np.shape(img), dtype=np.int32)
+        mask = np.zeros(img.shape, dtype=np.int32)
         pts = np.asarray(pts, dtype=np.int32)
         cv2.fillConvexPoly(mask, pts, (1, 1, 1), lineType=cv2.LINE_AA)
         masks.append(mask)
@@ -317,11 +317,11 @@ def extract_components(mov_tot,
             mov_tot = mov_tot / norm_fact[:, np.newaxis, np.newaxis, np.newaxis]
         else:
             norm_fact = np.array([1., 1.])
-        c, T, d1, d2 = np.shape(mov_tot)
+        c, T, d1, d2 = mov_tot.shape
 
     else:
         norm_fact = 1
-        T, d1, d2 = np.shape(mov_tot)
+        T, d1, d2 = mov_tot.shape
         c = 1
 
     tt = time.time()

--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -77,7 +77,7 @@ def compute_event_exceptionality(traces: np.ndarray,
         # Without this, numpy ranged syntax does not work correctly, and also N=0 is conceptually incoherent
         raise Exception("FATAL: N=0 is not a valid value for compute_event_exceptionality()")
 
-    T = np.shape(traces)[-1]
+    T = traces.shape[-1]
     if use_mode_fast:
         md = caiman.utils.stats.mode_robust_fast(traces, axis=1)
     else:
@@ -140,7 +140,7 @@ def find_activity_intervals(C, Npeaks: int = 5, tB=-3, tA=10, thres: float = 0.3
     # todo todocument
     logger = logging.getLogger("caiman")
 
-    K, T = np.shape(C)
+    K, T = C.shape
     L:list = []
     for i in range(K):
         if np.sum(np.abs(np.diff(C[i, :]))) == 0:
@@ -210,7 +210,7 @@ def classify_components_ep(Y, A, C, b, f, Athresh=0.1, Npeaks=5, tB=-3, tA=10, t
     """
     logger = logging.getLogger("caiman")
 
-    K, _ = np.shape(C)
+    K, _ = C.shape
     A = csc_matrix(A)
     AA = (A.T * A).toarray()
     nA = np.sqrt(np.array(A.power(2).sum(0)))
@@ -417,7 +417,7 @@ def evaluate_components(Y: np.ndarray,
     tB = np.minimum(-2, np.floor(-5. / 30 * final_frate))
     tA = np.maximum(5, np.ceil(25. / 30 * final_frate))
     logger.info(f'{tB=},{tA=}')
-    dims, T = np.shape(Y)[:-1], np.shape(Y)[-1]
+    dims, T = Y.shape[:-1], Y.shape[-1]
 
     Yr = np.reshape(Y, (np.prod(dims), T), order='F')
 
@@ -429,7 +429,7 @@ def evaluate_components(Y: np.ndarray,
 
     logger.debug('Removing Baseline')
     if remove_baseline:
-        num_samps_bl = np.minimum(np.shape(traces)[-1]// 5, 800)
+        num_samps_bl = np.minimum(traces.shape[-1]// 5, 800)
         slow_baseline = False
         if slow_baseline:
 
@@ -443,7 +443,7 @@ def evaluate_components(Y: np.ndarray,
             padbefore = int(np.floor(elm_missing / 2.))
             padafter = int(np.ceil(elm_missing / 2.))
             tr_tmp = np.pad(traces.T, ((padbefore, padafter), (0, 0)), mode='reflect')
-            numFramesNew, num_traces = np.shape(tr_tmp)
+            numFramesNew, num_traces = tr_tmp.shape
                                                                                              # compute baseline quickly
             logger.debug("binning data ...")
             tr_BL = np.reshape(tr_tmp, (downsampfact, numFramesNew // downsampfact, num_traces), order='F')

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -577,7 +577,7 @@ def parallel_dot_product(A: np.ndarray, b, block_size: int = 5000, dview=None, t
     logger = logging.getLogger("caiman")
 
     pars = []
-    d1, d2 = np.shape(A)
+    d1, d2 = A.shape
     b = pickle.dumps(b)
     logger.debug(f'parallel dot product block size: {block_size}')
 
@@ -598,9 +598,9 @@ def parallel_dot_product(A: np.ndarray, b, block_size: int = 5000, dview=None, t
     b = pickle.loads(b)
 
     if transpose:
-        output = np.zeros((d2, np.shape(b)[-1]), dtype=np.float32)
+        output = np.zeros((d2, b.shape[-1]), dtype=np.float32)
     else:
-        output = np.zeros((d1, np.shape(b)[-1]), dtype=np.float32)
+        output = np.zeros((d1, b.shape[-1]), dtype=np.float32)
 
     if dview is None:
         if transpose:

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -1002,7 +1002,7 @@ def bin_median(mat, window=10, exclude_nans=True):
             median image
     """
 
-    T, d1, d2 = np.shape(mat)
+    T, d1, d2 = mat.shape
     if T < window:
         window = T
     num_windows = int(T // window)
@@ -1031,7 +1031,7 @@ def bin_median_3d(mat, window=10, exclude_nans=True):
             median image
     """
 
-    T, d1, d2, d3 = np.shape(mat)
+    T, d1, d2, d3 = mat.shape
     if T < window:
         window = T
     num_windows = int(T // window)
@@ -1692,14 +1692,14 @@ def apply_shifts_dft(src_freq, shifts, diffphase, is_freq=True, border_nan=True)
             src_freq = np.array(src_freq, dtype=np.complex128, copy=False)
 
     if not is3D:
-        nr, nc = np.shape(src_freq)
+        nr, nc = src_freq.shape
         Nr = ifftshift(np.arange(-np.fix(nr/2.), np.ceil(nr/2.)))
         Nc = ifftshift(np.arange(-np.fix(nc/2.), np.ceil(nc/2.)))
         Nc, Nr = np.meshgrid(Nc, Nr)
         Greg = src_freq * np.exp(1j * 2 * np.pi *
                                  (-shifts[0] * Nr / nr - shifts[1] * Nc / nc))
     else:
-        nr, nc, nd = np.array(np.shape(src_freq), dtype=float)
+        nr, nc, nd = np.array(src_freq.shape, dtype=float)
         Nr = ifftshift(np.arange(-np.fix(nr / 2.), np.ceil(nr / 2.)))
         Nc = ifftshift(np.arange(-np.fix(nc / 2.), np.ceil(nc / 2.)))
         Nd = ifftshift(np.arange(-np.fix(nd / 2.), np.ceil(nd / 2.)))
@@ -2649,10 +2649,10 @@ def compute_metrics_motion_correction(fname, final_size_x, final_size_y, swap_di
     m_min = mi + (ma - mi) / 100
     m_max = mi + (ma - mi) / 4
 
-    max_shft_x = int(np.ceil((np.shape(m)[1] - final_size_x) / 2))
-    max_shft_y = int(np.ceil((np.shape(m)[2] - final_size_y) / 2))
-    max_shft_x_1 = - ((np.shape(m)[1] - max_shft_x) - (final_size_x))
-    max_shft_y_1 = - ((np.shape(m)[2] - max_shft_y) - (final_size_y))
+    max_shft_x = int(np.ceil((m.shape[1] - final_size_x) / 2))
+    max_shft_y = int(np.ceil((m.shape[2] - final_size_y) / 2))
+    max_shft_x_1 = - ((m.shape[1] - max_shft_x) - (final_size_x))
+    max_shft_y_1 = - ((m.shape[2] - max_shft_y) - (final_size_y))
     if max_shft_x_1 == 0:
         max_shft_x_1 = None
 

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -293,7 +293,7 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
     if gSiz is None:
         gSiz = 2 * (np.asarray(gSig) + .5).astype(int) + 1
 
-    d, T = np.shape(Y)[:-1], np.shape(Y)[-1]
+    d, T = Y.shape[:-1], Y.shape[-1]
     # rescale according to downsampling factor
     gSig = np.asarray(gSig, dtype=float) / ssub
     gSiz = np.round(np.asarray(gSiz) / ssub).astype(int)
@@ -371,7 +371,7 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
     else:
         raise Exception(f"Unsupported initialization method {method}")
 
-    K = np.shape(Ain)[-1]
+    K = Ain.shape[-1]
 
     if Ain.size > 0 and not center_psf and ssub != 1:
 
@@ -454,7 +454,7 @@ def ICA_PCA(Y_ds, nr, sigma_smooth=(.5, .5, .5), truncate=2, fun='logcosh',
         m1 = m
     pca_comp = nr
 
-    T, d1, d2 = np.shape(m1)
+    T, d1, d2 = m1.shape
     d = d1 * d2
     yr = np.reshape(m1, [T, d], order='F')
 
@@ -764,7 +764,7 @@ def greedyROI(Y, nr=30, gSig=[5, 5], gSiz=[11, 11], nIter=5, kernel=None, nb=1,
     """
     logger = logging.getLogger("caiman")
     logger.info(f"Greedy initialization of spatial and temporal components using spatial Gaussian filtering. Params={nmf_overrides}")
-    d = np.shape(Y)
+    d = Y.shape
     Y[np.isnan(Y)] = 0
     med = np.median(Y, axis=-1)
     Y = Y - med[..., np.newaxis]
@@ -1065,8 +1065,6 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv=True):
 
     else:
         X = scipy.ndimage.correlate(Y, kernel[..., np.newaxis], mode='constant')
-        # for t in range(np.shape(Y)[-1]):
-        #    X[:,:,t] = correlate(Y[:,:,t],kernel,mode='constant', cval=0.0)
 
     return X
 
@@ -1107,7 +1105,7 @@ def hals(Y, A, C, b, f, bSiz=3, maxIter=5):
     """
 
     # smooth the components
-    dims, T = np.shape(Y)[:-1], np.shape(Y)[-1]
+    dims, T = Y.shape[:-1], Y.shape[-1]
     K = A.shape[1]  # number of neurons
     nb = b.shape[1]  # number of background components
     if bSiz is not None:

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -252,13 +252,13 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
     for jj, fff in enumerate(file_res):
         if fff is not None:
             idx_, shapes, A, b, C, f, S, bl, c1, neurons_sn, g, sn, _, YrA = fff
-            for _ in range(np.shape(b)[-1]):
+            for _ in range(b.shape[-1]):
                 count_bgr += 1
 
             A = A.tocsc()
             if del_duplicates:
                 keep = []
-                for ii in range(np.shape(A)[-1]):
+                for ii in range(A.shape[-1]):
                     neuron_center = (np.array(scipy.ndimage.center_of_mass(
                         A[:, ii].toarray().reshape(shapes, order='F'))) -
                         np.array(shapes) / 2. + np.array(patch_centers[jj]))
@@ -276,7 +276,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
                     file_res[jj][10] = g[keep]
                 file_res[jj][-1] = YrA[keep]
 
-            # for ii in range(np.shape(A)[-1]):
+            # for ii in range(A.shape[-1]):
             #     new_comp = A[:, ii] / np.sqrt(A[:, ii].power(2).sum())
             #     if new_comp.sum() > 0:
             #         count += 1
@@ -332,7 +332,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
                 idx_ptr_B += list(b.indptr[1:] - b.indptr[:-1])
                 idx_tot_B.append(idx_[b.indices])
             else:
-                for ii in range(np.shape(b)[-1]):
+                for ii in range(b.shape[-1]):
                     b_tot.append(b[:, ii])
                     idx_tot_B.append(idx_)
                     idx_ptr_B.append(len(idx_))
@@ -343,7 +343,7 @@ def run_CNMF_patches(file_name, shape, params, gnb=1, dview=None,
             else:  # full background per patch
                 F_tot = np.concatenate([F_tot, f])
 
-            for ii in range(np.shape(A)[-1]):
+            for ii in range(A.shape[-1]):
                 new_comp = A[:, ii]  # / np.sqrt(A[:, ii].power(2).sum())
                 if new_comp.sum() > 0:
                     a_tot.append(new_comp.toarray().flatten())

--- a/caiman/source_extraction/cnmf/merging.py
+++ b/caiman/source_extraction/cnmf/merging.py
@@ -139,7 +139,7 @@ def merge_components(Y, A, b, C, R, f, S, sn_pix, temporal_params,
     if R is None:
         R = np.zeros_like(C)
 
-    [d, t] = np.shape(Y)
+    d, t = Y.shape
 
     # find graph of overlapping spatial components
     A_corr = scipy.sparse.triu(A.T * A)
@@ -169,7 +169,7 @@ def merge_components(Y, A, b, C, R, f, S, sn_pix, temporal_params,
     list_conxcomp = np.asarray(list_conxcomp_initial).T
 
     if list_conxcomp.ndim > 1:
-        cor = np.zeros((np.shape(list_conxcomp)[1], 1))
+        cor = np.zeros((list_conxcomp.shape[1], 1))
         for i in range(np.size(cor)):
             fm = np.where(list_conxcomp[:, i])[0]
             for j1 in range(np.size(fm)):

--- a/caiman/source_extraction/cnmf/online_cnmf.py
+++ b/caiman/source_extraction/cnmf/online_cnmf.py
@@ -1781,7 +1781,7 @@ def demix_and_deconvolve(C, noisyC, AtY, AtA, OASISinstances, iters=3, n_refit=0
 def init_shapes_and_sufficient_stats(Y, A, C, b, f, W=None, b0=None, ssub_B=1, bSiz=3,
                                      downscale_matrix=None, upscale_matrix=None):
     # smooth the components
-    dims, T = np.shape(Y)[:-1], np.shape(Y)[-1]
+    dims, T = Y.shape[:-1], Y.shape[-1]
     K = A.shape[1]  # number of neurons
     if W is None:
         nb = b.shape[1]  # number of background components
@@ -2154,7 +2154,7 @@ def update_num_components(t, sv, Ab, Cf, Yres_buf, Y_buf, rho_buf,
     gHalf = np.array(gSiz) // 2
 
     # number of total components (including background)
-    M = np.shape(Ab)[-1]
+    M = Ab.shape[-1]
     N = M - gnb                 # number of components (without background)
 
     if corr_img is None:

--- a/caiman/source_extraction/cnmf/pre_processing.py
+++ b/caiman/source_extraction/cnmf/pre_processing.py
@@ -114,7 +114,7 @@ def get_noise_welch(Y, noise_range=[0.25, 0.5], noise_method='logmexp',
                             Y[..., int(T // 2 - max_num_samples_fft / 3 / 2):
                             int(T // 2 + max_num_samples_fft / 3 / 2)],
                             Y[..., -max_num_samples_fft // 3:]), axis=-1)
-        T = np.shape(Y)[-1]
+        T = Y.shape[-1]
     ff, Pxx = scipy.signal.welch(Y)
     Pxx = Pxx[..., (ff >= noise_range[0]) & (ff <= noise_range[1])]
     sn = {
@@ -156,7 +156,7 @@ def get_noise_fft(Y, noise_range=[0.25, 0.5], noise_method='logmexp', max_num_sa
                             Y[..., int(T // 2 - max_num_samples_fft / 3 / 2)
                                           :int(T // 2 + max_num_samples_fft / 3 / 2)],
                             Y[..., -max_num_samples_fft // 3:]), axis=-1)
-        T = np.shape(Y)[-1]
+        T = Y.shape[-1]
 
     # we create a map of what is the noise on the FFT space
     ff = np.arange(0, 0.5 + 1. / T, 1. / T)
@@ -396,7 +396,7 @@ def estimate_time_constant(Y, sn, p=None, lags=5, include_noise=False, pixels=No
     if p is None:
         raise Exception("You need to define p")
     if pixels is None:
-        pixels = np.arange(np.size(Y) // np.shape(Y)[-1])
+        pixels = np.arange(np.size(Y) // Y.shape[-1])
 
     npx = len(pixels)
     lags += p

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -186,7 +186,7 @@ def update_spatial_components(Y, C=None, f=None, A_in=None, sn=None, dims=None,
         ind_list = np.array(ind_list, dtype=int)
         ind2_ = [ind_list[np.setdiff1d(a,ff)] if len(a) else a for a in ind2_]
 
-    nr = np.shape(C)[0]
+    nr = C.shape[0]
     if normalize_yyt_one and C is not None:
         C = np.array(C)
         d_ = scipy.sparse.lil_matrix((nr, nr))
@@ -371,7 +371,7 @@ def regression_ipyparallel(pars):
     else:
         C = C_name
 
-    _, T = np.shape(C)  # initialize values
+    _, T = C.shape  # initialize values
     As = []
     for y, px, idx_px_from_0 in zip(Y, idxs_Y, range(len(idxs_C))):
         c = C[idxs_C[idx_px_from_0], :]
@@ -491,7 +491,7 @@ def threshold_components(A, dims, medw=None, thr_method='max', maxthr=0.1, nrgth
     if ss is None:
         ss = np.ones((3,) * len(dims), dtype='uint8')
     # dims and nm of neurones
-    d, nr = np.shape(A)
+    d, nr = A.shape
     # instantiation of A thresh.
     #Ath = np.zeros((d, nr))
     pars = []
@@ -783,17 +783,15 @@ def test(Y, A_in, C, f, n_pixels_per_process, nb):
         if len(A_in.shape) == 1:
             A_in = np.atleast_2d(A_in).T
             if A_in.shape[0] == 1:
-                raise Exception(
-                    'Dimension of Matrix A must be pixels x neurons ')
+                raise Exception('Dimension of Matrix A must be pixels x neurons ')
 
-    [d, T] = np.shape(Y)
+    [d, T] = Y.shape
 
     if A_in is None:
-        A_in = np.ones((d, np.shape(C)[1]), dtype=bool)
+        A_in = np.ones((d, C.shape[1]), dtype=bool)
 
     if n_pixels_per_process > d:
-        print('The number of pixels per process (n_pixels_per_process)'
-              ' is larger than the total number of pixels!! Decreasing suitably.')
+        print(f'The number of pixels per process (n_pixels_per_process:{n_pixels_per_process}) is larger than the total number of pixels. Decreasing suitably.')
         n_pixels_per_process = d
 
     if f is not None:
@@ -850,7 +848,7 @@ def determine_search_location(A, dims, method='ellipse', min_size=3, max_size=8,
         d1, d2 = dims
     elif len(dims) == 3:
         d1, d2, d3 = dims
-    d, nr = np.shape(A)
+    d, nr = A.shape
     A = csc_matrix(A)
 #    dist_indicator = scipy.sparse.lil_matrix((d, nr),dtype= np.float32)
 #    dist_indicator = scipy.sparse.csc_matrix((d, nr), dtype=np.float32)
@@ -1062,7 +1060,7 @@ def computing_indicator(Y, A_in, b, C, f, nb, method, dims, min_size, max_size, 
             C = np.maximum(csr_matrix(dist_indicator_av.T).dot(
                 Y) - dist_indicator_av.T.dot(b).dot(f), 0)
             A_in = scipy.sparse.coo_matrix(A_in.astype(np.float32))
-            nr, _ = np.shape(C)  # number of neurons
+            nr, _ = C.shape  # number of neurons
             ind2_ = [np.hstack((np.where(iid_)[0], nr + np.arange(f.shape[0])))
                      if np.size(np.where(iid_)[0]) > 0 else [] for iid_ in dist_indicator]
 
@@ -1070,7 +1068,7 @@ def computing_indicator(Y, A_in, b, C, f, nb, method, dims, min_size, max_size, 
         if C is None:
             raise Exception('You need to provide estimate of C and f')
 
-        nr, _ = np.shape(C)  # number of neurons
+        nr, _ = C.shape  # number of neurons
 
         if b is None:
             dist_indicator = determine_search_location(

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -49,7 +49,7 @@ def constrained_foopsi_parallel(arg_in):
     """
 
     Ytemp, nT, jj_, bl, c1, g, sn, argss = arg_in
-    T = np.shape(Ytemp)[0]
+    T = Ytemp.shape[0]
     cc_, cb_, c1_, gn_, sn_, sp_, lam_ = caiman.source_extraction.cnmf.deconvolution.constrained_foopsi(
         Ytemp, bl=bl, c1=c1, g=g, sn=sn, **argss)
     gd_ = np.max(np.real(np.roots(np.hstack((1, -gn_.T)))))
@@ -174,8 +174,8 @@ def update_temporal_components(Y, A, b, Cin, fin, bl=None, c1=None, g=None, sn=N
         raise Exception("You have to provide a value for p")
 
     # INITIALIZATION OF VARS
-    d, T = np.shape(Y)
-    nr = np.shape(A)[-1]
+    d, T = Y.shape
+    nr = A.shape[-1]
     if b is not None:
         # if b.shape[0] < b.shape[1]:
         #     b = b.T
@@ -193,7 +193,7 @@ def update_temporal_components(Y, A, b, Cin, fin, bl=None, c1=None, g=None, sn=N
         sn = np.repeat(None, nr)
 
     A = scipy.sparse.hstack((A, b)).tocsc()
-    S = np.zeros(np.shape(Cin))
+    S = np.zeros(Cin.shape)
     Cin = np.vstack((Cin, fin))
     C = Cin.copy()
     nA = np.ravel(A.power(2).sum(axis=0)) + np.finfo(np.float32).eps

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -572,7 +572,7 @@ def fast_prct_filt(input_data, level=8, frames_window=1000):
     """
 
     data = np.atleast_2d(input_data).copy()
-    T = np.shape(data)[-1]
+    T = data.shape[-1]
     downsampfact = frames_window
 
     elm_missing = int(np.ceil(T * 1.0 / downsampfact)
@@ -580,7 +580,7 @@ def fast_prct_filt(input_data, level=8, frames_window=1000):
     padbefore = int(np.floor(elm_missing / 2.))
     padafter = int(np.ceil(elm_missing / 2.))
     tr_tmp = np.pad(data.T, ((padbefore, padafter), (0, 0)), mode='reflect')
-    numFramesNew, num_traces = np.shape(tr_tmp)
+    numFramesNew, num_traces = tr_tmp.shape
     # compute baseline quickly
 
     tr_BL = np.reshape(tr_tmp, (downsampfact, int(numFramesNew / downsampfact),
@@ -743,8 +743,8 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
     else:
         A = np.array(A)
 
-    d1, d2 = np.shape(Cn)
-    d, nr = np.shape(A)
+    d1, d2 = Cn.shape
+    d, nr  = A.shape
     if max_number is None:
         max_number = nr
 
@@ -760,9 +760,9 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
         cumEn /= cumEn[-1]
         Bvec = np.zeros(d)
         Bvec[indx] = cumEn
-        Bmat[i] = np.reshape(Bvec, np.shape(Cn), order='F')
+        Bmat[i] = np.reshape(Bvec, Cn.shape, order='F')
 
-    T = np.shape(Y)[-1]
+    T = Y.shape[-1]
 
     plt.close()
     fig = plt.figure()
@@ -792,7 +792,7 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
             y3_tiny = Y[coords_y[0]:coords_y[-1] +
                         1, coords_x[0]:coords_x[-1] + 1, :]
 
-            dy_sz, dx_sz = np.shape(a3_tiny)[:-1]
+            dy_sz, dx_sz = a3_tiny.shape[:-1]
             y2_tiny = np.reshape(y3_tiny, (dx_sz * dy_sz, T), order='F')
             a2_tiny = np.reshape(a3_tiny, (dx_sz * dy_sz, nr), order='F')
             y2_res = y2_tiny - a2_tiny.dot(C)
@@ -812,7 +812,7 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
             cumEn /= cumEn[-1]
             Bvec = np.zeros(d)
             Bvec[indx] = cumEn
-            bmat = np.reshape(Bvec, np.shape(Cn), order='F')
+            bmat = np.reshape(Bvec, Cn.shape, order='F')
             plt.contour(y, x, bmat, [thr])
             plt.pause(.01)
 
@@ -869,7 +869,7 @@ def update_order(A, new_a=None, prev_list=None, method='greedy'):
 
     Written by Eftychios A. Pnevmatikakis, Simons Foundation, 2015
     '''
-    K = np.shape(A)[-1]
+    K = A.shape[-1]
     if new_a is None and prev_list is None:
 
         if method == 'greedy':
@@ -941,7 +941,7 @@ def update_order_random(A, flag_AA=True):
     randomized partitions of non-overlapping components
     """
 
-    K = np.shape(A)[-1]
+    K = A.shape[-1]
     if flag_AA:
         AA = A.copy()
     else:
@@ -992,7 +992,7 @@ def update_order_greedy(A, flag_AA=True):
     Author:
         Eftychios A. Pnevmatikakis, Simons Foundation, 2017
     """
-    K = np.shape(A)[-1]
+    K = A.shape[-1]
     parllcomp:list = []
     for i in range(K):
         new_list = True

--- a/caiman/summary_images.py
+++ b/caiman/summary_images.py
@@ -206,7 +206,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
     if swap_dim:
         Y = np.transpose(Y, tuple(np.hstack((Y.ndim - 1, list(range(Y.ndim))[:-1]))))
 
-    rho = np.zeros(np.shape(Y)[1:])
+    rho = np.zeros(Y.shape[1:])
     w_mov = (Y - np.mean(Y, axis=0)) / np.std(Y, axis=0)
 
     rho_h = np.mean(np.multiply(w_mov[:, :-1, :], w_mov[:, 1:, :]), axis=0)
@@ -214,7 +214,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
 
     # yapf: disable
     if order_mean == 0:
-        rho = np.ones(np.shape(Y)[1:])
+        rho = np.ones(Y.shape[1:])
         rho_h = rho_h
         rho_w = rho_w
         rho[:-1, :] = rho[:-1, :] * rho_h
@@ -232,7 +232,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
         rho[:, :, :-1] = rho[:, :, :-1] + rho_d
         rho[:, :, 1:] = rho[:, :, 1:] + rho_d
 
-        neighbors = 6 * np.ones(np.shape(Y)[1:])
+        neighbors = 6 * np.ones(Y.shape[1:])
         neighbors[0]        = neighbors[0]        - 1
         neighbors[-1]       = neighbors[-1]       - 1
         neighbors[:,     0] = neighbors[:,     0] - 1
@@ -258,7 +258,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
                 rho[1:,  :-1] = rho[1:,  :-1] + rho_d1**(order_mean)
                 rho[:-1,  1:] = rho[:-1,  1:] + rho_d2**(order_mean)
 
-            neighbors = 8 * np.ones(np.shape(Y)[1:3])
+            neighbors = 8 * np.ones(Y.shape[1:3])
             neighbors[0,   :] = neighbors[0,   :] - 3
             neighbors[-1,  :] = neighbors[-1,  :] - 3
             neighbors[:,   0] = neighbors[:,   0] - 3
@@ -268,7 +268,7 @@ def local_correlations(Y, eight_neighbours: bool = True, swap_dim: bool = True, 
             neighbors[-1,  0] = neighbors[-1,  0] + 1
             neighbors[0,  -1] = neighbors[0,  -1] + 1
         else:
-            neighbors = 4 * np.ones(np.shape(Y)[1:3])
+            neighbors = 4 * np.ones(Y.shape[1:3])
             neighbors[0,  :]  = neighbors[0,  :] - 1
             neighbors[-1, :]  = neighbors[-1, :] - 1
             neighbors[:,  0]  = neighbors[:,  0] - 1

--- a/caiman/tests/comparison/create_gt.py
+++ b/caiman/tests/comparison/create_gt.py
@@ -147,7 +147,7 @@ def create():
     m_orig = cm.load(fname)
     min_mov = m_orig[:400].min()
     comp = comparison.Comparison()
-    comp.dims = np.shape(m_orig)[1:]
+    comp.dims = m_orig.shape[1:]
 
     ################ RIG CORRECTION #################
     t1 = time.time()

--- a/caiman/tests/comparison_general.py
+++ b/caiman/tests/comparison_general.py
@@ -150,7 +150,7 @@ def test_general():
     m_orig = cm.load(fname)
     min_mov = m_orig[:400].min()
     comp = comparison.Comparison()
-    comp.dims = np.shape(m_orig)[1:]
+    comp.dims = m_orig.shape[1:]
 
     ################ RIG CORRECTION #################
     t1 = time.time()

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -396,7 +396,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
 
     if 'csc_matrix' not in str(type(A)):
         A = csc_matrix(A)
-    d, nr = np.shape(A)
+    d, nr = A.shape
 
     coordinates = []
 
@@ -570,8 +570,8 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
 
         plt.close()
         K = np.max([[len(cor['coordinates']) for cor in cc] for cc in coors])
-        cc1 = np.nan * np.zeros(np.shape(coors) + (K,))
-        cc2 = np.nan * np.zeros(np.shape(coors) + (K,))
+        cc1 = np.nan * np.zeros(coors.shape + (K,))
+        cc2 = np.nan * np.zeros(coors.shape + (K,))
         for i, cor in enumerate(coors[0]):
             cc1[0, i, :len(cor['coordinates'])
                 ] = cor['coordinates'][:, 0] + offset1
@@ -848,7 +848,7 @@ def nb_plot_contour(image, A, d1, d2, thr=None, thr_method='max', maxthr=0.2, nr
     p.circle(center[:, 1], center[:, 0], size=10, color="black",
              fill_color=None, line_width=2, alpha=1)
     if coordinates is None:
-        coors = get_contours(A, np.shape(image), thr, thr_method)
+        coors = get_contours(A, image.shape, thr, thr_method)
     else:
         coors = coordinates
     cc1 = [np.clip(cor['coordinates'][1:-1, 0], 0, d2) for cor in coors]
@@ -1099,7 +1099,7 @@ def plot_contours(A, Cn, thr=None, thr_method='max', maxthr=0.2, nrgthr=0.9, dis
         plt.imshow(Cn, interpolation=None, cmap=cmap, vmin=vmin, vmax=vmax)
 
     if coordinates is None:
-        coordinates = get_contours(A, np.shape(Cn), thr, thr_method, swap_dim)
+        coordinates = get_contours(A, Cn.shape, thr, thr_method, swap_dim)
     for c in coordinates:
         v = c['coordinates']
         c['bbox'] = [np.floor(np.nanmin(v[:, 1])), np.ceil(np.nanmax(v[:, 1])),

--- a/demos/general/demo_behavior.py
+++ b/demos/general/demo_behavior.py
@@ -90,7 +90,7 @@ def main():
         spfl = spatial_filter
         spfl = cm.movie(spfl[None, :, :]).resize(
             1 / resize_fact, 1 / resize_fact, 1).squeeze()
-        max_x, max_y = np.add((min_x, min_y), np.shape(spfl))
+        max_x, max_y = np.add((min_x, min_y), spfl.shape)
 
         mask[min_x:max_x, min_y:max_y] = spfl
         mask[mask < np.nanpercentile(spfl, 70)] = np.nan


### PR DESCRIPTION
Replace all uses of np.shape(obj) with obj.shape

The only thing this might break is if people ignore docs and pass in things that are not numpy objects in; np.shape([1,2,3,4]) returns (4,) while [1,2,3,4].shape gets you an AttributeError. It's worth missing out on that for the sake of cleaner code (and people really should pass compatible types in).