### PR TITLE
Exclude scikit-image 0.26.0 due to remove_small_* regression

### DIFF
--- a/environment-minimal.yml
+++ b/environment-minimal.yml
@@ -22,7 +22,7 @@ dependencies:
 - pyside6
 - pytest
 - pytorch
-- scikit-image >=0.19.0
+- scikit-image >=0.19.0, !=0.26.0
 - scikit-learn >=1.2
 - scipy >= 1.10.1
 - setuptools

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pytorch
-- scikit-image >=0.19.0
+- scikit-image >=0.19.0, !=0.26.0
 - scikit-learn >=1.2
 - scipy >= 1.10.1
 - setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "pytest-cov",
   "setuptools",
   "torch",
-  "scikit-image >= 0.19.0",
+  "scikit-image >= 0.19.0, != 0.26.0",
   "scikit-learn >= 1.2",
   "scipy >= 1.10.1",
   "torchvision",


### PR DESCRIPTION
# Description

Another scikit-image issue... In 0.26.0, the behavior of `remove_small_objects` and `remove_small_holes` was changed slightly, due to a parameter in each being deprecated and replaced with a different one (`min_size`) that effectively allows holes/objects that are 1 pixel larger. The change was documented, but imo still careless to change the behavior even when still using the deprecated parameter. Furthermore, it will be reversed in the next version (see this merged PR: scikit-image/scikit-image#8003).

It was causing a mysterious test failure on mesmerize-core. It seems reasonable to me to just exclude this specific version.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Has your PR been tested?

Tested with mesmerize; I'm assuming caiman tests will still work with this version but CI will make sure