### PR TITLE
Update scikit-image version to 0.25.0

### DIFF
--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyside6
 - pytest
 - pytorch
-- scikit-image >=0.19.0
+- scikit-image==0.25.0
 - scikit-learn >=1.2
 - scipy >= 1.10.1
 - tifffile

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytorch
-- scikit-image >=0.19.0
+- scikit-image==0.25.0
 - scikit-learn >=1.2
 - scipy >= 1.10.1
 - tifffile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "pytest",
   "pytest-cov",
   "torch",
-  "scikit-image >= 0.19.0",
+  "scikit-image==0.25.0",
   "scikit-learn >= 1.2",
   "scipy >= 1.10.1",
   "torchvision",


### PR DESCRIPTION
# Description
Update scikit-image version to 0.25.0 due to the version 0.26 skimage.morphology.dilation() not having the 'shift_x' argument which in turn create a bug in colpy.spikepursuit.volspike.

Fixes # (issue)

Demo: 'demo_pipeline_voltage_imaging'

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

