### PR TITLE
Fix demos for windows (multiprocessing) + some misc. cleanup

### DIFF
--- a/caiman/caimanmanager.py
+++ b/caiman/caimanmanager.py
@@ -166,8 +166,7 @@ def do_nt_run_demotests(targdir: str) -> None:
     # Windows platform can't run shell scripts, and doing it in batch files
     # is a terrible idea. So we'll do a minimal implementation of run_demos for
     # windows inline here.
-    os.environ['MPLCONFIG'] = 'ps'             # Not sure this does anything on windows
-    demos = glob.glob('demos/general/*.py')    # Should still work on windows I think
+    demos = glob.glob('demos/general/*.py', root_dir=caiman_datadir())
     for demo in demos:
         print("========================================")
         print(f"Testing {demo}")
@@ -178,7 +177,8 @@ def do_nt_run_demotests(targdir: str) -> None:
         elif "demo_pipeline_voltage_imaging.py" in demo:
             print(f"  Skipping tests on {demo}: This needs Keras, an optional dependency")
         else:
-            out, err, ret = runcmd(["python", demo], ignore_error=False)
+            demo_path = os.path.join(caiman_datadir(), demo)
+            out, err, ret = runcmd(["python", demo_path], ignore_error=False)
             if ret != 0:
                 print(f"  Tests failed with returncode {ret}")
                 print(f"  Failed test is {demo}")

--- a/demos/general/demo_OnACID.py
+++ b/demos/general/demo_OnACID.py
@@ -85,4 +85,5 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()

--- a/demos/general/demo_OnACID_mesoscope.py
+++ b/demos/general/demo_OnACID_mesoscope.py
@@ -84,12 +84,16 @@ def main():
     T_detect = 1e3*np.array(cnm.t_detect)
     T_shapes = 1e3*np.array(cnm.t_shapes)
     T_track  = 1e3*np.array(cnm.t_online) - T_motion - T_detect - T_shapes
-    plt.figure()
-    plt.stackplot(np.arange(len(T_motion)), T_motion, T_track, T_detect, T_shapes)
-    plt.legend(labels=['motion', 'tracking', 'detect', 'shapes'], loc=2)
-    plt.title('Processing time allocation')
-    plt.xlabel('Frame #')
-    plt.ylabel('Processing time [ms]')
+
+    if not cfg.no_play:
+        plt.ion()
+        plt.figure()
+        plt.stackplot(np.arange(len(T_motion)), T_motion, T_track, T_detect, T_shapes)
+        plt.legend(labels=['motion', 'tracking', 'detect', 'shapes'], loc=2)
+        plt.title('Processing time allocation')
+        plt.xlabel('Frame #')
+        plt.ylabel('Processing time [ms]')
+        plt.show()
 
     # Prepare result visualisations (might take time)
     c, dview, n_processes = cm.cluster.setup_cluster(backend=cfg.cluster_backend, n_processes=cfg.cluster_nproc)
@@ -120,8 +124,6 @@ def main():
     cnm.save(os.path.splitext(fnames[0])[0] + '_results.hdf5')
 
     dview.terminate()
-    if not cfg.no_play:
-        matplotlib.pyplot.show(block=True)
 
 def handle_args():
     parser = argparse.ArgumentParser(description="Full OnACID Caiman demo")
@@ -135,4 +137,5 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()

--- a/demos/general/demo_behavior.py
+++ b/demos/general/demo_behavior.py
@@ -113,4 +113,5 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()

--- a/demos/general/demo_caiman_basic.py
+++ b/demos/general/demo_caiman_basic.py
@@ -132,4 +132,5 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()

--- a/demos/general/demo_pipeline.py
+++ b/demos/general/demo_pipeline.py
@@ -19,7 +19,7 @@ import argparse
 import cv2
 import glob
 import logging
-import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 
@@ -67,6 +67,7 @@ def main():
     # To close the video press q
 
     if not cfg.no_play:
+        plt.ion()
         ds_ratio = 0.2
         moviehandle = m_orig.resize(1, 1, ds_ratio)
         moviehandle.play(q_max=99.5, fr=60, magnification=2)
@@ -179,7 +180,7 @@ def main():
     # Stop the cluster and clean up log files
     caiman.stop_server(dview=dview)
     if not cfg.no_play:
-        matplotlib.pyplot.show(block=True)
+        plt.show()
 
     if not cfg.keep_logs:
         log_files = glob.glob('*_LOG_*')
@@ -198,5 +199,6 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()
 

--- a/demos/general/demo_pipeline_NWB.py
+++ b/demos/general/demo_pipeline_NWB.py
@@ -246,5 +246,6 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()
 

--- a/demos/general/demo_pipeline_cnmfE.py
+++ b/demos/general/demo_pipeline_cnmfE.py
@@ -150,5 +150,6 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()
 

--- a/demos/general/demo_pipeline_voltage_imaging.py
+++ b/demos/general/demo_pipeline_voltage_imaging.py
@@ -286,5 +286,6 @@ def handle_args():
     return parser.parse_args()
 
 ########
-main()
+if __name__ == '__main__':
+    main()
 

--- a/test_demos.sh
+++ b/test_demos.sh
@@ -32,8 +32,6 @@ if [ $OS == "Linux" ]; then
 	fi
 fi
 
-# Tell matplotlib to try to plot less to begin with by specifying a postscript backend
-export MPLCONFIG=ps
 
 cd `dirname ${BASH_SOURCE[0]}`
 


### PR DESCRIPTION
# Description

Various fixes for demotests, mainly so they run on Windows. This is long overdue (from me, I know I'm probably the heaviest Windows user who contributes).

The main issue with Windows is that all the demo scripts were missing the `if __name__ == '__main__':` guard. This is really important when using multiprocessing on Windows, because it uses the "spawn" method which relies on child processes being able to import the main file without running the actual script. Without the guard, one sees an endless sequence of these errors as the workers keep dying and the pool tries to replace them:

```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```
(since we're not freezing, just the `if __name__ == '__main__':` is sufficient.)

Other changes:
- I removed the `export MPLCONFIG=ps` line from the shell script and the equivalent for Windows. I cannot find any information about this variable online - it seems like it was probably supposed to be [`MPLBACKEND`](https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend) instead. Nevertheless, the tests have been running fine without this setting the entire time they've existed - thanks to `xvfb-run`, an interactive backend works fine. I also confirmed that setting `MPLBACKEND=ps` instead of `MPLCONFIG` does not negate the need for `xvfb-run` (it's also needed for some opencv plotting).
- I removed the `block=True` from `matplotlib.pyplot.show(block=True)` and also ensured `plt.ion()` is always called, so that `show` doesn't block by default. This was causing certain runs to hang forever on Linux.
- To be consistent with the non-Windows run, I changed the Windows function to look for the demos under caiman_datadir rather than under the current directory.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Yes!