### PR TITLE
Fix saved movie scaling

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -2059,7 +2059,7 @@ def play_movie(movie,
                     if save_movie:
                         if frame.ndim < 3:
                             frame = np.repeat(frame[:, :, None], 3, axis=-1)
-                        frame = frame.astype('u1') 
+                        frame = np.clip((frame * 255.), 0, 255).astype('u1')
                         out.write(frame)
                     if backend == 'opencv' and (cv2.waitKey(int(1. / fr * 1000)) & 0xFF == ord('q')):
                         looping = False


### PR DESCRIPTION
# Description

Fixes the lack of scaling to `uint8` in saved OpenCV movies.

Fixes #1553 

# Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

This PR is currently failing these tests on `caimanmanager test` 

```
FAILED caiman/tests/test_motion_correction.py::test_register_n_apply - ValueError: NoneType copy mode not allowed.
FAILED caiman/tests/test_motion_correction.py::test_register_n_apply_3d - ValueError: NoneType copy mode not allowed.
FAILED caiman/tests/test_motion_correction.py::test_tile_and_correct - ValueError: NoneType copy mode not allowed.
FAILED caiman/tests/test_motion_correction.py::test_tile_and_correct_3d - ValueError: NoneType copy mode not allowed.
FAILED caiman/tests/test_motion_correction.py::test_motion_correct_rigid - ValueError: NoneType copy mode not allowed.
FAILED caiman/tests/test_motion_correction.py::test_motion_correct_rigid_3d - ValueError: NoneType copy mode not allowed.                                                                                                                                        
```

Also, I'm getting some errors while running `caimanmanager demotest`.  However, I'm getting the same errors and failed tests in the `dev` branch and the bug in the issue minimal example was fixed.