### PR TITLE
Clean up/consolidate make_contours/thresholding code and don't impose arbitrary order on tied pixels

### DIFF
--- a/caiman/base/rois.py
+++ b/caiman/base/rois.py
@@ -18,6 +18,7 @@ from skimage.segmentation import watershed
 import tempfile
 import time
 from typing import Any, Optional
+import warnings
 import zipfile
 
 from caiman.motion_correction import tile_and_correct, get_patch_centers, interpolate_shifts
@@ -57,7 +58,10 @@ def com(A, d1: int, d2: int, d3: Optional[int] = None, order: str = 'F') -> np.n
     coor = np.stack([c.ravel(order=order) for c in coors])
 
     # take weighted sum of pixel positions along each coordinate
-    cm = (coor @ A / A.sum(axis=0)).T
+    with warnings.catch_warnings():
+        # ignore 0 / 0 (should give nan)
+        warnings.filterwarnings('ignore', category=RuntimeWarning, message='invalid value encountered in divide')
+        cm = (coor @ A / A.sum(axis=0)).T
     return np.array(cm)
 
 
@@ -687,17 +691,23 @@ def extract_active_components(assignments, indices, only=True):
     return components
 
 
-def norm_nrg(a_):
+def norm_nrg(a: np.ndarray) -> np.ndarray:
+    """
+    Construct an array of the same shape as a containing energy
+    (squared values) accumulated from highest to lowest-valued pixel,
+    normalized so the maximum value is 1. This version maintains ties
+    between pixel values, such that in each set of tied pixels, each pixel
+    in the set gets the total energy from all pixels in that set added to its 
+    cumulative energy.
+    """
+    if a.size == 0:
+        return a.copy()
 
-    a = a_.copy()
-    dims = a.shape
-    a = a.reshape(-1, order='F')
-    indx = np.argsort(a, axis=None)[::-1]
-    cumEn = np.cumsum(a.flatten()[indx]**2)
-    cumEn /= cumEn[-1]
-    a = np.zeros(np.prod(dims))
-    a[indx] = cumEn
-    return a.reshape(dims, order='F')
+    vals_asc, inds_inv, counts = np.unique(a, return_inverse=True, return_counts=True)
+    energy = vals_asc ** 2 * counts  # each energy value is multiplied by its frequency to get the same total
+    cumEn = np.cumsum(energy[::-1])[::-1]  # accumulate from high to low
+    cumEn /= cumEn[0]
+    return np.reshape(cumEn[inds_inv], a.shape)
 
 
 def distance_masks(M_s:list, cm_s: list[list], max_dist: float, enclosed_thr: Optional[float] = None) -> list:

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -710,7 +710,7 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
                    movie in 2D
 
          (dx,dy): tuple
-                   dimensions of the square used to identify neurons (should be set to the galue of gsiz)
+                   dimensions of the square used to identify neurons (should be set to the value of gsiz)
 
          A:   np.ndarray or sparse matrix
                    Matrix of Spatial components (d x K)
@@ -739,7 +739,7 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
     """
     (dx, dy) = xxx_todo_changeme
     if issparse(A):
-        A = np.array(A.todense())
+        A = A.toarray()
     else:
         A = np.array(A)
 
@@ -755,12 +755,8 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
 
     Bmat = np.zeros((np.minimum(nr, max_number), d1, d2))
     for i in range(np.minimum(nr, max_number)):
-        indx = np.argsort(A[:, i], axis=None)[::-1]
-        cumEn = np.cumsum(A[:, i].flatten()[indx]**2)
-        cumEn /= cumEn[-1]
-        Bvec = np.zeros(d)
-        Bvec[indx] = cumEn
-        Bmat[i] = np.reshape(Bvec, Cn.shape, order='F')
+        comp_nrg = caiman.base.rois.norm_nrg(A[:, i])
+        Bmat[i] = np.reshape(comp_nrg, Cn.shape, order='F')
 
     T = Y.shape[-1]
 
@@ -807,11 +803,7 @@ def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_
 
             A = np.concatenate([A, a_f], axis=1)
             C = np.concatenate([C, c__], axis=0)
-            indx = np.argsort(a_f, axis=None)[::-1]
-            cumEn = np.cumsum(a_f.flatten()[indx]**2)
-            cumEn /= cumEn[-1]
-            Bvec = np.zeros(d)
-            Bvec[indx] = cumEn
+            Bvec = caiman.base.rois.norm_nrg(a_f)
             bmat = np.reshape(Bvec, Cn.shape, order='F')
             plt.contour(y, x, bmat, [thr])
             plt.pause(.01)

--- a/caiman/source_extraction/volpy/mrcnn/utils.py
+++ b/caiman/source_extraction/volpy/mrcnn/utils.py
@@ -24,6 +24,9 @@ from torchvision.transforms.v2 import functional as F
 import torchvision.transforms.v2 as T
 from typing import Any, Optional
 
+from caiman.base.rois import norm_nrg
+
+
 class ScaleImage:
     """
     Scale image so it is between 0-1: works on floats only
