### PR TITLE
Test fixes related to pytorch & numpy

### DIFF
--- a/caiman/source_extraction/cnmf/pre_processing.py
+++ b/caiman/source_extraction/cnmf/pre_processing.py
@@ -223,7 +223,7 @@ def get_noise_fft_parallel(Y, n_pixels_per_process=100, dview=None, **kwargs):
     pixel_groups = list(
         range(0, Y.shape[0] - n_pixels_per_process + 1, n_pixels_per_process))
 
-    if isinstance(Y, np.core.memmap):  # if input file is already memory mapped then find the filename
+    if isinstance(Y, np.memmap):  # if input file is already memory mapped then find the filename
         Y_name = Y.filename
 
     else:

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -1069,7 +1069,7 @@ def creatememmap(Y, Cf, dview):
         C_name = os.path.join(folder, 'C_temp.npy')
         np.save(C_name, Cf)
 
-        if isinstance(Y, np.core.memmap):  # if input file is already memory mapped then find the filename
+        if isinstance(Y, np.memmap):  # if input file is already memory mapped then find the filename
             Y_name = Y.filename
         # if not create a memory mapped version (necessary for parallelization)
         elif isinstance(Y, str) or dview is None:
@@ -1077,7 +1077,7 @@ def creatememmap(Y, Cf, dview):
         else:
             Y_name = os.path.join(folder, 'Y_temp.npy')
             np.save(Y_name, Y)
-            Y, _, _, _ = caiman.mmapping.load_memmap(Y_name)
+            Y, _, _ = caiman.mmapping.load_memmap(Y_name)
             raise Exception('Not implemented consistently')
     return C_name, Y_name, folder
 

--- a/caiman/tests/test_keras.py
+++ b/caiman/tests/test_keras.py
@@ -12,9 +12,9 @@ try:
     import keras_core as keras
 except ImportError:
     import keras
-    
-def test_keras():
-    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+
+def test_keras(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "-1")
 
     try:
         model_name = os.path.join(caiman_datadir(), 'model', 'cnn_model')
@@ -31,7 +31,4 @@ def test_keras():
     try:
         predictions = loaded_model.predict(A, batch_size=32)
     except:
-        raise Exception('NN model could not be deployed. use_keras = ' + str(use_keras))
-
-if __name__ == "__main__":
-    test_keras()
+        raise Exception('NN model could not be deployed.')

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -414,7 +414,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
             if len(cumEn) == 0:
                 pars = dict(
                     coordinates=np.array([]),
-                    CoM=np.array([np.NaN, np.NaN]),
+                    CoM=np.array([np.nan, np.nan]),
                     neuron_id=i + 1,
                 )
                 coordinates.append(pars)


### PR DESCRIPTION
# Description

This fixes the problem with test_mrcnn caused by test_keras on GPU torch installs that I brought up in a comment on #1535. It also fixes some remaining warnings/incorrect names from the numpy 2.0 transition that I noticed.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Yes, on a Windows computer with the CUDA version of pytorch installed, all tests now pass. It would be ideal to have a test runner with GPU to use for CI, but it seems like that would incur extra charges if we use GitHub's (https://docs.github.com/en/actions/concepts/runners/larger-runners). 