### PR TITLE
Numpy 2.x

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -1360,9 +1360,9 @@ def register_translation_3d(src_image, target_image, upsample_factor = 1,
     # real data needs to be fft'd.
     elif space.lower() == 'real':
         src_image_cpx = np.array(
-            src_image, dtype=np.complex64, copy=False)
+            src_image, dtype=np.complex64, copy=None)
         target_image_cpx = np.array(
-            target_image, dtype=np.complex64, copy=False)
+            target_image, dtype=np.complex64, copy=None)
         src_freq = np.fft.fftn(src_image_cpx)
         target_freq = np.fft.fftn(target_image_cpx)
     else:
@@ -1553,12 +1553,12 @@ def register_translation(src_image, target_image, upsample_factor=1,
         src_freq_1 = cv2.dft(
             src_image, flags=cv2.DFT_COMPLEX_OUTPUT + cv2.DFT_SCALE)
         src_freq = src_freq_1[:, :, 0] + 1j * src_freq_1[:, :, 1]
-        src_freq = np.array(src_freq, dtype=np.complex128, copy=False)
+        src_freq = np.array(src_freq, dtype=np.complex128, copy=None)
         target_freq_1 = cv2.dft(
             target_image, flags=cv2.DFT_COMPLEX_OUTPUT + cv2.DFT_SCALE)
         target_freq = target_freq_1[:, :, 0] + 1j * target_freq_1[:, :, 1]
         target_freq = np.array(
-            target_freq, dtype=np.complex128, copy=False)
+            target_freq, dtype=np.complex128, copy=None)
     else:
         raise ValueError('Error: register_translation only knows the "real" and "fourier" values for the ``space`` argument.')
 
@@ -1693,7 +1693,7 @@ def apply_shifts_dft(src_freq, shifts, diffphase, is_freq=True, border_nan=True)
             src_freq = np.dstack([np.real(src_freq), np.imag(src_freq)])
             src_freq = cv2.dft(src_freq, flags=cv2.DFT_COMPLEX_OUTPUT + cv2.DFT_SCALE)
             src_freq = src_freq[:, :, 0] + 1j * src_freq[:, :, 1]
-            src_freq = np.array(src_freq, dtype=np.complex128, copy=False)
+            src_freq = np.array(src_freq, dtype=np.complex128, copy=None)
 
     if not is3D:
         nr, nc = src_freq.shape

--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -503,7 +503,7 @@ def recursively_save_dict_contents_to_group(h5file:h5py.File, path:str, dic:dict
 
         if isinstance(item, (list, tuple)):
             if len(item) > 0 and all(isinstance(elem, str) for elem in item):
-                item = np.string_(item)
+                item = np.bytes_(item)
             else:
                 item = np.array(item)
         if not isinstance(key, str):

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -12,7 +12,7 @@ dependencies:
 - keras
 - matplotlib
 - moviepy
-- numpy
+- numpy >=2.0.0
 - numpydoc
 - opencv
 - peakutils >=1.3.5

--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -12,7 +12,7 @@ dependencies:
 - keras
 - matplotlib
 - moviepy
-- numpy <2.0.0,>=1.26
+- numpy
 - numpydoc
 - opencv
 - peakutils >=1.3.5

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - matplotlib
 - moviepy
 - mypy
-- numpy
+- numpy >=2.0.0
 - numpydoc
 - opencv
 - panel >=1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - matplotlib
 - moviepy
 - mypy
-- numpy <2.0.0,>=1.26
+- numpy
 - numpydoc
 - opencv
 - panel >=1.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "matplotlib",
   "moviepy",
   "mypy",
-  "numpy",
+  "numpy >= 2.0.0",
   "numpydoc",
   "opencv-python",
   "panel >= 1.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "matplotlib",
   "moviepy",
   "mypy",
-  "numpy <2.0.0, >=1.26",
+  "numpy",
   "numpydoc",
   "opencv-python",
   "panel >= 1.0.2",


### PR DESCRIPTION
This tries to address the big issues with #1354, using the copy=None flag to the numpy.array constructor which is semantically close to the numpy 1.x behaviour (don't copy if you don't need to, but if you do don't error out). It also lifts the pin.

I don't think this works on numpy 1.x; we may actually need a minimum version pin, as it looks like the typedef for NPY_COPYMODE is a 2.x thing (the numpy codebase is not that easy to read though, both because these parts are a mix of C and python and because they use a lot of abstraction). The docs kind of imply that it's ok to pass none, but empirical tests suggest otherwise.

Numpy 1.x:
```
>>> import numpy as np
>>> data = np.array([[1,2,3,4],[2,3,4,5]])
>>> data
array([[1, 2, 3, 4],
       [2, 3, 4, 5]])
>>> data2 = np.array(data, copy=None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: NoneType copy mode not allowed.
```

Numpy  2.x:
```
>>> import numpy as np
>>> data = np.array([[1,2,3,4],[2,3,4,5]])
>>> data2 = np.array(data, copy=None)
```