@@ -473,29 +476,3 @@ def normalize_image(image):
     image_shifted = image - image.min()
     image_normed = image_shifted/image_shifted.max()
     return np.array(image_normed, dtype=np.float32)
-
-def norm_nrg(a_):
-    """
-    Calculates the normalized cumulative energy map of an array.
-
-    The function flattens the input array, sorts its elements in descending
-    order, and computes the normalized cumulative energy. The resulting energy
-    values are then placed back into an array with the original shape at the
-    locations corresponding to the original element values.
-
-    Args:
-        a_ (np.ndarray): The input NumPy array.
-
-    Returns:
-        np.ndarray: An array of the same shape as the input, containing the
-                    normalized cumulative energy values.
-    """
-    a = a_.copy()
-    dims = a.shape
-    a = a.reshape(-1, order='F')
-    indx = np.argsort(a, axis=None)[::-1]
-    cumEn = np.cumsum(a.flatten()[indx]**2)
-    cumEn /= cumEn[-1]
-    a = np.zeros(np.prod(dims))
-    a[indx] = cumEn
-    return a.reshape(dims, order='F')

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -1030,7 +1030,7 @@ def view_patches_bar(Yr, A, C, b, f, d1, d2, YrA=None, img=None,
     plt.show()
 
 def plot_contours(A, Cn, thr=None, thr_method='max', maxthr=0.2, nrgthr=0.9, display_numbers=True, max_number=None,
-                  cmap=None, swap_dim=False, colors='w', vmin=None, vmax=None, coordinates=None,
+                  cmap=None, swap_dim=False, color='w', vmin=None, vmax=None, coordinates=None,
                   contour_args={}, number_args={}, **kwargs):
     """Plots contour of spatial components against a background image and returns their coordinates
 
@@ -1084,8 +1084,7 @@ def plot_contours(A, Cn, thr=None, thr_method='max', maxthr=0.2, nrgthr=0.9, dis
 
     for key in ['c', 'colors', 'line_color']:
         if key in kwargs.keys():
-            color = kwargs[key]
-            kwargs.pop(key)
+            color = kwargs.pop(key)
 
     ax = plt.gca()
     if vmax is None and vmin is None:
@@ -1101,14 +1100,14 @@ def plot_contours(A, Cn, thr=None, thr_method='max', maxthr=0.2, nrgthr=0.9, dis
         v = c['coordinates']
         c['bbox'] = [np.floor(np.nanmin(v[:, 1])), np.ceil(np.nanmax(v[:, 1])),
                      np.floor(np.nanmin(v[:, 0])), np.ceil(np.nanmax(v[:, 0]))]
-        plt.plot(*v.T, c=colors, **contour_args)
+        plt.plot(*v.T, c=color, **contour_args)
 
     if display_numbers:
         nr = A.shape[1]
         if max_number is None:
             max_number = nr
         for i, c in zip(range(np.minimum(nr, max_number)), coordinates):
-            ax.text(c['CoM'][1], c['CoM'][0], str(i + 1), color=colors, **number_args)
+            ax.text(c['CoM'][1], c['CoM'][0], str(i + 1), color=color, **number_args)
     return coordinates
 
 def plot_shapes(Ab, dims, num_comps=15, size=(15, 15), comps_per_row=None,

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -362,6 +362,27 @@ def hv_view_patches(Yr, A, C, b, f, d1, d2, YrA=None, image_neurons=None, denois
                 .redim.range(unit_id=(0, nr-1), scale=(0.0, 1.0)))
 
 
+def get_slice_coords(B: np.ndarray, thr: float) -> np.ndarray:
+    """Get contour coordinates for a 2D slice"""
+    d1, d2 = B.shape
+    vertices = find_contours(B.T, thr)
+    # this fix is necessary for having disjoint figures and borders plotted correctly
+    v = np.array([[np.nan, np.nan]])
+    for _, vtx in enumerate(vertices):
+        num_close_coords = np.sum(np.isclose(vtx[0, :], vtx[-1, :]))
+        if num_close_coords < 2:
+            if num_close_coords == 0:
+                # case angle
+                newpt = np.round(np.mean(vtx[[0, -1], :], axis=0) / [d2, d1]) * [d2, d1]
+                vtx = np.concatenate((newpt[np.newaxis, :], vtx, newpt[np.newaxis, :]), axis=0)
+            else:
+                # case one is border
+                vtx = np.concatenate((vtx, vtx[0, np.newaxis]), axis=0)
+        v = np.concatenate(
+            (v, vtx, np.array([[np.nan, np.nan]])), axis=0)
+    return v
+
+
 def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: Optional[int] = None):
     """Gets contour of spatial components and returns their coordinates
 
@@ -431,30 +452,10 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
             Bmat = np.reshape(Bvec, dims, order='C')
         else:
             Bmat = np.reshape(Bvec, dims, order='F')
-
-        def get_slice_coords(B: np.ndarray) -> np.ndarray:
-            """Get contour coordinates for a 2D slice"""
-            d1, d2 = B.shape
-            vertices = find_contours(B.T, thr)
-            # this fix is necessary for having disjoint figures and borders plotted correctly
-            v = np.array([[np.nan, np.nan]])
-            for _, vtx in enumerate(vertices):
-                num_close_coords = np.sum(np.isclose(vtx[0, :], vtx[-1, :]))
-                if num_close_coords < 2:
-                    if num_close_coords == 0:
-                        # case angle
-                        newpt = np.round(np.mean(vtx[[0, -1], :], axis=0) / [d2, d1]) * [d2, d1]
-                        vtx = np.concatenate((newpt[np.newaxis, :], vtx, newpt[np.newaxis, :]), axis=0)
-                    else:
-                        # case one is border
-                        vtx = np.concatenate((vtx, vtx[0, np.newaxis]), axis=0)
-                v = np.concatenate(
-                    (v, vtx, np.array([[np.nan, np.nan]])), axis=0)
-            return v
         
         pars = {}
         if len(dims) == 2:
-            pars['coordinates'] = get_slice_coords(Bmat)
+            pars['coordinates'] = get_slice_coords(Bmat, thr)
         else:
             # make a list of the contour coordinates for each 2D slice
             pars['coordinates'] = []
@@ -462,7 +463,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
                 slice_dim = 0 if swap_dim else -1
             for s in range(dims[slice_dim]):
                 B = Bmat.take(s, axis=slice_dim)
-                pars['coordinates'].append(get_slice_coords(B))
+                pars['coordinates'].append(get_slice_coords(B, thr))
 
         pars['CoM'] = np.squeeze(cm[i, :])
         pars['neuron_id'] = i + 1
@@ -494,6 +495,8 @@ def nb_view_patches3d(Y_r, A, C, dims, image_type='mean', Yr=None,
 
         max_projection: boolean
             plot max projection along specified axis if True, plot layers if False
+            FIXME - type checking reveals that this code path can't work, namely 
+                    coors is a list of dicts that doesn't have a "shape" attribute
 
         axis: int (0, 1 or 2)
             axis along which max projection is performed or layers are shown

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -405,26 +405,22 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
 
     # for each patches
     for i in range(nr):
-        pars:dict = dict()
-        # we compute the cumulative sum of the energy of the Ath component that has been ordered from least to highest
+        if A.indptr[i] == A.indptr[i + 1]:
+            # component is all zeros
+            pars = dict(
+                coordinates=np.array([]),
+                CoM=np.array([np.nan, np.nan]),
+                neuron_id=i + 1,
+            )
+            coordinates.append(pars)
+            continue
+
         patch_data = A.data[A.indptr[i]:A.indptr[i + 1]]
-        indx = np.argsort(patch_data)[::-1]
+
         if thr_method == 'nrg':
-            cumEn = np.cumsum(patch_data[indx]**2)
-            if len(cumEn) == 0:
-                pars = dict(
-                    coordinates=np.array([]),
-                    CoM=np.array([np.nan, np.nan]),
-                    neuron_id=i + 1,
-                )
-                coordinates.append(pars)
-                continue
-            else:
-                # we work with normalized values
-                cumEn /= cumEn[-1]
-                Bvec = np.ones(d)
-                # we put it in a similar matrix
-                Bvec[A.indices[A.indptr[i]:A.indptr[i + 1]][indx]] = cumEn
+            comp_nrg = caiman.base.rois.norm_nrg(patch_data)
+            Bvec = np.ones(d)
+            Bvec[A.indices[A.indptr[i]:A.indptr[i + 1]]] = comp_nrg
         else:
             if thr_method != 'max':
                 warn("Unknown threshold method. Choosing max")
@@ -441,7 +437,7 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
             d1, d2 = B.shape
             vertices = find_contours(B.T, thr)
             # this fix is necessary for having disjoint figures and borders plotted correctly
-            v = np.atleast_2d([np.nan, np.nan])
+            v = np.array([[np.nan, np.nan]])
             for _, vtx in enumerate(vertices):
                 num_close_coords = np.sum(np.isclose(vtx[0, :], vtx[-1, :]))
                 if num_close_coords < 2:
@@ -453,9 +449,10 @@ def get_contours(A, dims, thr=0.9, thr_method='nrg', swap_dim=False, slice_dim: 
                         # case one is border
                         vtx = np.concatenate((vtx, vtx[0, np.newaxis]), axis=0)
                 v = np.concatenate(
-                    (v, vtx, np.atleast_2d([np.nan, np.nan])), axis=0)
+                    (v, vtx, np.array([[np.nan, np.nan]])), axis=0)
             return v
         
+        pars = {}
         if len(dims) == 2:
             pars['coordinates'] = get_slice_coords(Bmat)
         else:


### PR DESCRIPTION
# Description

I wrote a cumulative-energy normalization function (replacement for `norm_nrg` which was copied in a few places) that is more predictable than the existing one because it doesn't depend on the order numpy chooses to sort pixels using `np.argsort`. Instead, it uses `np.unique` and applies the total cumulative sum up to each pixel's squared value to each pixel with that value. (A little hard to describe - see the implementation).

One benefit is that because it's more predictable, it allows testing that the contours have stayed the same even if internal details of `np.argsort` change (as happened from numpy 1 to 2). This PR itself changes the contours, making it debatably a breaking change, but again I think the new version ("keeping ties") is less surprising. I have attached an example test script and figure showing the difference between the old and new methods. (Note, this case of a perfect Gaussian with many sets of perfectly tied pixels is an edge case - if there are no perfect ties, the contours will stay the same.)

<img width="1307" height="317" alt="contours_tie_example" src="https://github.com/user-attachments/assets/74bb43d4-de3a-4673-a07f-169ae1e0fc12" />

[nrg_contour_test.py](https://github.com/user-attachments/files/25435822/nrg_contour_test.py)

Fixes #1570

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- debatable: Breaking change (fix or feature that would break back-compatibility)

# Has your PR been tested?

`caimanmanager test` and `demotest` pass on linux with numpy 2.
