### PR TITLE
Set default add_to_movie = 0.0001

### DIFF
--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -177,7 +177,7 @@ def save_memmap_each(fnames: list[str],
     return fnames_new
 
 def save_memmap_join(mmap_fnames:list[str], base_name: str = None, n_chunks: int = 20, dview=None,
-                     add_to_mov=0) -> str:
+                     add_to_mov: float = 0) -> str:
     """
     Makes a large file memmap from a number of smaller files
 
@@ -363,7 +363,7 @@ def save_memmap(filenames:list[str],
                 var_name_hdf5: str = 'mov',
                 xy_shifts: Optional[list] = None,
                 is_3D: bool = False,
-                add_to_movie: float = 0,
+                add_to_movie: float = 0.0001,
                 border_to_0=0,
                 dview=None,
                 n_chunks: int = 100,
@@ -449,7 +449,7 @@ def save_memmap(filenames:list[str],
                                               xy_shifts=xy_shifts,
                                               is_3D=is_3D,
                                               slices=slices,
-                                              add_to_movie=add_to_movie)
+                                              add_to_movie=0)  # applied below in save_memmap_join
         else:
             fname_parts = filenames
 
@@ -458,7 +458,7 @@ def save_memmap(filenames:list[str],
             raise Exception('You cannot merge files in F order, they must be in C order')
 
         fname_new = caiman.save_memmap_join(fname_parts, base_name=base_name,
-                                        dview=dview, n_chunks=n_chunks)
+                                        dview=dview, n_chunks=n_chunks, add_to_mov=add_to_movie)
 
     else:
         # TODO: can be done online
@@ -505,7 +505,7 @@ def save_memmap(filenames:list[str],
                 if slices is not None:
                     if isinstance(slices, list):
                         raise Exception(
-                            'You cannot slice in x and y and then use add_to_movie: if you only want to slice in time do not pass in a list but just a slice object'
+                            'You cannot slice in x and y and then use border_to_0: if you only want to slice in time do not pass in a list but just a slice object'
                         )
 
                 min_mov = Yr.calc_min()
@@ -523,7 +523,7 @@ def save_memmap(filenames:list[str],
             T, dims = Yr.shape[0], Yr.shape[1:]
             Yr = np.transpose(Yr, list(range(1, len(dims) + 1)) + [0])
             Yr = np.reshape(Yr, (np.prod(dims), T), order='F')
-            Yr = np.ascontiguousarray(Yr, dtype=np.float32) + np.float32(0.0001) + np.float32(add_to_movie)
+            Yr = np.ascontiguousarray(Yr, dtype=np.float32) + np.float32(add_to_movie)
 
             if idx == 0:
                 fname_tot = caiman.paths.generate_fname_tot(base_name, dims, order)

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -177,7 +177,7 @@ def save_memmap_each(fnames: list[str],
     return fnames_new
 
 def save_memmap_join(mmap_fnames:list[str], base_name: str = None, n_chunks: int = 20, dview=None,
-                     add_to_mov: float = 0) -> str:
+                     add_to_mov: float = 0.0) -> str:
     """
     Makes a large file memmap from a number of smaller files
 
@@ -190,7 +190,7 @@ def save_memmap_join(mmap_fnames:list[str], base_name: str = None, n_chunks: int
 
         dview: cluster handle
 
-        add_to_mov: (undocumented)
+        add_to_mov: constant to add to the entire movie
 
     """
     logger = logging.getLogger("caiman")
@@ -449,7 +449,7 @@ def save_memmap(filenames:list[str],
                                               xy_shifts=xy_shifts,
                                               is_3D=is_3D,
                                               slices=slices,
-                                              add_to_movie=0)  # applied below in save_memmap_join
+                                              add_to_movie=0.0)  # applied below in save_memmap_join
         else:
             fname_parts = filenames
 


### PR DESCRIPTION
# Description

Partially addresses #1533 - clarifies the behavior of `save_memmap` by pulling the 0.0001 that is currently added in almost all cases into the default value of `add_to_movie`. See the issue page for more discussion - we are still considering adding more robust checks for negative or invalid values.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would break back-compatibility)

Technically this could be a breaking change in 2 edge cases:
- The input is a list of multiple .mmap files, which are being concatenated without transposing, slicing or indexing dimensions, adding any constant value, removing initial frames, or setting a border. In this case, currently no constant is added, whereas with this change 0.0001 will always be added by default.
- A non-default value is used for `add_to_movie`; currently, 0.0001 will be added in addition to this value, whereas with this change the value will be used exactly. It probably will not make a difference in most cases and the current behavior is considered a bug.

# Has your PR been tested?

I did not run tests on this exact commit myself because I do not have the environment set up to use pytorch, but I did cherry-pick it onto main and run `caimanmanager test`, and all tests pass.